### PR TITLE
NOTIF-242 Fetch system Endpoints instead of creating

### DIFF
--- a/src/generated/OpenapiNotifications.ts
+++ b/src/generated/OpenapiNotifications.ts
@@ -225,13 +225,10 @@ export namespace Schemas {
 
   export const MigrationReport = zodSchemaMigrationReport();
   export type MigrationReport = {
-    accountsWithDefaults?: AtomicLong | undefined | null;
-    accountsWithNonDefaults?: AtomicLong | undefined | null;
-    actionsPersisted?: AtomicLong | undefined | null;
-    behaviorGroupsAggregated?: AtomicLong | undefined | null;
-    behaviorGroupsPersisted?: AtomicLong | undefined | null;
-    behaviorsPersisted?: AtomicLong | undefined | null;
+    deletedEndpoints?: AtomicLong | undefined | null;
     durationInMs?: AtomicLong | undefined | null;
+    updatedAccounts?: AtomicLong | undefined | null;
+    updatedBehaviorGroupActions?: AtomicLong | undefined | null;
   };
 
   export const MultivaluedMapStringObject =
@@ -276,6 +273,37 @@ export namespace Schemas {
     invocationTime: number;
   };
 
+  export const PageRbacGroup = zodSchemaPageRbacGroup();
+  export type PageRbacGroup = {
+    data: Array<RbacGroup>;
+    links: {
+      [x: string]: string;
+    };
+    meta: Meta;
+  };
+
+  export const PageRbacUser = zodSchemaPageRbacUser();
+  export type PageRbacUser = {
+    data: Array<RbacUser>;
+    links: {
+      [x: string]: string;
+    };
+    meta: Meta;
+  };
+
+  export const RbacGroup = zodSchemaRbacGroup();
+  export type RbacGroup = {
+    created?: string | undefined | null;
+    description?: string | undefined | null;
+    modified?: string | undefined | null;
+    name?: string | undefined | null;
+    platform_default?: boolean | undefined | null;
+    principalCount?: number | undefined | null;
+    roleCount?: number | undefined | null;
+    system?: boolean | undefined | null;
+    uuid?: UUID | undefined | null;
+  };
+
   export const RbacRaw = zodSchemaRbacRaw();
   export type RbacRaw = {
     data?:
@@ -296,6 +324,18 @@ export namespace Schemas {
         }
       | undefined
       | null;
+  };
+
+  export const RbacUser = zodSchemaRbacUser();
+  export type RbacUser = {
+    active?: boolean | undefined | null;
+    email?: string | undefined | null;
+    firstName?: string | undefined | null;
+    isActive?: boolean | undefined | null;
+    isOrgAdmin?: boolean | undefined | null;
+    lastName?: string | undefined | null;
+    orgAdmin?: boolean | undefined | null;
+    username?: string | undefined | null;
   };
 
   export const Response = zodSchemaResponse();
@@ -607,13 +647,12 @@ export namespace Schemas {
   function zodSchemaMigrationReport() {
       return z
       .object({
-          accountsWithDefaults: zodSchemaAtomicLong().optional().nullable(),
-          accountsWithNonDefaults: zodSchemaAtomicLong().optional().nullable(),
-          actionsPersisted: zodSchemaAtomicLong().optional().nullable(),
-          behaviorGroupsAggregated: zodSchemaAtomicLong().optional().nullable(),
-          behaviorGroupsPersisted: zodSchemaAtomicLong().optional().nullable(),
-          behaviorsPersisted: zodSchemaAtomicLong().optional().nullable(),
-          durationInMs: zodSchemaAtomicLong().optional().nullable()
+          deletedEndpoints: zodSchemaAtomicLong().optional().nullable(),
+          durationInMs: zodSchemaAtomicLong().optional().nullable(),
+          updatedAccounts: zodSchemaAtomicLong().optional().nullable(),
+          updatedBehaviorGroupActions: zodSchemaAtomicLong()
+          .optional()
+          .nullable()
       })
       .nonstrict();
   }
@@ -657,12 +696,63 @@ export namespace Schemas {
       .nonstrict();
   }
 
+  function zodSchemaPageRbacGroup() {
+      return z
+      .object({
+          data: z.array(zodSchemaRbacGroup()),
+          links: z.record(z.string()),
+          meta: zodSchemaMeta()
+      })
+      .nonstrict();
+  }
+
+  function zodSchemaPageRbacUser() {
+      return z
+      .object({
+          data: z.array(zodSchemaRbacUser()),
+          links: z.record(z.string()),
+          meta: zodSchemaMeta()
+      })
+      .nonstrict();
+  }
+
+  function zodSchemaRbacGroup() {
+      return z
+      .object({
+          created: z.string().optional().nullable(),
+          description: z.string().optional().nullable(),
+          modified: z.string().optional().nullable(),
+          name: z.string().optional().nullable(),
+          platform_default: z.boolean().optional().nullable(),
+          principalCount: z.number().int().optional().nullable(),
+          roleCount: z.number().int().optional().nullable(),
+          system: z.boolean().optional().nullable(),
+          uuid: zodSchemaUUID().optional().nullable()
+      })
+      .nonstrict();
+  }
+
   function zodSchemaRbacRaw() {
       return z
       .object({
           data: z.array(z.record(z.unknown())).optional().nullable(),
           links: z.record(z.string()).optional().nullable(),
           meta: z.record(z.number().int()).optional().nullable()
+      })
+      .nonstrict();
+  }
+
+  function zodSchemaRbacUser() {
+      return z
+      .object({
+          active: z.boolean().optional().nullable(),
+          email: z.string().optional().nullable(),
+          firstName: z.string().optional().nullable(),
+          isActive: z.boolean().optional().nullable(),
+          isOrgAdmin: z.boolean().optional().nullable(),
+          lastName: z.string().optional().nullable(),
+          orgAdmin: z.boolean().optional().nullable(),
+          username: z.string().optional().nullable()
       })
       .nonstrict();
   }

--- a/src/generated/OpenapiPrivate.ts
+++ b/src/generated/OpenapiPrivate.ts
@@ -225,13 +225,10 @@ export namespace Schemas {
 
   export const MigrationReport = zodSchemaMigrationReport();
   export type MigrationReport = {
-    accountsWithDefaults?: AtomicLong | undefined | null;
-    accountsWithNonDefaults?: AtomicLong | undefined | null;
-    actionsPersisted?: AtomicLong | undefined | null;
-    behaviorGroupsAggregated?: AtomicLong | undefined | null;
-    behaviorGroupsPersisted?: AtomicLong | undefined | null;
-    behaviorsPersisted?: AtomicLong | undefined | null;
+    deletedEndpoints?: AtomicLong | undefined | null;
     durationInMs?: AtomicLong | undefined | null;
+    updatedAccounts?: AtomicLong | undefined | null;
+    updatedBehaviorGroupActions?: AtomicLong | undefined | null;
   };
 
   export const MultivaluedMapStringObject =
@@ -276,6 +273,37 @@ export namespace Schemas {
     invocationTime: number;
   };
 
+  export const PageRbacGroup = zodSchemaPageRbacGroup();
+  export type PageRbacGroup = {
+    data: Array<RbacGroup>;
+    links: {
+      [x: string]: string;
+    };
+    meta: Meta;
+  };
+
+  export const PageRbacUser = zodSchemaPageRbacUser();
+  export type PageRbacUser = {
+    data: Array<RbacUser>;
+    links: {
+      [x: string]: string;
+    };
+    meta: Meta;
+  };
+
+  export const RbacGroup = zodSchemaRbacGroup();
+  export type RbacGroup = {
+    created?: string | undefined | null;
+    description?: string | undefined | null;
+    modified?: string | undefined | null;
+    name?: string | undefined | null;
+    platform_default?: boolean | undefined | null;
+    principalCount?: number | undefined | null;
+    roleCount?: number | undefined | null;
+    system?: boolean | undefined | null;
+    uuid?: UUID | undefined | null;
+  };
+
   export const RbacRaw = zodSchemaRbacRaw();
   export type RbacRaw = {
     data?:
@@ -296,6 +324,18 @@ export namespace Schemas {
         }
       | undefined
       | null;
+  };
+
+  export const RbacUser = zodSchemaRbacUser();
+  export type RbacUser = {
+    active?: boolean | undefined | null;
+    email?: string | undefined | null;
+    firstName?: string | undefined | null;
+    isActive?: boolean | undefined | null;
+    isOrgAdmin?: boolean | undefined | null;
+    lastName?: string | undefined | null;
+    orgAdmin?: boolean | undefined | null;
+    username?: string | undefined | null;
   };
 
   export const Response = zodSchemaResponse();
@@ -607,13 +647,12 @@ export namespace Schemas {
   function zodSchemaMigrationReport() {
       return z
       .object({
-          accountsWithDefaults: zodSchemaAtomicLong().optional().nullable(),
-          accountsWithNonDefaults: zodSchemaAtomicLong().optional().nullable(),
-          actionsPersisted: zodSchemaAtomicLong().optional().nullable(),
-          behaviorGroupsAggregated: zodSchemaAtomicLong().optional().nullable(),
-          behaviorGroupsPersisted: zodSchemaAtomicLong().optional().nullable(),
-          behaviorsPersisted: zodSchemaAtomicLong().optional().nullable(),
-          durationInMs: zodSchemaAtomicLong().optional().nullable()
+          deletedEndpoints: zodSchemaAtomicLong().optional().nullable(),
+          durationInMs: zodSchemaAtomicLong().optional().nullable(),
+          updatedAccounts: zodSchemaAtomicLong().optional().nullable(),
+          updatedBehaviorGroupActions: zodSchemaAtomicLong()
+          .optional()
+          .nullable()
       })
       .nonstrict();
   }
@@ -657,12 +696,63 @@ export namespace Schemas {
       .nonstrict();
   }
 
+  function zodSchemaPageRbacGroup() {
+      return z
+      .object({
+          data: z.array(zodSchemaRbacGroup()),
+          links: z.record(z.string()),
+          meta: zodSchemaMeta()
+      })
+      .nonstrict();
+  }
+
+  function zodSchemaPageRbacUser() {
+      return z
+      .object({
+          data: z.array(zodSchemaRbacUser()),
+          links: z.record(z.string()),
+          meta: zodSchemaMeta()
+      })
+      .nonstrict();
+  }
+
+  function zodSchemaRbacGroup() {
+      return z
+      .object({
+          created: z.string().optional().nullable(),
+          description: z.string().optional().nullable(),
+          modified: z.string().optional().nullable(),
+          name: z.string().optional().nullable(),
+          platform_default: z.boolean().optional().nullable(),
+          principalCount: z.number().int().optional().nullable(),
+          roleCount: z.number().int().optional().nullable(),
+          system: z.boolean().optional().nullable(),
+          uuid: zodSchemaUUID().optional().nullable()
+      })
+      .nonstrict();
+  }
+
   function zodSchemaRbacRaw() {
       return z
       .object({
           data: z.array(z.record(z.unknown())).optional().nullable(),
           links: z.record(z.string()).optional().nullable(),
           meta: z.record(z.number().int()).optional().nullable()
+      })
+      .nonstrict();
+  }
+
+  function zodSchemaRbacUser() {
+      return z
+      .object({
+          active: z.boolean().optional().nullable(),
+          email: z.string().optional().nullable(),
+          firstName: z.string().optional().nullable(),
+          isActive: z.boolean().optional().nullable(),
+          isOrgAdmin: z.boolean().optional().nullable(),
+          lastName: z.string().optional().nullable(),
+          orgAdmin: z.boolean().optional().nullable(),
+          username: z.string().optional().nullable()
       })
       .nonstrict();
   }

--- a/src/pages/Notifications/Form/EditBehaviorGroupPage.tsx
+++ b/src/pages/Notifications/Form/EditBehaviorGroupPage.tsx
@@ -1,4 +1,6 @@
 import { addDangerNotification, addSuccessNotification } from '@redhat-cloud-services/insights-common-typescript';
+import isEqual from 'lodash/isEqual';
+import uniqWith from 'lodash/uniqWith';
 import * as React from 'react';
 import { useContext } from 'react';
 import { ClientContext } from 'react-fetching-library';
@@ -6,12 +8,17 @@ import { ClientContext } from 'react-fetching-library';
 import { BehaviorGroupSaveModal } from '../../../components/Notifications/BehaviorGroup/BehaviorGroupSaveModal';
 import { useGetIntegrations } from '../../../components/Notifications/useGetIntegrations';
 import { useGetRecipients } from '../../../components/Notifications/useGetRecipients';
+import { getDefaultSystemEndpointAction } from '../../../services/Integrations/GetDefaultSystemEndpoint';
 import { useSaveBehaviorGroupMutation } from '../../../services/Notifications/SaveBehaviorGroup';
 import { useUpdateBehaviorGroupActionsMutation } from '../../../services/Notifications/UpdateBehaviorGroupActions';
-import { deleteIntegrationActionCreator } from '../../../services/useDeleteIntegration';
-import { createIntegrationActionCreator } from '../../../services/useSaveIntegration';
-import { IntegrationType } from '../../../types/Integration';
-import { Action, BehaviorGroup, NewBehaviorGroup, NotificationType, UUID } from '../../../types/Notification';
+import { toSystemProperties } from '../../../types/adapters/NotificationAdapter';
+import {
+    BehaviorGroup,
+    NewBehaviorGroup,
+    NotificationType,
+    SystemProperties,
+    UUID
+} from '../../../types/Notification';
 
 interface EditBehaviorGroupPageProps {
     behaviorGroup?: Partial<BehaviorGroup>;
@@ -29,7 +36,7 @@ export const EditBehaviorGroupPage: React.FunctionComponent<EditBehaviorGroupPag
     const saveBehaviorGroupMutation = useSaveBehaviorGroupMutation();
     const updateBehaviorGroupActionsMutation = useUpdateBehaviorGroupActionsMutation();
     const { query } = useContext(ClientContext);
-    const [ creatingIntegrations, setCreatingNotifications ] = React.useState<boolean>(false);
+    const [ fetchingIntegrations, setFetchingIntegrations ] = React.useState<boolean>(false);
 
     const onSave = React.useCallback(async (data: BehaviorGroup | NewBehaviorGroup) => {
         const updateBehaviorGroupActions = updateBehaviorGroupActionsMutation.mutate;
@@ -46,22 +53,22 @@ export const EditBehaviorGroupPage: React.FunctionComponent<EditBehaviorGroupPag
                 throw new Error('Behavior group wasn\'t saved');
             }) : Promise.resolve(data.id)).then(behaviorGroupId => {
 
-            // Determine what Integrations we need to create (other than webhook)
-            const toCreate: Array<Action> = data.actions.filter(action => !action.integrationId);
-            if (toCreate.find(newAction => newAction.type !== NotificationType.EMAIL_SUBSCRIPTION)) {
+            // Determine what system Integrations we need to fetch
+            const toFetch: Array<SystemProperties> = uniqWith(
+                data.actions.filter(action => !action.integrationId).map(action => toSystemProperties(action)),
+                isEqual
+            );
+
+            if (toFetch.find(props => props.type !== NotificationType.EMAIL_SUBSCRIPTION)) {
                 throw new Error('Only email subscriptions are created when assigning behavior groups');
             }
 
-            if (toCreate.length > 0) {
-                setCreatingNotifications(true);
+            if (toFetch.length > 0) {
+                setFetchingIntegrations(true);
             }
 
             return Promise.all(
-                toCreate.map(_ => query(createIntegrationActionCreator({
-                    type: IntegrationType.EMAIL_SUBSCRIPTION,
-                    name: 'Email subscription',
-                    isEnabled: true
-                }))
+                toFetch.map(props => query(getDefaultSystemEndpointAction(props))
                 .then(result => result.payload?.type === 'Endpoint' ? result.payload.value.id : undefined)
                 )
             ).then(newIds => {
@@ -74,12 +81,6 @@ export const EditBehaviorGroupPage: React.FunctionComponent<EditBehaviorGroupPag
             });
         }).then(value => {
             if (value.payload?.status === 200) {
-                // Delete non-user actions in the background; user doesn't need to wait.
-                (props.behaviorGroup?.actions ?? [])
-                .filter(action => action.type !== NotificationType.INTEGRATION)
-                .filter(action => !data.actions.find(newAction => newAction.integrationId === action.integrationId))
-                .map(oldNonUserAction =>  query(deleteIntegrationActionCreator(oldNonUserAction.integrationId)));
-
                 if (data.id === undefined) {
                     addSuccessNotification(
                         'New behavior group created',
@@ -127,8 +128,8 @@ export const EditBehaviorGroupPage: React.FunctionComponent<EditBehaviorGroupPag
     }, [ saveBehaviorGroupMutation.mutate, updateBehaviorGroupActionsMutation.mutate, props.behaviorGroup, query ]);
 
     const isSaving = React.useMemo(() => {
-        return creatingIntegrations || saveBehaviorGroupMutation.loading || updateBehaviorGroupActionsMutation.loading;
-    }, [ creatingIntegrations, saveBehaviorGroupMutation.loading, updateBehaviorGroupActionsMutation.loading ]);
+        return fetchingIntegrations || saveBehaviorGroupMutation.loading || updateBehaviorGroupActionsMutation.loading;
+    }, [ fetchingIntegrations, saveBehaviorGroupMutation.loading, updateBehaviorGroupActionsMutation.loading ]);
 
     return (
         <BehaviorGroupSaveModal

--- a/src/services/Integrations/GetDefaultSystemEndpoint.ts
+++ b/src/services/Integrations/GetDefaultSystemEndpoint.ts
@@ -1,0 +1,12 @@
+import { Operations } from '../../generated/OpenapiIntegrations';
+import { NotificationType, SystemProperties } from '../../types/Notification';
+
+export const getDefaultSystemEndpointAction = (props: SystemProperties) => {
+    if (props.type !== NotificationType.EMAIL_SUBSCRIPTION) {
+        throw new Error('Only email subscriptions are allowed to be fetched');
+    }
+
+    return Operations.EndpointServiceGetOrCreateEmailSubscriptionEndpoint.actionCreator({
+        body: {}
+    });
+};

--- a/src/types/Notification.ts
+++ b/src/types/Notification.ts
@@ -61,3 +61,8 @@ export type BehaviorGroup = {
 }
 
 export type NewBehaviorGroup = Partial<Pick<BehaviorGroup, 'id'>> & Omit<BehaviorGroup, 'id'>;
+
+export type EmailSystemProperties = {
+    type: NotificationType.EMAIL_SUBSCRIPTION
+}
+export type SystemProperties = EmailSystemProperties;

--- a/src/types/adapters/NotificationAdapter.ts
+++ b/src/types/adapters/NotificationAdapter.ts
@@ -2,7 +2,13 @@ import { assertNever } from 'assert-never';
 
 import { Schemas } from '../../generated/OpenapiNotifications';
 import { ServerIntegrationResponse, UserIntegration } from '../Integration';
-import { Action, NotificationBase, NotificationType, ServerNotificationResponse } from '../Notification';
+import {
+    Action,
+    NotificationBase,
+    NotificationType,
+    ServerNotificationResponse,
+    SystemProperties
+} from '../Notification';
 import { filterOutDefaultAction, toIntegration } from './IntegrationAdapter';
 
 const _toAction = (type: NotificationType, serverAction: ServerIntegrationResponse): Action => {
@@ -56,3 +62,13 @@ export const toAction = (serverAction: ServerIntegrationResponse): Action => {
 
 export const toNotifications = (serverNotifications: Array<ServerNotificationResponse>) => serverNotifications.map(toNotification);
 export const toActions = (serverActions: Array<ServerIntegrationResponse>): Array<Action> => filterOutDefaultAction(serverActions).map(toAction);
+
+export const toSystemProperties = (action: Action): SystemProperties => {
+    if (action.type === NotificationType.EMAIL_SUBSCRIPTION) {
+        return {
+            type: NotificationType.EMAIL_SUBSCRIPTION
+        };
+    } else {
+        throw new Error(`No system properties for type ${action.type}`);
+    }
+};


### PR DESCRIPTION
Instead of creating/deleting the Email endpoints, makes use of the new API to fetch the system endpoints to assign them to behavior groups.

Requires https://github.com/RedHatInsights/notifications-backend/pull/362