### PR TITLE
NOTIF-224 Only request the behavior groups if the notifications changed

### DIFF
--- a/src/pages/Notifications/List/useBehaviorGroupNotificationRows.tsx
+++ b/src/pages/Notifications/List/useBehaviorGroupNotificationRows.tsx
@@ -144,29 +144,29 @@ export const useBehaviorGroupNotificationRows = (notifications: Array<Notificati
                 behaviors: [],
                 isEditMode: false
             })));
-        }
 
-        if (notifications) {
-            limit.clearQueue();
+            if (notifications) {
+                limit.clearQueue();
 
-            notifications.map(notification => notification.id).forEach(notificationId => {
-                limit(() => query(getBehaviorGroupByNotificationAction(notificationId))).then(response => {
-                    setNotificationRows(produce(draft => {
-                        const draftNotification = getNotification(draft, notificationId);
-                        if (response.payload?.status === 200) {
-                            draftNotification.loadingActionStatus = 'done';
-                            draftNotification.behaviors = response.payload.value.map(toBehaviorGroup).map(bg => ({
-                                ...bg,
-                                isLoading: false,
-                                actions: castDraft(bg.actions)
-                            }));
-                        } else {
-                            draftNotification.loadingActionStatus = 'error';
-                            draftNotification.behaviors = [];
-                        }
-                    }));
+                notifications.map(notification => notification.id).forEach(notificationId => {
+                    limit(() => query(getBehaviorGroupByNotificationAction(notificationId))).then(response => {
+                        setNotificationRows(produce(draft => {
+                            const draftNotification = getNotification(draft, notificationId);
+                            if (response.payload?.status === 200) {
+                                draftNotification.loadingActionStatus = 'done';
+                                draftNotification.behaviors = response.payload.value.map(toBehaviorGroup).map(bg => ({
+                                    ...bg,
+                                    isLoading: false,
+                                    actions: castDraft(bg.actions)
+                                }));
+                            } else {
+                                draftNotification.loadingActionStatus = 'error';
+                                draftNotification.behaviors = [];
+                            }
+                        }));
+                    });
                 });
-            });
+            }
         }
 
     }, [ notifications, limit, query, prevNotificationInput, setNotificationRows ]);


### PR DESCRIPTION
With this, we no longer request twice the event types of a notification. 
The reason it was failing was because the request code wasn't checking if the notifications changed.