### PR TITLE
Unregister app nav listener.

### DIFF
--- a/src/pages/Notifications/List/Page.tsx
+++ b/src/pages/Notifications/List/Page.tsx
@@ -33,11 +33,16 @@ export const NotificationsListPage: React.FunctionComponent = () => {
     const getApplications = useGetApplications();
 
     React.useEffect(() => {
+        let unregister;
         if (onFunction) {
-            onFunction('APP_NAVIGATION', (event: any) => {
+            unregister = onFunction('APP_NAVIGATION', (event: any) => {
                 history.push(linkTo.notifications(event.navId));
             });
         }
+
+        return () => {
+            typeof unregister === 'function' && unregister();
+        };
     }, [ history, onFunction ]);
 
     const bundle: Facet | BundleStatus = useMemo(() => {


### PR DESCRIPTION
There is a hidden bug within notifications that changes history in other apps. There is a listener on the `APP_NAV_CLICK` event but it's never removed once the notifications application is unmounted.

That means the listener is still active when other applications are mounted and it changes their routing sometimes.

cc @josejulio 