### PR TITLE
Migrate app to chrome 2

### DIFF
--- a/config/dev.webpack.config.ts
+++ b/config/dev.webpack.config.ts
@@ -7,7 +7,7 @@ import { updateTsLoaderRule } from './common.webpack.config';
 const { config: webpackConfig, plugins } = config({
     rootFolder: resolve(__dirname, '../'),
     debug: true,
-    https: true,
+    https: false,
     useFileHash: false
 });
 
@@ -17,7 +17,9 @@ plugins.push(
     federatedModules(
         {
             root: resolve(__dirname, '../'),
-            useFileHash: false
+            debug: true,
+            useFileHash: false,
+            exclude: [ 'react-router-dom' ]
         }
     )
 );

--- a/config/prod.webpack.config.ts
+++ b/config/prod.webpack.config.ts
@@ -12,7 +12,8 @@ plugins.push(
     federatedModules(
         {
             root: resolve(__dirname, '../'),
-            useFileHash: false
+            useFileHash: true,
+            exclude: [ 'react-router-dom' ]
         }
     )
 );

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@babel/plugin-transform-runtime": "7.12.1",
     "@babel/preset-env": "7.12.1",
     "@babel/preset-react": "7.12.5",
-    "@redhat-cloud-services/frontend-components-config": "4.0.1",
+    "@redhat-cloud-services/frontend-components-config": "4.0.5",
     "@testing-library/dom": "7.27.0",
     "@testing-library/jest-dom": "5.11.6",
     "@testing-library/react": "11.1.2",

--- a/profiles/local-frontend-and-api.ts
+++ b/profiles/local-frontend-and-api.ts
@@ -7,10 +7,10 @@ const API_PORT = 8085;
 const routes = {};
 
 APP_MOUNTS.forEach(mount => {
-    routes[`/beta/${SECTION}/${mount}`] = { host: `https://localhost:${FRONTEND_PORT}` };
-    routes[`/${SECTION}/${mount}`]      = { host: `https://localhost:${FRONTEND_PORT}` };
-    routes[`/beta/apps/${mount}`]       = { host: `https://localhost:${FRONTEND_PORT}` };
-    routes[`/apps/${mount}`]            = { host: `https://localhost:${FRONTEND_PORT}` };
+    routes[`/beta/${SECTION}/${mount}`] = { host: `http://localhost:${FRONTEND_PORT}` };
+    routes[`/${SECTION}/${mount}`]      = { host: `http://localhost:${FRONTEND_PORT}` };
+    routes[`/beta/apps/${mount}`]       = { host: `http://localhost:${FRONTEND_PORT}` };
+    routes[`/apps/${mount}`]            = { host: `http://localhost:${FRONTEND_PORT}` };
     routes[`/api/${mount}/`] = { host: `http://localhost:${API_PORT}` };
 });
 

