### PR TITLE
Refactor RBAC object handed to the application

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -34,9 +34,9 @@ const App: React.FunctionComponent<RouteComponentProps> = () => {
         const appId = getSubApp(location.pathname);
         switch (appId) {
             case Config.integrations.subAppId:
-                return rbac?.hasPermission(appId, 'endpoints', 'read');
+                return rbac?.canReadIntegrationsEndpoints;
             case Config.notifications.subAppId:
-                return rbac?.hasPermission(appId, 'notifications', 'read');
+                return rbac?.canReadNotifications;
         }
 
         return false;

--- a/src/app/AppContext.tsx
+++ b/src/app/AppContext.tsx
@@ -1,16 +1,25 @@
-import { Rbac } from '@redhat-cloud-services/insights-common-typescript';
 import * as React from 'react';
 import { useContext } from 'react';
 
 import { Schemas } from '../generated/OpenapiIntegrations';
 
 export interface AppContext {
-    rbac: Rbac;
+    rbac: {
+        canWriteIntegrationsEndpoints: boolean;
+        canReadIntegrationsEndpoints: boolean;
+        canWriteNotifications: boolean;
+        canReadNotifications: boolean;
+    };
     applications: Array<Schemas.ApplicationFacet>
 }
 
 export const AppContext = React.createContext<AppContext>({
-    rbac: new Rbac({}),
+    rbac: {
+        canReadIntegrationsEndpoints: false,
+        canReadNotifications: false,
+        canWriteIntegrationsEndpoints: false,
+        canWriteNotifications: false
+    },
     applications: []
 });
 

--- a/src/app/__tests__/App.test.tsx
+++ b/src/app/__tests__/App.test.tsx
@@ -61,7 +61,7 @@ describe('src/app/App', () => {
 
     it('Shows loading when applications is not set', async () => {
         jest.useFakeTimers();
-        const promise = Promise.resolve({});
+        const promise = Promise.resolve(new Rbac({}));
         (fetchRBAC as jest.Mock).mockImplementation(() => promise);
         let resolver;
         fetchMock.get('/api/notifications/v1.0/notifications/facets/applications', new Promise(resolv => resolver = resolv));

--- a/src/app/useApp.ts
+++ b/src/app/useApp.ts
@@ -43,7 +43,12 @@ export const useApp = (): Omit<AppContext, 'rbac' | 'applications'> & Partial<Pi
     }, []);
 
     return {
-        rbac,
+        rbac: rbac ? {
+            canWriteNotifications: rbac.hasPermission('notifications', 'notifications', 'write'),
+            canReadNotifications: rbac.hasPermission('notifications', 'notifications', 'read'),
+            canWriteIntegrationsEndpoints: rbac.hasPermission('integrations', 'endpoints', 'write'),
+            canReadIntegrationsEndpoints: rbac.hasPermission('integrations', 'endpoints', 'read')
+        } : undefined,
         applications
     };
 };

--- a/src/pages/Integrations/List/Page.tsx
+++ b/src/pages/Integrations/List/Page.tsx
@@ -15,7 +15,6 @@ import { AppContext } from '../../../app/AppContext';
 import { IntegrationFilters } from '../../../components/Integrations/Filters';
 import { IntegrationsTable } from '../../../components/Integrations/Table';
 import { IntegrationsToolbar } from '../../../components/Integrations/Toolbar';
-import Config from '../../../config/Config';
 import { usePage } from '../../../hooks/usePage';
 import { Messages } from '../../../properties/Messages';
 import { useListIntegrationPQuery, useListIntegrationsQuery } from '../../../services/useListIntegrations';
@@ -41,8 +40,7 @@ const integrationFilterBuilder = (filters?: IntegrationFilters) => {
 
 export const IntegrationsListPage: React.FunctionComponent = () => {
 
-    const { rbac } = useContext(AppContext);
-    const canWriteIntegrations = rbac.hasPermission(Config.integrations.subAppId, 'endpoints', 'write');
+    const { rbac: { canWriteIntegrationsEndpoints }} = useContext(AppContext);
     const integrationFilter = useIntegrationFilter();
     const pageData = usePage<IntegrationFilters>(10, integrationFilterBuilder, integrationFilter.filters);
     const integrationsQuery = useListIntegrationsQuery(pageData.page);
@@ -117,7 +115,7 @@ export const IntegrationsListPage: React.FunctionComponent = () => {
     }, [ exportIntegrationsQuery ]);
 
     const actionResolver = useActionResolver({
-        canWrite: canWriteIntegrations,
+        canWrite: canWriteIntegrationsEndpoints,
         onEdit,
         onDelete,
         onEnable: integrationRows.onEnable
@@ -152,7 +150,7 @@ export const IntegrationsListPage: React.FunctionComponent = () => {
             <Main>
                 <Section className='pf-c-page__main-section pf-m-light'>
                     <IntegrationsToolbar
-                        onAddIntegration={ canWriteIntegrations ? onAddIntegrationClicked : undefined }
+                        onAddIntegration={ canWriteIntegrationsEndpoints ? onAddIntegrationClicked : undefined }
                         onExport={ onExport }
                         filters={ integrationFilter.filters }
                         setFilters={ integrationFilter.setFilters }
@@ -169,7 +167,7 @@ export const IntegrationsListPage: React.FunctionComponent = () => {
                             loadingCount={ loadingCount }
                             integrations={ integrationRows.rows }
                             onCollapse={ integrationRows.onCollapse }
-                            onEnable={ canWriteIntegrations ? integrationRows.onEnable : undefined }
+                            onEnable={ canWriteIntegrationsEndpoints ? integrationRows.onEnable : undefined }
                             actionResolver={ actionResolver }
                         />
                     </IntegrationsToolbar>

--- a/src/pages/Integrations/List/__tests__/Page.test.tsx
+++ b/src/pages/Integrations/List/__tests__/Page.test.tsx
@@ -7,7 +7,6 @@ import { waitForAsyncEvents } from '../../../../../test/TestUtils';
 import { Schemas } from '../../../../generated/OpenapiIntegrations';
 import { IntegrationsListPage } from '../Page';
 import Endpoint = Schemas.Endpoint;
-import { Rbac } from '@redhat-cloud-services/insights-common-typescript';
 import { getByLabelText, getByRole, getByText } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ouiaSelectors } from 'insights-common-typescript-dev';

--- a/src/pages/Integrations/List/__tests__/Page.test.tsx
+++ b/src/pages/Integrations/List/__tests__/Page.test.tsx
@@ -48,14 +48,12 @@ describe('src/pages/Integrations/List/Page', () => {
                     wrapper: getConfiguredAppWrapper({
                         appContext: {
                             applications: [],
-                            rbac: new Rbac({
-                                integrations: {
-                                    endpoints: [ 'read' ]
-                                },
-                                notifications: {
-                                    notifications: [ 'read', 'write' ]
-                                }
-                            })
+                            rbac: {
+                                canWriteNotifications: true,
+                                canWriteIntegrationsEndpoints: false,
+                                canReadIntegrationsEndpoints: true,
+                                canReadNotifications: true
+                            }
                         }
                     })
                 }
@@ -91,14 +89,12 @@ describe('src/pages/Integrations/List/Page', () => {
                     wrapper: getConfiguredAppWrapper({
                         appContext: {
                             applications: [],
-                            rbac: new Rbac({
-                                integrations: {
-                                    endpoints: [ 'read', 'write' ]
-                                },
-                                notifications: {
-                                    notifications: [ 'read', 'write' ]
-                                }
-                            })
+                            rbac: {
+                                canWriteNotifications: true,
+                                canWriteIntegrationsEndpoints: true,
+                                canReadIntegrationsEndpoints: true,
+                                canReadNotifications: true
+                            }
                         }
                     })
                 }
@@ -134,14 +130,12 @@ describe('src/pages/Integrations/List/Page', () => {
                     wrapper: getConfiguredAppWrapper({
                         appContext: {
                             applications: [],
-                            rbac: new Rbac({
-                                integrations: {
-                                    endpoints: [ 'read' ]
-                                },
-                                notifications: {
-                                    notifications: [ 'read', 'write' ]
-                                }
-                            })
+                            rbac: {
+                                canWriteNotifications: true,
+                                canWriteIntegrationsEndpoints: false,
+                                canReadIntegrationsEndpoints: true,
+                                canReadNotifications: true
+                            }
                         }
                     })
                 }
@@ -180,14 +174,12 @@ describe('src/pages/Integrations/List/Page', () => {
                     wrapper: getConfiguredAppWrapper({
                         appContext: {
                             applications: [],
-                            rbac: new Rbac({
-                                integrations: {
-                                    endpoints: [ 'read', 'write' ]
-                                },
-                                notifications: {
-                                    notifications: [ 'read', 'write' ]
-                                }
-                            })
+                            rbac: {
+                                canWriteNotifications: true,
+                                canWriteIntegrationsEndpoints: true,
+                                canReadIntegrationsEndpoints: true,
+                                canReadNotifications: true
+                            }
                         }
                     })
                 }
@@ -225,14 +217,12 @@ describe('src/pages/Integrations/List/Page', () => {
                     wrapper: getConfiguredAppWrapper({
                         appContext: {
                             applications: [],
-                            rbac: new Rbac({
-                                integrations: {
-                                    endpoints: [ 'read' ]
-                                },
-                                notifications: {
-                                    notifications: [ 'read', 'write' ]
-                                }
-                            })
+                            rbac: {
+                                canWriteNotifications: true,
+                                canWriteIntegrationsEndpoints: false,
+                                canReadIntegrationsEndpoints: true,
+                                canReadNotifications: true
+                            }
                         }
                     })
                 }
@@ -286,14 +276,12 @@ describe('src/pages/Integrations/List/Page', () => {
                     wrapper: getConfiguredAppWrapper({
                         appContext: {
                             applications: [],
-                            rbac: new Rbac({
-                                integrations: {
-                                    endpoints: [ 'read', 'write' ]
-                                },
-                                notifications: {
-                                    notifications: [ 'read', 'write' ]
-                                }
-                            })
+                            rbac: {
+                                canWriteNotifications: true,
+                                canWriteIntegrationsEndpoints: true,
+                                canReadIntegrationsEndpoints: true,
+                                canReadNotifications: true
+                            }
                         }
                     })
                 }

--- a/src/pages/Notifications/List/Page.tsx
+++ b/src/pages/Notifications/List/Page.tsx
@@ -16,7 +16,6 @@ import { DefaultBehavior } from '../../../components/Notifications/DefaultBehavi
 import { NotificationsTable } from '../../../components/Notifications/Table';
 import { NotificationsToolbar } from '../../../components/Notifications/Toolbar';
 import { GroupByEnum } from '../../../components/Notifications/Types';
-import Config from '../../../config/Config';
 import { Messages } from '../../../properties/Messages';
 import { useDefaultNotificationBehavior } from '../../../services/useDefaultNotificationBehavior';
 import { useListNotifications } from '../../../services/useListNotifications';
@@ -52,8 +51,7 @@ const emptyArray = [];
 
 export const NotificationsListPage: React.FunctionComponent = () => {
 
-    const { rbac } = useContext(AppContext);
-    const canWriteNotifications = rbac.hasPermission(Config.notifications.subAppId, 'notifications', 'write');
+    const { rbac: { canWriteNotifications }} = useContext(AppContext);
     const defaultNotificationBehavior = useDefaultNotificationBehavior();
     const { applications } = useAppContext();
 

--- a/src/pages/Notifications/List/__tests__/Page.test.tsx
+++ b/src/pages/Notifications/List/__tests__/Page.test.tsx
@@ -333,14 +333,12 @@ describe('src/pages/Notifications/List/Page', () => {
                 wrapper: getConfiguredAppWrapper({
                     appContext: {
                         applications: [],
-                        rbac: new Rbac({
-                            integrations: {
-                                endpoints: [ 'read', 'write' ]
-                            },
-                            notifications: {
-                                notifications: [ 'read' ]
-                            }
-                        })
+                        rbac: {
+                            canWriteNotifications: false,
+                            canWriteIntegrationsEndpoints: true,
+                            canReadIntegrationsEndpoints: true,
+                            canReadNotifications: true
+                        }
                     }
                 })
             }
@@ -388,14 +386,12 @@ describe('src/pages/Notifications/List/Page', () => {
                 wrapper: getConfiguredAppWrapper({
                     appContext: {
                         applications: [],
-                        rbac: new Rbac({
-                            integrations: {
-                                endpoints: [ 'read', 'write' ]
-                            },
-                            notifications: {
-                                notifications: [ 'read', 'write' ]
-                            }
-                        })
+                        rbac: {
+                            canWriteNotifications: true,
+                            canWriteIntegrationsEndpoints: true,
+                            canReadIntegrationsEndpoints: true,
+                            canReadNotifications: true
+                        }
                     }
                 })
             }
@@ -443,14 +439,12 @@ describe('src/pages/Notifications/List/Page', () => {
                 wrapper: getConfiguredAppWrapper({
                     appContext: {
                         applications: [],
-                        rbac: new Rbac({
-                            integrations: {
-                                endpoints: [ 'read', 'write' ]
-                            },
-                            notifications: {
-                                notifications: [ 'read' ]
-                            }
-                        })
+                        rbac: {
+                            canWriteNotifications: false,
+                            canWriteIntegrationsEndpoints: true,
+                            canReadIntegrationsEndpoints: true,
+                            canReadNotifications: true
+                        }
                     }
                 })
             }
@@ -498,14 +492,12 @@ describe('src/pages/Notifications/List/Page', () => {
                 wrapper: getConfiguredAppWrapper({
                     appContext: {
                         applications: [],
-                        rbac: new Rbac({
-                            integrations: {
-                                endpoints: [ 'read', 'write' ]
-                            },
-                            notifications: {
-                                notifications: [ 'read', 'write' ]
-                            }
-                        })
+                        rbac: {
+                            canWriteNotifications: true,
+                            canWriteIntegrationsEndpoints: true,
+                            canReadIntegrationsEndpoints: true,
+                            canReadNotifications: true
+                        }
                     }
                 })
             }

--- a/src/pages/Notifications/List/__tests__/Page.test.tsx
+++ b/src/pages/Notifications/List/__tests__/Page.test.tsx
@@ -1,4 +1,3 @@
-import { Rbac } from '@redhat-cloud-services/insights-common-typescript';
 import { getByText, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import fetchMock from 'fetch-mock';

--- a/test/AppWrapper.tsx
+++ b/test/AppWrapper.tsx
@@ -61,14 +61,12 @@ type Config = {
 }
 
 const defaultAppContextSettings = {
-    rbac: new Rbac({
-        integrations: {
-            endpoints: [ 'read', 'write' ]
-        },
-        notifications: {
-            notifications: [ 'read', 'write' ]
-        }
-    }),
+    rbac: {
+        canWriteNotifications: true,
+        canWriteIntegrationsEndpoints: true,
+        canReadIntegrationsEndpoints: true,
+        canReadNotifications: true
+    },
     applications: [
         {
             label: 'Policies',


### PR DESCRIPTION
 - Pass only the required permissions to the application instead of
   the Rbac object. This prevents any error on the calls and in
   general makes it easier to use this object.