### PR TITLE
NOTIF-223 Correctly show behavior groups on collapsed …

### DIFF
--- a/config/setupTests.ts
+++ b/config/setupTests.ts
@@ -1,6 +1,9 @@
 import { mockInsights } from 'insights-common-typescript-dev';
 import React from 'react';
 
-declare const global: any;
-global.React = React;
+import { mockResizeObserver } from './testutils/ResizeObserverMock';
+
+declare const window: any;
+window.React = React;
 mockInsights();
+mockResizeObserver();

--- a/config/testutils/ResizeObserverMock.ts
+++ b/config/testutils/ResizeObserverMock.ts
@@ -1,0 +1,92 @@
+// Copied from resize-observer-polyfill
+interface ResizeObserverCallback {
+    (entries: ResizeObserverEntry[], observer: ResizeObserver): void
+}
+interface ResizeObserverEntry {
+    readonly target: Element;
+    readonly contentRect: DOMRectReadOnly;
+}
+interface ResizeObserver {
+    observe(target: Element): void;
+    unobserve(target: Element): void;
+    disconnect(): void;
+}
+
+const observers: Array<ResizeObserverMock> = [];
+
+class ResizeObserverMock implements ResizeObserver {
+    readonly callback: ResizeObserverCallback;
+    targets: Array<Element>;
+
+    constructor(callback: ResizeObserverCallback) {
+        this.callback = callback;
+        this.targets = [];
+        observers.push(this);
+    }
+
+    mockEvent = (contentRect?: Partial<DOMRectReadOnly>, target?: Element) => {
+        if (!target) {
+            if (this.targets.length > 0) {
+                target = this.targets[this.targets.length - 1];
+            } else {
+                throw new Error('Nothing observed to mock an event');
+            }
+        } else {
+            if (this.targets.indexOf(target) === -1) {
+                throw new Error('Target not yet observed');
+            }
+        }
+
+        this.callback([{
+            target,
+            contentRect: {
+                width: 0,
+                height: 0,
+                left: 0,
+                right: 0,
+                top: 0,
+                bottom: 0,
+                x: 0,
+                y: 0,
+                toJSON: () => 'Mocked contentRect',
+                ...contentRect
+            }
+        }], this);
+    };
+
+    observe = jest.fn((target: Element) => {
+        this.targets.push(target);
+    });
+
+    unobserve = jest.fn((target: Element) => {
+        this.targets.splice(
+            this.targets.indexOf(target, 1)
+        );
+    });
+
+    disconnect = jest.fn(() => {
+        observers.splice(
+            observers.indexOf(this),
+            1
+        );
+    });
+}
+
+interface ResizeObserverMockWindow extends Window {
+    ResizeObserver: typeof ResizeObserverMock
+}
+
+declare const window: ResizeObserverMockWindow;
+
+export const mockResizeObserver = () => {
+    window.ResizeObserver = ResizeObserverMock;
+};
+
+export const getObservers = () => observers as ReadonlyArray<ResizeObserverMock>;
+export const getLastObserver = (): ResizeObserverMock =>  {
+    if (observers.length > 0) {
+        return observers[ observers.length - 1];
+    }
+
+    throw new Error('No observer has registered yet');
+};

--- a/src/components/Notifications/BehaviorGroup/BehaviorGroupCardList.tsx
+++ b/src/components/Notifications/BehaviorGroup/BehaviorGroupCardList.tsx
@@ -1,6 +1,7 @@
 import { Flex, FlexItem } from '@patternfly/react-core';
 import { global_spacer_md } from '@patternfly/react-tokens';
 import * as React from 'react';
+import { useMeasure } from 'react-use';
 import { style } from 'typestyle';
 
 import { BehaviorGroup } from '../../../types/Notification';