--- a/profiles/local-frontend.ts
+++ b/profiles/local-frontend.ts
@@ -7,10 +7,10 @@ const FRONTEND_PORT = 8002;
 const routes = {};
 
 APP_MOUNTS.forEach(mount => {
-    routes[`/beta/${SECTION}/${mount}`] = { host: `https://localhost:${FRONTEND_PORT}` };
-    routes[`/${SECTION}/${mount}`]      = { host: `https://localhost:${FRONTEND_PORT}` };
-    routes[`/beta/apps/${mount}`]       = { host: `https://localhost:${FRONTEND_PORT}` };
-    routes[`/apps/${mount}`]            = { host: `https://localhost:${FRONTEND_PORT}` };
+    routes[`/beta/${SECTION}/${mount}`] = { host: `http://localhost:${FRONTEND_PORT}` };
+    routes[`/${SECTION}/${mount}`]      = { host: `http://localhost:${FRONTEND_PORT}` };
+    routes[`/beta/apps/${mount}`]       = { host: `http://localhost:${FRONTEND_PORT}` };
+    routes[`/apps/${mount}`]            = { host: `http://localhost:${FRONTEND_PORT}` };
 });
 
 module.exports = {

--- a/src/AppEntry.tsx
+++ b/src/AppEntry.tsx
@@ -19,7 +19,7 @@ interface AppEntryProps {
     logger?: Redux.Middleware;
 }
 
-export const AppEntry: React.FunctionComponent<AppEntryProps> = (props) => {
+const AppEntry: React.FunctionComponent<AppEntryProps> = (props) => {
 
     const client = React.useMemo(() => createFetchingClient(getInsights, {
         responseInterceptors: [ validateSchemaResponseInterceptor ]
@@ -47,3 +47,5 @@ export const AppEntry: React.FunctionComponent<AppEntryProps> = (props) => {
         </IntlProvider>
     );
 };
+
+export default AppEntry;

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -5,7 +5,7 @@ import { NotificationsPortal } from '@redhat-cloud-services/frontend-components-
 import { AppSkeleton } from '@redhat-cloud-services/insights-common-typescript';
 import * as React from 'react';
 import { useIntl } from 'react-intl';
-import { RouteComponentProps, useLocation, withRouter } from 'react-router';
+import { useLocation } from 'react-router';
 
 import Config from '../config/Config';
 import messages from '../properties/DefinedMessages';
@@ -14,7 +14,7 @@ import { getSubApp } from '../utils/Basename';
 import { AppContext } from './AppContext';
 import { useApp } from './useApp';
 
-const App: React.FunctionComponent<RouteComponentProps> = () => {
+const App: React.ComponentType = () => {
     const intl = useIntl();
     const { rbac, applications } = useApp();
     const location = useLocation();
@@ -65,4 +65,4 @@ const App: React.FunctionComponent<RouteComponentProps> = () => {
     );
 };
 
-export default withRouter(App);
+export default App;

--- a/src/bootstrap-dev.tsx
+++ b/src/bootstrap-dev.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import logger from 'redux-logger';
 
-import { AppEntry } from './AppEntry';
+import AppEntry from './AppEntry';
 
 ReactDOM.render(
     <AppEntry logger={ logger } />,

--- a/src/bootstrap.tsx
+++ b/src/bootstrap.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { AppEntry } from './AppEntry';
+import AppEntry from './AppEntry';
 
 ReactDOM.render(
     <AppEntry />,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1403,10 +1403,10 @@
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.9.22.tgz#d23488cddf19ad065ef55bd43b47336ee63bf4cc"
   integrity sha512-hN/8u7mFR62naFB2hdO7nl1p/0lCXtNq+VY+BAbp4UFC2/QyjNP0IOPBR+mR9Pbj5JwxrURI7G5blLp+k9RLvQ==
 
-"@redhat-cloud-services/frontend-components-config@4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.0.1.tgz#7c315460e4700a58e7628ee05aa6cfd2ac9788bf"
-  integrity sha512-E6BeIWaYWSSOQSqO+44jMEYdJJAEUUbzgaxAeiwS21QU06aBuY7V1hPzbYu1czpX2PWef+Jxkx+UxbyQRStSOA==
+"@redhat-cloud-services/frontend-components-config@4.0.5":
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/@redhat-cloud-services/frontend-components-config/-/frontend-components-config-4.0.5.tgz#5490a72e25c53054fc768a12da44837e6cbf64a4"
+  integrity sha512-NDBOemjw/zgH9VCdcYTKaYdbhgwtB3s5jjI0Z4TjdlfoXigAphejmHIBrU3BJtqV6odx5Ieq0GxvdFkNkAwVUw==
   dependencies:
     assert "^2.0.0"
     babel-loader "^8.2.1"
@@ -1418,7 +1418,7 @@
     file-loader "^6.2.0"
     git-revision-webpack-plugin "^3.0.6"
     html-replace-webpack-plugin "^2.6.0"
-    html-webpack-plugin "^4.5.0"
+    html-webpack-plugin "^5.1.0"
     koa-connect "^2.1.0"
     mini-css-extract-plugin "^1.3.1"
     node-sass "^5.0.0"
@@ -1930,7 +1930,7 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.0.tgz#7036640b4e21cc2f259ae826ce843d277dad8cff"
   integrity sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
 
-"@types/tapable@*", "@types/tapable@^1.0.5":
+"@types/tapable@*":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
   integrity sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
@@ -1982,7 +1982,7 @@
     "@types/webpack-sources" "*"
     source-map "^0.6.0"
 
-"@types/webpack@^4.4.31", "@types/webpack@^4.41.8":
+"@types/webpack@^4.4.31":
   version "4.41.26"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.41.26.tgz#27a30d7d531e16489f9c7607c747be6bc1a459ef"
   integrity sha512-7ZyTfxjCRwexh+EJFwRUM+CDB2XvgHl4vfuqf1ZKrgGvcS5BrNvPQqJh3tsZ0P6h6Aa1qClVHaJZszLPzpqHeA==
@@ -4081,7 +4081,7 @@ default-gateway@^4.2.0:
     execa "^1.0.0"
     ip-regex "^2.1.0"
 
-define-properties@^1.1.2, define-properties@^1.1.3:
+define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
@@ -5962,20 +5962,17 @@ html-tags@^3.1.0:
   resolved "https://registry.yarnpkg.com/html-tags/-/html-tags-3.1.0.tgz#7b5e6f7e665e9fb41f30007ed9e0d41e97fb2140"
   integrity sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==
 
-html-webpack-plugin@^4.5.0:
-  version "4.5.1"
-  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.5.1.tgz#40aaf1b5cb78f2f23a83333999625c20929cda65"
-  integrity sha512-yzK7RQZwv9xB+pcdHNTjcqbaaDZ+5L0zJHXfi89iWIZmb/FtzxhLk0635rmJihcQbs3ZUF27Xp4oWGx6EK56zg==
+html-webpack-plugin@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-5.1.0.tgz#1c11bbe01ab9d1262c4b601edebcf394364b1f60"
+  integrity sha512-2axkp+2NHmvHUWrKe1dY4LyM3WatQEdFChr42OY7R/Ad7f0AQzaKscGCcqN/FtQBxo8rdfJP7M3RMFDttqok3g==
   dependencies:
     "@types/html-minifier-terser" "^5.0.0"
-    "@types/tapable" "^1.0.5"
-    "@types/webpack" "^4.41.8"
     html-minifier-terser "^5.0.1"
-    loader-utils "^1.2.3"
+    loader-utils "^2.0.0"
     lodash "^4.17.20"
     pretty-error "^2.1.1"
-    tapable "^1.1.3"
-    util.promisify "1.0.0"
+    tapable "^2.0.0"
 
 htmlparser2@^3.10.0, htmlparser2@^3.3.0:
   version "3.10.1"
@@ -7477,7 +7474,7 @@ loader-runner@^4.2.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384"
   integrity sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==
 
-loader-utils@^1.2.3, loader-utils@^1.4.0:
+loader-utils@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
   integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
@@ -8492,14 +8489,6 @@ object.fromentries@^2.0.2:
     es-abstract "^1.17.0-next.1"
     function-bind "^1.1.1"
     has "^1.0.3"
-
-object.getownpropertydescriptors@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz#369bf1f9592d8ab89d712dced5cb81c7c5352649"
-  integrity sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -11078,12 +11067,12 @@ table@^6.0.3:
     slice-ansi "^4.0.0"
     string-width "^4.2.0"
 
-tapable@^1.0.0, tapable@^1.1.3:
+tapable@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
   integrity sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==
 
-tapable@^2.1.1, tapable@^2.2.0:
+tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.0.tgz#5c373d281d9c672848213d0e037d1c4165ab426b"
   integrity sha512-FBk4IesMV1rBxX2tfiK8RAmogtWn53puLOQlvO8XuwlgxcYbP4mVPS9Ph4aeamSyyVjOl24aYWAuc8U5kCVwMw==
@@ -11709,14 +11698,6 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
-
-util.promisify@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.0.tgz#440f7165a459c9a16dc145eb8e72f35687097030"
-  integrity sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==
-  dependencies:
-    define-properties "^1.1.2"
-    object.getownpropertydescriptors "^2.0.3"
 
 util@^0.12.0, util@^0.12.3:
   version "0.12.3"


### PR DESCRIPTION
cc @josejulio 

I have found some issues that have to be fixed in order for the app to work in chrome 2

- the react-router dom package sharing was not working; don't know why yet, I am suspicious it might be caused by the TS build; for now, it's removed from dependency sharing
- app entry was not exporting the app as a `default` module; This is required because of the React.lazy API
- Also I have changed the dev server to use from HTTP instead of HTTPS protocol; Required because of the proxy from /beta to / route for webpack dev server (it was unintentionally working in old chrome because the history API fallback was routing static assets from /beta to / but there are now XHR requests that are not caught by the fallback)

Have to be merged with: https://github.com/RedHatInsights/cloud-services-config/pull/407