### PR TITLE
Revert deploy settings:

### DIFF
--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -7,7 +7,7 @@ source ./.github/scripts/commands.sh
 if [ "${TRAVIS_BRANCH}" = "master" ]
 then
     ensure_beta
-    for env in ci
+    for env in ci qa
     do
         echo "PUSHING ${env}-beta"
         rm -rf ./dist/.git
@@ -19,7 +19,7 @@ fi
 if [ "${TRAVIS_BRANCH}" = "master" ]
 then
     ensure_stable
-    for env in ci
+    for env in ci qa
     do
         echo "PUSHING ${env}-stable"
         rm -rf ./dist/.git


### PR DESCRIPTION
 master -> ci,qa-beta-stable

To merge when we are ready to upgrade qa/stage to use behavior groups by default