@@ -28,12 +29,21 @@ interface BehaviorGroupCardListLayoutProps {
 }
 
 const BehaviorGroupCardListLayout: React.FunctionComponent<BehaviorGroupCardListLayoutProps> = props => {
-    const ref = React.useCallback(container => {
-        if (container?.firstChild?.firstChild) {
-            const height = container.firstChild.firstChild.getBoundingClientRect().height;
-            container.firstChild.style['max-height'] = `${height}px`;
+
+    const [ measureRef, measuredSizing ] = useMeasure<HTMLDivElement>();
+    const container = React.useRef<HTMLDivElement>();
+    const ref = React.useCallback(refContainer => {
+        container.current = refContainer;
+        measureRef(refContainer);
+    }, [ container, measureRef ]);
+
+    React.useEffect(() => {
+        if (container.current?.firstChild?.firstChild) {
+            const element = container.current.firstChild as HTMLElement;
+            const height = (element.firstChild as HTMLElement).getBoundingClientRect().height;
+            element.style['max-height'] = `${height}px`;
         }
-    }, []);
+    }, [ measuredSizing ]);
 
     return (
         <div ref={ ref }>

--- a/src/components/Notifications/BehaviorGroup/BehaviorGroupCardList.tsx
+++ b/src/components/Notifications/BehaviorGroup/BehaviorGroupCardList.tsx
@@ -46,11 +46,12 @@ const BehaviorGroupCardListLayout: React.FunctionComponent<BehaviorGroupCardList
     }, [ measuredSizing ]);
 
     return (
-        <div ref={ ref }>
+        <div ref={ ref } data-testid="ref-card-list-container">
             <Flex
                 alignItems={ { default: 'alignItemsStretch' } }
                 alignContent={ { default: 'alignContentSpaceBetween' } }
                 className={ cardsWrapperClassName }
+                data-testid="card-list-container"
             >
                 { props.contents.map(content => (
                     <FlexItem key={ content.key } className={ cardWrapperClassName }>

--- a/src/components/Notifications/BehaviorGroup/__tests__/BehaviorGroupCardList.test.tsx
+++ b/src/components/Notifications/BehaviorGroup/__tests__/BehaviorGroupCardList.test.tsx
@@ -1,0 +1,82 @@
+import { act, render, screen } from '@testing-library/react';
+import * as React from 'react';
+
+import { getLastObserver } from '../../../../../config/testutils/ResizeObserverMock';
+import { waitForAsyncEvents } from '../../../../../test/TestUtils';
+import { BehaviorGroup, NotificationType } from '../../../../types/Notification';
+import { BehaviorGroupCardList } from '../BehaviorGroupCardList';
+
+const Container: React.FunctionComponent<{
+    hideContent: boolean
+}> = props => (
+    <div>
+        <div style={ props.hideContent ? { display: 'none' } : { display: 'block' } }>
+            { props.children }
+        </div>
+    </div>
+);
+
+const makeRect = (contentRect?: Partial<DOMRectReadOnly>) => ({
+    bottom: 0,
+    height: 0,
+    left: 0,
+    right: 0,
+    top: 0,
+    width: 0,
+    x: 0,
+    y: 0,
+    toJSON: () => 'foo',
+    ...contentRect
+});
+
+describe('src/components/Notifications/BehaviorGroup/BehaviorGroupCardList', () => {
+    it('Behavior groups created inside a display:none section are still show correctly after when setting display:block', async () => {
+
+        const bg: Array<BehaviorGroup> = [{
+            bundleId: 'foo',
+            actions: [
+                {
+                    integrationId: 'bar',
+                    recipient: [],
+                    type: NotificationType.EMAIL_SUBSCRIPTION
+                }
+            ],
+            displayName: 'My group',
+            id: 'bar'
+        }];
+
+        window. HTMLDivElement.prototype.getBoundingClientRect = () => makeRect();
+
+        const { rerender } = render(
+            <Container hideContent={ true }>
+                <BehaviorGroupCardList onEdit={ jest.fn() } onDelete={ jest.fn() } behaviorGroups={ bg } />
+            </Container>
+        );
+
+        expect(screen.getByText(/my group/i)).toBeInTheDocument();
+        expect(screen.getByText(/my group/i)).not.toBeVisible();
+        expect(screen.getByTestId('card-list-container')).toHaveStyle('max-height:0px');
+
+        window. HTMLDivElement.prototype.getBoundingClientRect = () => makeRect({
+            height: 100
+        });
+
+        rerender(
+            <Container hideContent={ false }>
+                <BehaviorGroupCardList onEdit={ jest.fn() } onDelete={ jest.fn() } behaviorGroups={ bg } />
+            </Container>
+        );
+
+        // Simulate resize
+        act(() => {
+            getLastObserver().mockEvent({
+                height: 100
+            });
+        });
+        await waitForAsyncEvents();
+
+        expect(screen.getByText(/my group/i)).toBeInTheDocument();
+        expect(screen.getByText(/my group/i)).toBeVisible();
+        expect(screen.getByTestId('card-list-container')).toHaveStyle('max-height:100px');
+    });
+});

--- a/src/pages/Notifications/List/BehaviorGroupsSection.tsx
+++ b/src/pages/Notifications/List/BehaviorGroupsSection.tsx
@@ -78,7 +78,8 @@ export const BehaviorGroupsSection: React.FunctionComponent<BehaviorGroupSection
     const [ editModalState, editModalActions ] = useFormModalReducer<BehaviorGroup>();
     const [ deleteModalState, deleteModalActions ] = useDeleteModalReducer<BehaviorGroup>();
 
-    const createGroup = React.useCallback(() => {
+    const createGroup = React.useCallback((event) => {
+        event.stopPropagation();
         editModalActions.create({
             bundleId: props.bundleId
         });


### PR DESCRIPTION
 - This will prevent from the behavior groups list to remain hidden even
   if the content is collapsed
 - Also fixes the Create button from triggering a collapse/expand
