### PR TITLE
NOTIF-429 Uses camel:splunk types

### DIFF
--- a/src/components/Integrations/Form.tsx
+++ b/src/components/Integrations/Form.tsx
@@ -3,6 +3,7 @@ import { Form, FormSelect, FormTextInput, getInsights, OuiaComponentProps, ouiaI
 import { useFormikContext } from 'formik';
 import * as React from 'react';
 
+import Config from '../../config/Config';
 import { Messages } from '../../properties/Messages';
 import { maxIntegrationNameLength } from '../../schemas/Integrations/Integration';
 import { isStagingStableOrAnyProd } from '../../types/Environments';
@@ -23,7 +24,7 @@ export const IntegrationsForm: React.FunctionComponent<OuiaComponentProps> = (pr
         ];
 
         return options
-        .map(type => (<FormSelectOption key={ type } label={ Messages.components.integrations.integrationType[type] } value={ type } />));
+        .map(type => (<FormSelectOption key={ type } label={ Config.integrations.types[type].name } value={ type } />));
     }, [ insights ]);
 
     return (

--- a/src/components/Integrations/Form.tsx
+++ b/src/components/Integrations/Form.tsx
@@ -1,31 +1,28 @@
 import { FormSelectOption } from '@patternfly/react-core';
-import { Form, FormSelect, FormTextInput, getInsights, OuiaComponentProps, ouiaIdConcat } from '@redhat-cloud-services/insights-common-typescript';
+import { Form, FormSelect, FormTextInput, OuiaComponentProps, ouiaIdConcat } from '@redhat-cloud-services/insights-common-typescript';
 import { useFormikContext } from 'formik';
 import * as React from 'react';
 
 import Config from '../../config/Config';
-import { Messages } from '../../properties/Messages';
 import { maxIntegrationNameLength } from '../../schemas/Integrations/Integration';
-import { isStagingStableOrAnyProd } from '../../types/Environments';
-import { IntegrationType, NewUserIntegration } from '../../types/Integration';
+import { isReleased } from '../../types/Environments';
+import { NewUserIntegration } from '../../types/Integration';
 import { getOuiaProps } from '../../utils/getOuiaProps';
 import { IntegrationTypeForm } from './Form/IntegrationTypeForm';
 
 export const IntegrationsForm: React.FunctionComponent<OuiaComponentProps> = (props) => {
 
     const { values } = useFormikContext<NewUserIntegration>();
-    const insights = getInsights();
+    const released = isReleased();
 
     const options = React.useMemo(() => {
-        const options = isStagingStableOrAnyProd(insights) ? [ IntegrationType.WEBHOOK ] : [
-            IntegrationType.WEBHOOK,
-            IntegrationType.SPLUNK, // Todo: Make it easier to add types
-            IntegrationType.ANYCAMEL
-        ];
+        const options = released ?
+            Config.integrations.integrationActions.released :
+            Config.integrations.integrationActions.experimental;
 
         return options
         .map(type => (<FormSelectOption key={ type } label={ Config.integrations.types[type].name } value={ type } />));
-    }, [ insights ]);
+    }, [ released ]);
 
     return (
         <Form { ...getOuiaProps('Integrations/Form', props) }>

--- a/src/components/Integrations/Form.tsx
+++ b/src/components/Integrations/Form.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 
 import { Messages } from '../../properties/Messages';
 import { maxIntegrationNameLength } from '../../schemas/Integrations/Integration';
-import { isStagingOrProd } from '../../types/Environments';
+import { isStagingStableOrAnyProd } from '../../types/Environments';
 import { IntegrationType, NewUserIntegration } from '../../types/Integration';
 import { getOuiaProps } from '../../utils/getOuiaProps';
 import { IntegrationTypeForm } from './Form/IntegrationTypeForm';
@@ -16,9 +16,9 @@ export const IntegrationsForm: React.FunctionComponent<OuiaComponentProps> = (pr
     const insights = getInsights();
 
     const options = React.useMemo(() => {
-        const options = isStagingOrProd(insights) ? [ IntegrationType.WEBHOOK ] : [
+        const options = isStagingStableOrAnyProd(insights) ? [ IntegrationType.WEBHOOK ] : [
             IntegrationType.WEBHOOK,
-            IntegrationType.CAMEL
+            IntegrationType.SPLUNK
         ];
 
         return options

--- a/src/components/Integrations/Form.tsx
+++ b/src/components/Integrations/Form.tsx
@@ -17,8 +17,8 @@ export const IntegrationsForm: React.FunctionComponent<OuiaComponentProps> = (pr
 
     const options = React.useMemo(() => {
         const options = released ?
-            Config.integrations.integrationActions.released :
-            Config.integrations.integrationActions.experimental;
+            Config.integrations.actions.released :
+            Config.integrations.actions.experimental;
 
         return options
         .map(type => (<FormSelectOption key={ type } label={ Config.integrations.types[type].name } value={ type } />));

--- a/src/components/Integrations/Form.tsx
+++ b/src/components/Integrations/Form.tsx
@@ -18,7 +18,8 @@ export const IntegrationsForm: React.FunctionComponent<OuiaComponentProps> = (pr
     const options = React.useMemo(() => {
         const options = isStagingStableOrAnyProd(insights) ? [ IntegrationType.WEBHOOK ] : [
             IntegrationType.WEBHOOK,
-            IntegrationType.SPLUNK
+            IntegrationType.SPLUNK, // Todo: Make it easier to add types
+            IntegrationType.ANYCAMEL
         ];
 
         return options

--- a/src/components/Integrations/Form/IntegrationTypeCamelForm.tsx
+++ b/src/components/Integrations/Form/IntegrationTypeCamelForm.tsx
@@ -6,17 +6,8 @@ import { getOuiaProps } from '../../../utils/getOuiaProps';
 import { IntegrationTypeForm } from './IntegrationTypeForm';
 
 export const IntegrationTypeCamelForm: React.FunctionComponent<IntegrationTypeForm> = (props) => {
-    // <!-- this should be a dropdown -->
     return (
         <div className="pf-c-form" { ...getOuiaProps('Integrations/HttpForm', props) } >
-            <FormTextInput
-                isRequired={ true }
-                label="Sub type"
-                type="text"
-                name="subType"
-                id="integration-type-camel-type"
-                ouiaId={ ouiaIdConcat(props.ouiaId, 'camel-type') }
-            />
             <FormTextInput
                 isRequired={ true }
                 label="Endpoint URL"

--- a/src/components/Integrations/Form/IntegrationTypeForm.tsx
+++ b/src/components/Integrations/Form/IntegrationTypeForm.tsx
@@ -14,7 +14,8 @@ export const IntegrationTypeForm: React.FunctionComponent<IntegrationTypeForm> =
     switch (props.type) {
         case IntegrationType.WEBHOOK:
             return <IntegrationTypeHttpForm { ...props } />;
-        case IntegrationType.SPLUNK:
+        case IntegrationType.SPLUNK: // Todo: Make it easier to add types
+        case IntegrationType.ANYCAMEL:
             return <IntegrationTypeCamelForm { ...props } />;
         default:
             assertNever(props.type);

--- a/src/components/Integrations/Form/IntegrationTypeForm.tsx
+++ b/src/components/Integrations/Form/IntegrationTypeForm.tsx
@@ -2,7 +2,7 @@ import { OuiaComponentProps } from '@redhat-cloud-services/insights-common-types
 import { assertNever } from 'assert-never';
 import * as React from 'react';
 
-import { IntegrationType, UserIntegrationType } from '../../../types/Integration';
+import { IntegrationType, isCamelType, UserIntegrationType } from '../../../types/Integration';
 import { IntegrationTypeCamelForm } from './IntegrationTypeCamelForm';
 import { IntegrationTypeHttpForm } from './IntegrationTypeHttpForm';
 
@@ -11,12 +11,14 @@ export interface IntegrationTypeForm extends OuiaComponentProps {
 }
 
 export const IntegrationTypeForm: React.FunctionComponent<IntegrationTypeForm> = (props) => {
+
+    if (isCamelType(props.type)) {
+        return <IntegrationTypeCamelForm { ...props } />;
+    }
+
     switch (props.type) {
         case IntegrationType.WEBHOOK:
             return <IntegrationTypeHttpForm { ...props } />;
-        case IntegrationType.SPLUNK: // Todo: Make it easier to add types
-        case IntegrationType.ANYCAMEL:
-            return <IntegrationTypeCamelForm { ...props } />;
         default:
             assertNever(props.type);
     }

--- a/src/components/Integrations/Form/IntegrationTypeForm.tsx
+++ b/src/components/Integrations/Form/IntegrationTypeForm.tsx
@@ -14,7 +14,7 @@ export const IntegrationTypeForm: React.FunctionComponent<IntegrationTypeForm> =
     switch (props.type) {
         case IntegrationType.WEBHOOK:
             return <IntegrationTypeHttpForm { ...props } />;
-        case IntegrationType.CAMEL:
+        case IntegrationType.SPLUNK:
             return <IntegrationTypeCamelForm { ...props } />;
         default:
             assertNever(props.type);

--- a/src/components/Integrations/SaveModal.tsx
+++ b/src/components/Integrations/SaveModal.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { Messages } from '../../properties/Messages';
 import { IntegrationSchema } from '../../schemas/Integrations/Integration';
-import { IntegrationType, NewUserIntegration, UserIntegration } from '../../types/Integration';
+import { IntegrationType, isCamelIntegrationType, isCamelType, NewUserIntegration, UserIntegration } from '../../types/Integration';
 import { IntegrationsForm } from './Form';
 
 type PartialIntegration = Partial<UserIntegration>;
@@ -58,7 +58,7 @@ export const IntegrationSaveModal: React.FunctionComponent<IntegrationSaveModalP
         } as PartialIntegration;
 
         // patch extras to be a string for CAMEL
-        if (initial.type === IntegrationType.CAMEL && typeof initial.extras === 'object') {
+        if (isCamelIntegrationType(initial) && typeof initial.extras === 'object') {
             // We are casting as any, because `extras` is an object, but we need it to be a string for the form
             initial.extras = JSON.stringify(initial.extras, undefined, 2) as any;
         }

--- a/src/components/Integrations/SaveModal.tsx
+++ b/src/components/Integrations/SaveModal.tsx
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { Messages } from '../../properties/Messages';
 import { IntegrationSchema } from '../../schemas/Integrations/Integration';
-import { IntegrationType, isCamelIntegrationType, isCamelType, NewUserIntegration, UserIntegration } from '../../types/Integration';
+import { isCamelIntegrationType, NewUserIntegration, UserIntegration } from '../../types/Integration';
 import { IntegrationsForm } from './Form';
 
 type PartialIntegration = Partial<UserIntegration>;

--- a/src/components/Integrations/Table.tsx
+++ b/src/components/Integrations/Table.tsx
@@ -38,6 +38,7 @@ import * as React from 'react';
 import { useIntl } from 'react-intl';
 import { style } from 'typestyle';
 
+import Config from '../../config/Config';
 import messages from '../../properties/DefinedMessages';
 import { Messages } from '../../properties/Messages';
 import { IntegrationConnectionAttempt, UserIntegration } from '../../types/Integration';
@@ -197,7 +198,7 @@ const toTableRows = (integrations: Array<IntegrationRow>, onEnable?: OnEnable): 
                     title: integration.name
                 },
                 {
-                    title: Messages.components.integrations.integrationType[integration.type]
+                    title: Config.integrations.types[integration.type].name
                 },
                 {
                     title: getConnectionAttemptCell(integration.lastConnectionAttempts, integration.isConnectionAttemptLoading)

--- a/src/components/Notifications/ActionComponent.tsx
+++ b/src/components/Notifications/ActionComponent.tsx
@@ -7,6 +7,7 @@ import { assertNever } from 'assert-never';
 import * as React from 'react';
 import { style } from 'typestyle';
 
+import Config from '../../config/Config';
 import { Messages } from '../../properties/Messages';
 import { Action, NotificationType } from '../../types/Notification';
 import { getOuiaProps } from '../../utils/getOuiaProps';
@@ -90,9 +91,9 @@ export const ActionComponent: React.FunctionComponent<ActionComponentText> = (pr
     return (
         <ActionComponentWrapper { ...props }>
             <ActionTypeToIcon actionType={ props.action.type } />
-            <span className={ marginLeftClassName }>{ Messages.components.notifications.types[props.action.type] }</span>
+            <span className={ marginLeftClassName }>{ Config.notifications.types[props.action.type].name }</span>
             { props.action.type === NotificationType.INTEGRATION && (
-                <span>: { Messages.components.integrations.integrationType[props.action.integration.type] }</span>
+                <span>: { Config.integrations.types[props.action.integration.type].name }</span>
             ) }
         </ActionComponentWrapper>
     );

--- a/src/components/Notifications/ActionComponent.tsx
+++ b/src/components/Notifications/ActionComponent.tsx
@@ -8,7 +8,6 @@ import * as React from 'react';
 import { style } from 'typestyle';
 
 import Config from '../../config/Config';
-import { Messages } from '../../properties/Messages';
 import { Action, NotificationType } from '../../types/Notification';
 import { getOuiaProps } from '../../utils/getOuiaProps';
 import { WebhookIcon } from '../Icons/WebhookIcon';

--- a/src/components/Notifications/EventLog/EventLogActionPopoverContent.tsx
+++ b/src/components/Notifications/EventLog/EventLogActionPopoverContent.tsx
@@ -12,7 +12,6 @@ import Config from '../../../config/Config';
 import { NotificationEventAction, NotificationEventStatus } from '../../../types/Event';
 import { GetIntegrationRecipient, IntegrationType } from '../../../types/Integration';
 
-const actionLabelMap: Record<IntegrationType, string> = Config.integrationNames;
 const headerClass = style({
     minWidth: important('90px')
 });
@@ -78,7 +77,7 @@ export const EventLogActionPopoverContent: React.FunctionComponent<EventLogActio
             </Thead>
             <Tbody>
                 <Tr>
-                    <Td>{ actionLabelMap[props.action.endpointType] }</Td>
+                    <Td>{ Config.integrations.types[props.action.endpointType].action }</Td>
                     <Td>
                         { id ? recipient.loading ?  <Skeleton width="150px"  /> : recipient.value : (
                             <Tooltip content="The integration no longer exists, it could have been deleted.">

--- a/src/components/Notifications/EventLog/EventLogTable.tsx
+++ b/src/components/Notifications/EventLog/EventLogTable.tsx
@@ -29,8 +29,6 @@ export enum EventLogTableColumns {
     DATE
 }
 
-const actionLabelMap: Record<IntegrationType, string> = Config.integrationNames;
-
 const labelClassName = style({
     cursor: 'pointer'
 });
@@ -113,7 +111,7 @@ export const EventLogTable: React.FunctionComponent<EventLogTableProps> = props 
                                         className={ labelClassName }
                                         { ...toLabelProps(a) }
                                     >
-                                        { actionLabelMap[a.endpointType] }
+                                        { Config.integrations.types[a.endpointType].action }
                                     </Label>
                                 </Popover>))}
                             </LabelGroup>

--- a/src/components/Notifications/EventLog/EventLogTable.tsx
+++ b/src/components/Notifications/EventLog/EventLogTable.tsx
@@ -8,7 +8,7 @@ import { style } from 'typestyle';
 
 import Config from '../../../config/Config';
 import { NotificationEvent, NotificationEventAction, NotificationEventStatus } from '../../../types/Event';
-import { GetIntegrationRecipient, IntegrationType } from '../../../types/Integration';
+import { GetIntegrationRecipient } from '../../../types/Integration';
 import { UtcDate } from '../../UtcDate';
 import { EventLogActionPopoverContent } from './EventLogActionPopoverContent';
 

--- a/src/components/Notifications/Form/ActionOption.ts
+++ b/src/components/Notifications/Form/ActionOption.ts
@@ -1,5 +1,6 @@
 import { SelectOptionObject } from '@patternfly/react-core';
 
+import Config from '../../../config/Config';
 import { Messages } from '../../../properties/Messages';
 import { UserIntegrationType } from '../../../types/Integration';
 import { NotificationType } from '../../../types/Notification';
@@ -35,9 +36,9 @@ export class ActionOption implements SelectOptionObject {
     }
 
     toString(): string {
-        const actionName = Messages.components.notifications.types[this.notificationType];
+        const actionName = Config.notifications.types[this.notificationType].name;
         if (this.integrationType) {
-            const integrationName = Messages.components.integrations.integrationType[this.integrationType];
+            const integrationName = Config.integrations.types[this.integrationType].name;
             return `${actionName}: ${integrationName}`;
         }
 

--- a/src/components/Notifications/Form/ActionOption.ts
+++ b/src/components/Notifications/Form/ActionOption.ts
@@ -1,7 +1,6 @@
 import { SelectOptionObject } from '@patternfly/react-core';
 
 import Config from '../../../config/Config';
-import { Messages } from '../../../properties/Messages';
 import { UserIntegrationType } from '../../../types/Integration';
 import { NotificationType } from '../../../types/Notification';
 

--- a/src/components/Notifications/Form/ActionTypeahead.tsx
+++ b/src/components/Notifications/Form/ActionTypeahead.tsx
@@ -73,8 +73,8 @@ export const ActionTypeahead: React.FunctionComponent<ActionTypeaheadProps> = (p
             Config.notifications.actions.released :
             Config.notifications.actions.experimental;
         const integrationTypes = released ?
-            Config.integrations.integrationActions.released :
-            Config.integrations.integrationActions.experimental;
+            Config.integrations.actions.released :
+            Config.integrations.actions.experimental;
 
         return getSelectOptions(notificationTypes, integrationTypes, props.selectedNotifications)
         .map(o => <SelectOption key={ o.toString() } value={ o } />);

--- a/src/components/Notifications/Form/ActionTypeahead.tsx
+++ b/src/components/Notifications/Form/ActionTypeahead.tsx
@@ -2,7 +2,7 @@ import { Select, SelectOption, SelectOptionObject, SelectVariant } from '@patter
 import { getInsights, OuiaComponentProps } from '@redhat-cloud-services/insights-common-typescript';
 import * as React from 'react';
 
-import { isStagingOrProd } from '../../../types/Environments';
+import { isStagingOrProd, isStagingStableOrAnyProd } from '../../../types/Environments';
 import { UserIntegrationType } from '../../../types/Integration';
 import { Action, NotificationType } from '../../../types/Notification';
 import { getOuiaProps } from '../../../utils/getOuiaProps';
@@ -65,19 +65,19 @@ export const ActionTypeahead: React.FunctionComponent<ActionTypeaheadProps> = (p
         });
     }, [ props.action ]);
 
-    const showAsProd = isStagingOrProd(getInsights());
+    const hideCamel = isStagingStableOrAnyProd(getInsights());
 
     const selectableOptions = React.useMemo(() => {
-        const notificationTypes = showAsProd ?
+        const notificationTypes = hideCamel ?
             [ NotificationType.EMAIL_SUBSCRIPTION ]
             : [ NotificationType.EMAIL_SUBSCRIPTION, NotificationType.DRAWER ];
-        const integrationTypes = showAsProd ?
+        const integrationTypes = hideCamel ?
             [ UserIntegrationType.WEBHOOK ]
-            : [ UserIntegrationType.WEBHOOK, UserIntegrationType.CAMEL ];
+            : [ UserIntegrationType.WEBHOOK, UserIntegrationType.SPLUNK ];
 
         return getSelectOptions(notificationTypes, integrationTypes, props.selectedNotifications)
         .map(o => <SelectOption key={ o.toString() } value={ o } />);
-    }, [ showAsProd, props.selectedNotifications ]);
+    }, [ hideCamel, props.selectedNotifications ]);
 
     return (
         <div { ...getOuiaProps('ActionTypeahead', props) } >

--- a/src/components/Notifications/Form/ActionTypeahead.tsx
+++ b/src/components/Notifications/Form/ActionTypeahead.tsx
@@ -1,8 +1,9 @@
 import { Select, SelectOption, SelectOptionObject, SelectVariant } from '@patternfly/react-core';
-import { getInsights, OuiaComponentProps } from '@redhat-cloud-services/insights-common-typescript';
+import { OuiaComponentProps } from '@redhat-cloud-services/insights-common-typescript';
 import * as React from 'react';
 
-import { isStagingStableOrAnyProd } from '../../../types/Environments';
+import Config from '../../../config/Config';
+import { isReleased } from '../../../types/Environments';
 import { UserIntegrationType } from '../../../types/Integration';
 import { Action, NotificationType } from '../../../types/Notification';
 import { getOuiaProps } from '../../../utils/getOuiaProps';
@@ -65,19 +66,19 @@ export const ActionTypeahead: React.FunctionComponent<ActionTypeaheadProps> = (p
         });
     }, [ props.action ]);
 
-    const hideCamel = isStagingStableOrAnyProd(getInsights());
+    const released = isReleased();
 
     const selectableOptions = React.useMemo(() => {
-        const notificationTypes = hideCamel ?
-            [ NotificationType.EMAIL_SUBSCRIPTION ]
-            : [ NotificationType.EMAIL_SUBSCRIPTION, NotificationType.DRAWER ];
-        const integrationTypes = hideCamel ?
-            [ UserIntegrationType.WEBHOOK ]
-            : [ UserIntegrationType.WEBHOOK, UserIntegrationType.SPLUNK ];
+        const notificationTypes = released ?
+            Config.notifications.actions.released :
+            Config.notifications.actions.experimental;
+        const integrationTypes = released ?
+            Config.integrations.integrationActions.released :
+            Config.integrations.integrationActions.experimental;
 
         return getSelectOptions(notificationTypes, integrationTypes, props.selectedNotifications)
         .map(o => <SelectOption key={ o.toString() } value={ o } />);
-    }, [ hideCamel, props.selectedNotifications ]);
+    }, [ released, props.selectedNotifications ]);
 
     return (
         <div { ...getOuiaProps('ActionTypeahead', props) } >

--- a/src/components/Notifications/Form/ActionTypeahead.tsx
+++ b/src/components/Notifications/Form/ActionTypeahead.tsx
@@ -2,7 +2,7 @@ import { Select, SelectOption, SelectOptionObject, SelectVariant } from '@patter
 import { getInsights, OuiaComponentProps } from '@redhat-cloud-services/insights-common-typescript';
 import * as React from 'react';
 
-import { isStagingOrProd, isStagingStableOrAnyProd } from '../../../types/Environments';
+import { isStagingStableOrAnyProd } from '../../../types/Environments';
 import { UserIntegrationType } from '../../../types/Integration';
 import { Action, NotificationType } from '../../../types/Notification';
 import { getOuiaProps } from '../../../utils/getOuiaProps';

--- a/src/components/Notifications/Form/IntegrationRecipientTypeahead.tsx
+++ b/src/components/Notifications/Form/IntegrationRecipientTypeahead.tsx
@@ -3,6 +3,7 @@ import { OuiaComponentProps } from '@redhat-cloud-services/insights-common-types
 import * as React from 'react';
 import { usePrevious } from 'react-use';
 
+import Config from '../../../config/Config';
 import { Messages } from '../../../properties/Messages';
 import { UserIntegrationType } from '../../../types/Integration';
 import { IntegrationRef } from '../../../types/Notification';
@@ -89,7 +90,7 @@ export const IntegrationRecipientTypeahead: React.FunctionComponent<IntegrationR
 
     }, [ props.onSelected ]);
 
-    const chooseText = `Choose ${Messages.components.integrations.integrationType[props.integrationType].toLowerCase()}`;
+    const chooseText = `Choose ${Config.integrations.types[props.integrationType].name.toLowerCase()}`;
 
     return (
         <div { ...getOuiaProps('IntegrationRecipientTypeahead', props) }>

--- a/src/components/Notifications/Form/IntegrationRecipientTypeahead.tsx
+++ b/src/components/Notifications/Form/IntegrationRecipientTypeahead.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { usePrevious } from 'react-use';
 
 import Config from '../../../config/Config';
-import { Messages } from '../../../properties/Messages';
 import { UserIntegrationType } from '../../../types/Integration';
 import { IntegrationRef } from '../../../types/Notification';
 import { IntegrationRecipient } from '../../../types/Recipient';

--- a/src/components/Notifications/Form/__tests__/ActionTypeahead.test.tsx
+++ b/src/components/Notifications/Form/__tests__/ActionTypeahead.test.tsx
@@ -57,7 +57,7 @@ describe('src/components/Notifications/Form/ActionTypeahead', () => {
 
         expect(screen.queryByText(/send an email/i)).not.toBeInTheDocument();
         expect(screen.queryByText(/integration: webhook/i)).toBeInTheDocument();
-        expect(screen.queryByText(/integration: camel/i)).toBeInTheDocument();
+        expect(screen.queryByText(/integration: splunk/i)).toBeInTheDocument();
     });
 
     it('Calls actionSelected when selecting any action', async () => {

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -16,7 +16,8 @@ const Config = {
         subAppId: 'notifications',
         title: 'Notifications | Settings'
     },
-    integrationNames: {
+    integrationNames: { // Todo: Make it easier to add types: Maybe merge with Messages settings
+        [IntegrationType.ANYCAMEL]: 'Integration: AnyCamel',
         [IntegrationType.SPLUNK]: 'Integration: Splunk',
         [IntegrationType.WEBHOOK]: 'Integration: Webhook',
         [IntegrationType.EMAIL_SUBSCRIPTION]: 'Email'

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -17,7 +17,7 @@ const Config = {
         title: 'Notifications | Settings'
     },
     integrationNames: {
-        [IntegrationType.CAMEL]: 'Integration: Camel',
+        [IntegrationType.SPLUNK]: 'Integration: Splunk',
         [IntegrationType.WEBHOOK]: 'Integration: Webhook',
         [IntegrationType.EMAIL_SUBSCRIPTION]: 'Email'
     } as Record<IntegrationType, string>,

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -21,9 +21,6 @@ interface NotificationTypeConfig {
 }
 
 const integrationTypes: Record<IntegrationType, IntegrationTypeConfigBase> = {
-    [IntegrationType.ANYCAMEL]: {
-        name: 'AnyCamel'
-    },
     [IntegrationType.SPLUNK]: {
         name: 'Splunk'
     },
@@ -67,14 +64,13 @@ const Config = {
         subAppId: 'integrations',
         title: 'Integrations | Settings',
         types: computeIntegrationConfig(integrationTypes),
-        integrationActions: {
+        actions: {
             released: [
                 UserIntegrationType.WEBHOOK
             ],
             experimental: [
                 UserIntegrationType.WEBHOOK,
-                UserIntegrationType.SPLUNK,
-                UserIntegrationType.ANYCAMEL
+                UserIntegrationType.SPLUNK
             ]
         }
     },

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -1,6 +1,6 @@
 import { DeepReadonly } from 'ts-essentials';
 
-import { IntegrationType } from '../types/Integration';
+import { IntegrationType, UserIntegrationType } from '../types/Integration';
 import { NotificationType } from '../types/Notification';
 
 const apiVersion = 'v1.0';
@@ -66,12 +66,30 @@ const Config = {
     integrations: {
         subAppId: 'integrations',
         title: 'Integrations | Settings',
-        types: computeIntegrationConfig(integrationTypes)
+        types: computeIntegrationConfig(integrationTypes),
+        integrationActions: {
+            released: [
+                UserIntegrationType.WEBHOOK
+            ],
+            experimental: [
+                UserIntegrationType.WEBHOOK,
+                UserIntegrationType.SPLUNK,
+                UserIntegrationType.ANYCAMEL
+            ]
+        }
     },
     notifications: {
         subAppId: 'notifications',
         title: 'Notifications | Settings',
-        types: notificationTypes
+        types: notificationTypes,
+        actions: {
+            released: [
+                NotificationType.EMAIL_SUBSCRIPTION
+            ],
+            experimental: [
+                NotificationType.EMAIL_SUBSCRIPTION, NotificationType.DRAWER
+            ]
+        }
     },
     pages: {
     },

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -1,27 +1,78 @@
 import { DeepReadonly } from 'ts-essentials';
 
 import { IntegrationType } from '../types/Integration';
+import { NotificationType } from '../types/Notification';
 
 const apiVersion = 'v1.0';
 const apiBaseUrl = `/api/notifications/${apiVersion}`;
 
 export const withBaseUrl = (path: string) => `${apiBaseUrl}${path}`;
 
+interface IntegrationTypeConfigBase {
+    name: string;
+}
+
+interface IntegrationTypeConfig extends IntegrationTypeConfigBase {
+    action: string;
+}
+
+interface NotificationTypeConfig {
+    name: string;
+}
+
+const integrationTypes: Record<IntegrationType, IntegrationTypeConfigBase> = {
+    [IntegrationType.ANYCAMEL]: {
+        name: 'AnyCamel'
+    },
+    [IntegrationType.SPLUNK]: {
+        name: 'Splunk'
+    },
+    [IntegrationType.WEBHOOK]: {
+        name: 'Webhook'
+    },
+    [IntegrationType.EMAIL_SUBSCRIPTION]: {
+        name: 'Email'
+    }
+};
+
+const notificationTypes: Record<NotificationType, NotificationTypeConfig> = {
+    [NotificationType.EMAIL_SUBSCRIPTION]: {
+        name: 'Send an email'
+    },
+    [NotificationType.DRAWER]: {
+        name: 'Send to notification drawer'
+    },
+    [NotificationType.INTEGRATION]: {
+        name: 'Integration'
+    }
+};
+
+const computeIntegrationConfig = (base: Record<IntegrationType, IntegrationTypeConfigBase>) : Record<IntegrationType, IntegrationTypeConfig> => {
+    const complete = {} as Record<IntegrationType, IntegrationTypeConfig>;
+
+    const transform = (type: IntegrationType, element: IntegrationTypeConfigBase): IntegrationTypeConfig => ({
+        ...element,
+        action: type === IntegrationType.EMAIL_SUBSCRIPTION ? element.name : `Integration: ${element.name}`
+    });
+
+    Object.keys(base).forEach((key) => {
+        complete[key] = transform(key as IntegrationType, base[key]);
+    });
+
+    return complete;
+};
+
 const Config = {
     integrations: {
         subAppId: 'integrations',
-        title: 'Integrations | Settings'
+        title: 'Integrations | Settings',
+        types: computeIntegrationConfig(integrationTypes)
     },
     notifications: {
         subAppId: 'notifications',
-        title: 'Notifications | Settings'
+        title: 'Notifications | Settings',
+        types: notificationTypes
     },
-    integrationNames: { // Todo: Make it easier to add types: Maybe merge with Messages settings
-        [IntegrationType.ANYCAMEL]: 'Integration: AnyCamel',
-        [IntegrationType.SPLUNK]: 'Integration: Splunk',
-        [IntegrationType.WEBHOOK]: 'Integration: Webhook',
-        [IntegrationType.EMAIL_SUBSCRIPTION]: 'Email'
-    } as Record<IntegrationType, string>,
     pages: {
     },
     paging: {

--- a/src/generated/OpenapiIntegrations.ts
+++ b/src/generated/OpenapiIntegrations.ts
@@ -107,7 +107,6 @@ export namespace Schemas {
       | undefined
       | null;
     sub_type?: string | undefined | null;
-    subtype_ok?: boolean | undefined | null;
     type: EndpointType;
     updated?: string | undefined | null;
   };
@@ -217,7 +216,6 @@ export namespace Schemas {
   export const RequestDefaultBehaviorGroupPropertyList =
     zodSchemaRequestDefaultBehaviorGroupPropertyList();
   export type RequestDefaultBehaviorGroupPropertyList = {
-    group_id?: UUID | undefined | null;
     ignore_preferences: boolean;
     only_admins: boolean;
   };
@@ -370,7 +368,6 @@ export namespace Schemas {
           .optional()
           .nullable(),
           sub_type: z.string().optional().nullable(),
-          subtype_ok: z.boolean().optional().nullable(),
           type: zodSchemaEndpointType(),
           updated: z.string().optional().nullable()
       })
@@ -493,7 +490,6 @@ export namespace Schemas {
   function zodSchemaRequestDefaultBehaviorGroupPropertyList() {
       return z
       .object({
-          group_id: zodSchemaUUID().optional().nullable(),
           ignore_preferences: z.boolean(),
           only_admins: z.boolean()
       })

--- a/src/generated/OpenapiIntegrations.ts
+++ b/src/generated/OpenapiIntegrations.ts
@@ -106,6 +106,8 @@ export namespace Schemas {
       | (WebhookProperties | EmailSubscriptionProperties | CamelProperties)
       | undefined
       | null;
+    sub_type?: string | undefined | null;
+    subtype_ok?: boolean | undefined | null;
     type: EndpointType;
     updated?: string | undefined | null;
   };
@@ -149,6 +151,7 @@ export namespace Schemas {
       | undefined
       | null;
     endpoint_id?: UUID | undefined | null;
+    endpoint_sub_type?: string | undefined | null;
     endpoint_type: EndpointType;
     id: UUID;
     invocation_result: boolean;
@@ -366,6 +369,8 @@ export namespace Schemas {
           ])
           .optional()
           .nullable(),
+          sub_type: z.string().optional().nullable(),
+          subtype_ok: z.boolean().optional().nullable(),
           type: zodSchemaEndpointType(),
           updated: z.string().optional().nullable()
       })
@@ -409,6 +414,7 @@ export namespace Schemas {
       .object({
           details: z.record(z.unknown()).optional().nullable(),
           endpoint_id: zodSchemaUUID().optional().nullable(),
+          endpoint_sub_type: z.string().optional().nullable(),
           endpoint_type: zodSchemaEndpointType(),
           id: zodSchemaUUID(),
           invocation_result: z.boolean()

--- a/src/generated/OpenapiNotifications.ts
+++ b/src/generated/OpenapiNotifications.ts
@@ -107,7 +107,6 @@ export namespace Schemas {
       | undefined
       | null;
     sub_type?: string | undefined | null;
-    subtype_ok?: boolean | undefined | null;
     type: EndpointType;
     updated?: string | undefined | null;
   };
@@ -217,7 +216,6 @@ export namespace Schemas {
   export const RequestDefaultBehaviorGroupPropertyList =
     zodSchemaRequestDefaultBehaviorGroupPropertyList();
   export type RequestDefaultBehaviorGroupPropertyList = {
-    group_id?: UUID | undefined | null;
     ignore_preferences: boolean;
     only_admins: boolean;
   };
@@ -370,7 +368,6 @@ export namespace Schemas {
           .optional()
           .nullable(),
           sub_type: z.string().optional().nullable(),
-          subtype_ok: z.boolean().optional().nullable(),
           type: zodSchemaEndpointType(),
           updated: z.string().optional().nullable()
       })
@@ -493,7 +490,6 @@ export namespace Schemas {
   function zodSchemaRequestDefaultBehaviorGroupPropertyList() {
       return z
       .object({
-          group_id: zodSchemaUUID().optional().nullable(),
           ignore_preferences: z.boolean(),
           only_admins: z.boolean()
       })

--- a/src/generated/OpenapiNotifications.ts
+++ b/src/generated/OpenapiNotifications.ts
@@ -106,6 +106,8 @@ export namespace Schemas {
       | (WebhookProperties | EmailSubscriptionProperties | CamelProperties)
       | undefined
       | null;
+    sub_type?: string | undefined | null;
+    subtype_ok?: boolean | undefined | null;
     type: EndpointType;
     updated?: string | undefined | null;
   };
@@ -149,6 +151,7 @@ export namespace Schemas {
       | undefined
       | null;
     endpoint_id?: UUID | undefined | null;
+    endpoint_sub_type?: string | undefined | null;
     endpoint_type: EndpointType;
     id: UUID;
     invocation_result: boolean;
@@ -366,6 +369,8 @@ export namespace Schemas {
           ])
           .optional()
           .nullable(),
+          sub_type: z.string().optional().nullable(),
+          subtype_ok: z.boolean().optional().nullable(),
           type: zodSchemaEndpointType(),
           updated: z.string().optional().nullable()
       })
@@ -409,6 +414,7 @@ export namespace Schemas {
       .object({
           details: z.record(z.unknown()).optional().nullable(),
           endpoint_id: zodSchemaUUID().optional().nullable(),
+          endpoint_sub_type: z.string().optional().nullable(),
           endpoint_type: zodSchemaEndpointType(),
           id: zodSchemaUUID(),
           invocation_result: z.boolean()

--- a/src/generated/OpenapiPrivate.ts
+++ b/src/generated/OpenapiPrivate.ts
@@ -106,6 +106,8 @@ export namespace Schemas {
       | (WebhookProperties | EmailSubscriptionProperties | CamelProperties)
       | undefined
       | null;
+    sub_type?: string | undefined | null;
+    subtype_ok?: boolean | undefined | null;
     type: EndpointType;
     updated?: string | undefined | null;
   };
@@ -149,6 +151,7 @@ export namespace Schemas {
       | undefined
       | null;
     endpoint_id?: UUID | undefined | null;
+    endpoint_sub_type?: string | undefined | null;
     endpoint_type: EndpointType;
     id: UUID;
     invocation_result: boolean;
@@ -363,6 +366,8 @@ export namespace Schemas {
           ])
           .optional()
           .nullable(),
+          sub_type: z.string().optional().nullable(),
+          subtype_ok: z.boolean().optional().nullable(),
           type: zodSchemaEndpointType(),
           updated: z.string().optional().nullable()
       })
@@ -406,6 +411,7 @@ export namespace Schemas {
       .object({
           details: z.record(z.unknown()).optional().nullable(),
           endpoint_id: zodSchemaUUID().optional().nullable(),
+          endpoint_sub_type: z.string().optional().nullable(),
           endpoint_type: zodSchemaEndpointType(),
           id: zodSchemaUUID(),
           invocation_result: z.boolean()

--- a/src/generated/OpenapiPrivate.ts
+++ b/src/generated/OpenapiPrivate.ts
@@ -107,7 +107,6 @@ export namespace Schemas {
       | undefined
       | null;
     sub_type?: string | undefined | null;
-    subtype_ok?: boolean | undefined | null;
     type: EndpointType;
     updated?: string | undefined | null;
   };
@@ -217,7 +216,6 @@ export namespace Schemas {
   export const RequestDefaultBehaviorGroupPropertyList =
     zodSchemaRequestDefaultBehaviorGroupPropertyList();
   export type RequestDefaultBehaviorGroupPropertyList = {
-    group_id?: UUID | undefined | null;
     ignore_preferences: boolean;
     only_admins: boolean;
   };
@@ -367,7 +365,6 @@ export namespace Schemas {
           .optional()
           .nullable(),
           sub_type: z.string().optional().nullable(),
-          subtype_ok: z.boolean().optional().nullable(),
           type: zodSchemaEndpointType(),
           updated: z.string().optional().nullable()
       })
@@ -490,7 +487,6 @@ export namespace Schemas {
   function zodSchemaRequestDefaultBehaviorGroupPropertyList() {
       return z
       .object({
-          group_id: zodSchemaUUID().optional().nullable(),
           ignore_preferences: z.boolean(),
           only_admins: z.boolean()
       })

--- a/src/pages/Integrations/Create/__tests__/CreatePage.test.tsx
+++ b/src/pages/Integrations/Create/__tests__/CreatePage.test.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 
 import { appWrapperCleanup, appWrapperSetup, getConfiguredAppWrapper } from '../../../../../test/AppWrapper';
 import { waitForAsyncEvents } from '../../../../../test/TestUtils';
+import Config from '../../../../config/Config';
 import { Messages } from '../../../../properties/Messages';
 import { IntegrationType } from '../../../../types/Integration';
 import { CreatePage } from '../CreatePage';
@@ -46,7 +47,7 @@ describe('src/pages/Integrations/Create/CreatePage', () => {
                 isEdit={ false }
             />);
         await waitForAsyncEvents();
-        const firstIntegrationTypeDisplayName = Messages.components.integrations.integrationType[Object.values(IntegrationType)[0]];
+        const firstIntegrationTypeDisplayName = Config.integrations.types[Object.values(IntegrationType)[0]].name;
         expect(screen.getByDisplayValue(firstIntegrationTypeDisplayName)).toBeTruthy();
     });
 

--- a/src/pages/Integrations/Create/__tests__/CreatePage.test.tsx
+++ b/src/pages/Integrations/Create/__tests__/CreatePage.test.tsx
@@ -7,7 +7,6 @@ import * as React from 'react';
 import { appWrapperCleanup, appWrapperSetup, getConfiguredAppWrapper } from '../../../../../test/AppWrapper';
 import { waitForAsyncEvents } from '../../../../../test/TestUtils';
 import Config from '../../../../config/Config';
-import { Messages } from '../../../../properties/Messages';
 import { IntegrationType } from '../../../../types/Integration';
 import { CreatePage } from '../CreatePage';
 

--- a/src/pages/Integrations/List/Page.tsx
+++ b/src/pages/Integrations/List/Page.tsx
@@ -61,8 +61,8 @@ export const IntegrationsListPage: React.FunctionComponent<IntegrationsListPageP
             'type',
             Operator.EQUAL,
             released ?
-                Config.integrations.integrationActions.released as Array<string> :
-                Config.integrations.integrationActions.experimental as Array<string>
+                Config.integrations.actions.released as Array<string> :
+                Config.integrations.actions.experimental as Array<string>
         );
     }, [ released ]);
 

--- a/src/pages/Integrations/List/Page.tsx
+++ b/src/pages/Integrations/List/Page.tsx
@@ -24,13 +24,15 @@ import { Messages } from '../../../properties/Messages';
 import { useListIntegrationPQuery, useListIntegrationsQuery } from '../../../services/useListIntegrations';
 import { NotificationAppState } from '../../../store/types/NotificationAppState';
 import { SavedNotificationScopeState } from '../../../store/types/SavedNotificationScopeTypes';
-import { IntegrationType, UserIntegration } from '../../../types/Integration';
+import { IntegrationType, isCamelType, UserIntegration } from '../../../types/Integration';
 import { integrationExporterFactory } from '../../../utils/exporters/Integration/Factory';
 import { CreatePage } from '../Create/CreatePage';
 import { IntegrationDeleteModalPage } from '../Delete/DeleteModal';
 import { useActionResolver } from './useActionResolver';
 import { useIntegrationFilter } from './useIntegrationFilter';
 import { useIntegrationRows } from './useIntegrationRows';
+
+const wantedTypes = [ IntegrationType.WEBHOOK, ...Object.values(IntegrationType).filter(v => isCamelType(v)) ];
 
 const integrationFilterBuilder = (filters?: IntegrationFilters) => {
     const filter = new Filter();
@@ -39,7 +41,7 @@ const integrationFilterBuilder = (filters?: IntegrationFilters) => {
         filter.and('active', Operator.EQUAL, isEnabled.toString());
     }
 
-    return filter.and('type', Operator.EQUAL, [ IntegrationType.WEBHOOK, IntegrationType.CAMEL ]);
+    return filter.and('type', Operator.EQUAL, wantedTypes);
 };
 
 const userIntegrationCopier = (userIntegration: Partial<UserIntegration>) => ({

--- a/src/pages/Integrations/List/Page.tsx
+++ b/src/pages/Integrations/List/Page.tsx
@@ -17,6 +17,7 @@ import { AppContext } from '../../../app/AppContext';
 import { IntegrationFilters } from '../../../components/Integrations/Filters';
 import { IntegrationsTable } from '../../../components/Integrations/Table';
 import { IntegrationsToolbar } from '../../../components/Integrations/Toolbar';
+import Config from '../../../config/Config';
 import { useDeleteModalReducer } from '../../../hooks/useDeleteModalReducer';
 import { useFormModalReducer } from '../../../hooks/useFormModalReducer';
 import { usePage } from '../../../hooks/usePage';
@@ -24,25 +25,14 @@ import { Messages } from '../../../properties/Messages';
 import { useListIntegrationPQuery, useListIntegrationsQuery } from '../../../services/useListIntegrations';
 import { NotificationAppState } from '../../../store/types/NotificationAppState';
 import { SavedNotificationScopeState } from '../../../store/types/SavedNotificationScopeTypes';
-import { IntegrationType, isCamelType, UserIntegration } from '../../../types/Integration';
+import { isReleased } from '../../../types/Environments';
+import { UserIntegration } from '../../../types/Integration';
 import { integrationExporterFactory } from '../../../utils/exporters/Integration/Factory';
 import { CreatePage } from '../Create/CreatePage';
 import { IntegrationDeleteModalPage } from '../Delete/DeleteModal';
 import { useActionResolver } from './useActionResolver';
 import { useIntegrationFilter } from './useIntegrationFilter';
 import { useIntegrationRows } from './useIntegrationRows';
-
-const wantedTypes = [ IntegrationType.WEBHOOK, ...Object.values(IntegrationType).filter(v => isCamelType(v)) ];
-
-const integrationFilterBuilder = (filters?: IntegrationFilters) => {
-    const filter = new Filter();
-    if (filters?.enabled?.length === 1) {
-        const isEnabled = filters.enabled[0].toLocaleLowerCase() === 'enabled';
-        filter.and('active', Operator.EQUAL, isEnabled.toString());
-    }
-
-    return filter.and('type', Operator.EQUAL, wantedTypes);
-};
 
 const userIntegrationCopier = (userIntegration: Partial<UserIntegration>) => ({
     ...userIntegration,
@@ -58,6 +48,24 @@ export const IntegrationsListPage: React.FunctionComponent<IntegrationsListPageP
 
     const { rbac: { canWriteIntegrationsEndpoints }} = useContext(AppContext);
     const integrationFilter = useIntegrationFilter();
+
+    const released = isReleased();
+    const integrationFilterBuilder = React.useCallback((filters?: IntegrationFilters) => {
+        const filter = new Filter();
+        if (filters?.enabled?.length === 1) {
+            const isEnabled = filters.enabled[0].toLocaleLowerCase() === 'enabled';
+            filter.and('active', Operator.EQUAL, isEnabled.toString());
+        }
+
+        return filter.and(
+            'type',
+            Operator.EQUAL,
+            released ?
+                Config.integrations.integrationActions.released as Array<string> :
+                Config.integrations.integrationActions.experimental as Array<string>
+        );
+    }, [ released ]);
+
     const pageData = usePage<IntegrationFilters>(10, integrationFilterBuilder, integrationFilter.filters);
     const integrationsQuery = useListIntegrationsQuery(pageData.page);
     const exportIntegrationsQuery = useListIntegrationPQuery();

--- a/src/properties/Messages.ts
+++ b/src/properties/Messages.ts
@@ -2,7 +2,6 @@ import { intlHelper } from '@redhat-cloud-services/frontend-components-translati
 import { createIntl, createIntlCache } from 'react-intl';
 import { DeepReadonly } from 'ts-essentials';
 
-import { IntegrationType } from '../types/Integration';
 import messages from './DefinedMessages';
 
 const cache = createIntlCache();
@@ -76,19 +75,9 @@ const MutableMessages = {
             disableError: {
                 title: 'Unable to disable the Integration',
                 description: 'There was a problem trying to disable the integration: "{0}".\nPlease try again.'
-            },
-            integrationType: { // Todo: Make it easier to add types: Maybe merge with Config settings
-                [IntegrationType.WEBHOOK]: 'Webhook',
-                [IntegrationType.SPLUNK]: 'Splunk',
-                [IntegrationType.ANYCAMEL]: 'AnyCamel'
             }
         },
         notifications: {
-            types: {
-                EMAIL_SUBSCRIPTION: 'Send an email',
-                DRAWER: 'Send to notification drawer',
-                INTEGRATION: 'Integration'
-            },
             toolbar: {
                 actions: {
 

--- a/src/properties/Messages.ts
+++ b/src/properties/Messages.ts
@@ -77,9 +77,10 @@ const MutableMessages = {
                 title: 'Unable to disable the Integration',
                 description: 'There was a problem trying to disable the integration: "{0}".\nPlease try again.'
             },
-            integrationType: {
+            integrationType: { // Todo: Make it easier to add types: Maybe merge with Config settings
                 [IntegrationType.WEBHOOK]: 'Webhook',
-                [IntegrationType.SPLUNK]: 'Splunk'
+                [IntegrationType.SPLUNK]: 'Splunk',
+                [IntegrationType.ANYCAMEL]: 'AnyCamel'
             }
         },
         notifications: {

--- a/src/properties/Messages.ts
+++ b/src/properties/Messages.ts
@@ -79,7 +79,7 @@ const MutableMessages = {
             },
             integrationType: {
                 [IntegrationType.WEBHOOK]: 'Webhook',
-                [IntegrationType.CAMEL]: 'Camel'
+                [IntegrationType.SPLUNK]: 'Splunk'
             }
         },
         notifications: {

--- a/src/schemas/Integrations/Integration.ts
+++ b/src/schemas/Integrations/Integration.ts
@@ -18,11 +18,7 @@ export const maxIntegrationNameLength = 150;
 export const IntegrationSchemaBase: Yup.SchemaOf<NewIntegrationBase> = Yup.object({
     id: Yup.string().optional(),
     name: Yup.string().required('Write a name for this Integration.').max(maxIntegrationNameLength).trim(),
-    type: Yup.mixed<IntegrationType>().oneOf([ // Todo: Make it easier to add types
-        IntegrationType.WEBHOOK,
-        IntegrationType.SPLUNK,
-        IntegrationType.ANYCAMEL
-    ]).default(IntegrationType.WEBHOOK).optional(),
+    type: Yup.mixed<IntegrationType>().oneOf(Object.values(IntegrationType)).default(IntegrationType.WEBHOOK).optional(),
     isEnabled: Yup.boolean().default(true).required()
 });
 

--- a/src/schemas/Integrations/Integration.ts
+++ b/src/schemas/Integrations/Integration.ts
@@ -4,9 +4,13 @@ import Lazy from 'yup/lib/Lazy';
 import { Schemas } from '../../generated/OpenapiIntegrations';
 import {
     CamelIntegrationType,
-    IntegrationCamel, IntegrationHttp,
-    IntegrationType, isCamelType, NewIntegration,
-    NewIntegrationBase, NewIntegrationTemplate
+    IntegrationCamel,
+    IntegrationHttp,
+    IntegrationType,
+    isCamelType,
+    NewIntegration,
+    NewIntegrationBase,
+    NewIntegrationTemplate
 } from '../../types/Integration';
 
 export const maxIntegrationNameLength = 150;
@@ -14,7 +18,11 @@ export const maxIntegrationNameLength = 150;
 export const IntegrationSchemaBase: Yup.SchemaOf<NewIntegrationBase> = Yup.object({
     id: Yup.string().optional(),
     name: Yup.string().required('Write a name for this Integration.').max(maxIntegrationNameLength).trim(),
-    type: Yup.mixed<IntegrationType>().oneOf([ IntegrationType.WEBHOOK, IntegrationType.SPLUNK ]).default(IntegrationType.WEBHOOK).optional(),
+    type: Yup.mixed<IntegrationType>().oneOf([ // Todo: Make it easier to add types
+        IntegrationType.WEBHOOK,
+        IntegrationType.SPLUNK,
+        IntegrationType.ANYCAMEL
+    ]).default(IntegrationType.WEBHOOK).optional(),
     isEnabled: Yup.boolean().default(true).required()
 });
 

--- a/src/services/useListIntegrations.ts
+++ b/src/services/useListIntegrations.ts
@@ -13,7 +13,7 @@ export const listIntegrationsActionCreator = (pager?: Page) => {
     return Operations.EndpointServiceGetEndpoints.actionCreator({
         limit: +query.limit,
         offset: +query.offset,
-        type: query.filterType ? (query.filterType as Array<IntegrationType>).map(t => getEndpointType(t)) : undefined,
+        type: query.filterType ? (query.filterType as Array<IntegrationType>) : undefined,
         active: query.filterActive ? query.filterActive === 'true' : undefined
     });
 };

--- a/src/services/useListIntegrations.ts
+++ b/src/services/useListIntegrations.ts
@@ -5,7 +5,7 @@ import { useParameterizedQuery, useQuery } from 'react-fetching-library';
 import {
     Operations
 } from '../generated/OpenapiIntegrations';
-import { getEndpointType, toIntegrations } from '../types/adapters/IntegrationAdapter';
+import { toIntegrations } from '../types/adapters/IntegrationAdapter';
 import { IntegrationType, UserIntegration } from '../types/Integration';
 
 export const listIntegrationsActionCreator = (pager?: Page) => {

--- a/src/types/Environments.ts
+++ b/src/types/Environments.ts
@@ -12,10 +12,16 @@ export const stagingAndProdStable: Array<Environment> = [
     'prod'
 ];
 
+export const stagingStableAndAnyProd: Array<Environment> = [
+    'stage',
+    // 'prod-beta', // Todo: Add it back
+    'prod'
+];
+
 export const isStagingOrProd = (insights: InsightsType) => {
     return stagingAndProd.includes(getInsightsEnvironment(insights));
 };
 
-export const isStagingOrProdStable = (insights: InsightsType) => {
-    return stagingAndProdStable.includes(getInsightsEnvironment(insights));
+export const isStagingStableOrAnyProd = (insights: InsightsType) => {
+    return stagingStableAndAnyProd.includes(getInsightsEnvironment(insights));
 };

--- a/src/types/Environments.ts
+++ b/src/types/Environments.ts
@@ -14,7 +14,7 @@ export const stagingAndProdStable: Array<Environment> = [
 
 export const stagingStableAndAnyProd: Array<Environment> = [
     'stage',
-    // 'prod-beta', // Todo: Add it back
+    'prod-beta',
     'prod'
 ];
 

--- a/src/types/Environments.ts
+++ b/src/types/Environments.ts
@@ -1,4 +1,4 @@
-import { Environment, getInsightsEnvironment, InsightsType } from '@redhat-cloud-services/insights-common-typescript';
+import { Environment, getInsights, getInsightsEnvironment, InsightsType } from '@redhat-cloud-services/insights-common-typescript';
 
 export const stagingAndProd: Array<Environment> = [
     'stage-beta',
@@ -24,4 +24,9 @@ export const isStagingOrProd = (insights: InsightsType) => {
 
 export const isStagingStableOrAnyProd = (insights: InsightsType) => {
     return stagingStableAndAnyProd.includes(getInsightsEnvironment(insights));
+};
+
+export const isReleased = () => {
+    const insights = getInsights();
+    return isStagingStableOrAnyProd(insights);
 };

--- a/src/types/Integration.ts
+++ b/src/types/Integration.ts
@@ -2,6 +2,7 @@ import { Schemas } from '../generated/OpenapiIntegrations';
 import { UUID } from './Notification';
 
 // Integrations that exist
+// Value should always be type:sub_type or only type if doesn't use sub_types
 export enum IntegrationType {
     WEBHOOK = 'webhook',
     EMAIL_SUBSCRIPTION = 'email_subscription',

--- a/src/types/Integration.ts
+++ b/src/types/Integration.ts
@@ -4,14 +4,21 @@ import { UUID } from './Notification';
 // Integrations that exist
 export enum IntegrationType {
     WEBHOOK = 'webhook',
-    CAMEL = 'camel',
-    EMAIL_SUBSCRIPTION = 'email_subscription'
+    EMAIL_SUBSCRIPTION = 'email_subscription',
+    SPLUNK = 'camel:splunk'
 }
 
 export const UserIntegrationType = {
     WEBHOOK: IntegrationType.WEBHOOK,
-    CAMEL: IntegrationType.CAMEL
+    SPLUNK: IntegrationType.SPLUNK
 } as const;
+
+export type Subtypes<U, S extends string> = U extends `${S}:${string}` ? U : never;
+export type CamelIntegrationType = Subtypes<IntegrationType, 'camel'>;
+
+export const isCamelType = (type?: IntegrationType): type is CamelIntegrationType => !!type && type.startsWith('camel:');
+export const isCamelIntegrationType = (integration: Partial<Integration>): integration is IntegrationCamel =>
+    !!integration.type && isCamelType(integration.type);
 
 export type UserIntegrationType = (typeof UserIntegrationType)[keyof typeof UserIntegrationType];
 
@@ -30,12 +37,11 @@ export interface IntegrationHttp extends IntegrationBase<IntegrationType.WEBHOOK
     method: Schemas.HttpType;
 }
 
-export interface IntegrationCamel extends IntegrationBase<IntegrationType.CAMEL> {
-    type: IntegrationType.CAMEL;
+export interface IntegrationCamel extends IntegrationBase<CamelIntegrationType> {
+    type: CamelIntegrationType;
     url: string;
     sslVerificationEnabled: boolean;
     secretToken?: string;
-    subType?: string;
     basicAuth?: {
         user: string;
         pass: string;

--- a/src/types/Integration.ts
+++ b/src/types/Integration.ts
@@ -6,7 +6,7 @@ export enum IntegrationType {
     WEBHOOK = 'webhook',
     EMAIL_SUBSCRIPTION = 'email_subscription',
     SPLUNK = 'camel:splunk',
-    ANYCAMEL = 'camel:any-camel'
+    ANYCAMEL = 'camel:anycamel'
 }
 
 export const UserIntegrationType = {

--- a/src/types/Integration.ts
+++ b/src/types/Integration.ts
@@ -5,12 +5,14 @@ import { UUID } from './Notification';
 export enum IntegrationType {
     WEBHOOK = 'webhook',
     EMAIL_SUBSCRIPTION = 'email_subscription',
-    SPLUNK = 'camel:splunk'
+    SPLUNK = 'camel:splunk',
+    ANYCAMEL = 'camel:any-camel'
 }
 
 export const UserIntegrationType = {
     WEBHOOK: IntegrationType.WEBHOOK,
-    SPLUNK: IntegrationType.SPLUNK
+    SPLUNK: IntegrationType.SPLUNK,
+    ANYCAMEL: IntegrationType.ANYCAMEL
 } as const;
 
 export type Subtypes<U, S extends string> = U extends `${S}:${string}` ? U : never;

--- a/src/types/Integration.ts
+++ b/src/types/Integration.ts
@@ -6,14 +6,12 @@ import { UUID } from './Notification';
 export enum IntegrationType {
     WEBHOOK = 'webhook',
     EMAIL_SUBSCRIPTION = 'email_subscription',
-    SPLUNK = 'camel:splunk',
-    ANYCAMEL = 'camel:anycamel'
+    SPLUNK = 'camel:splunk'
 }
 
 export const UserIntegrationType = {
     WEBHOOK: IntegrationType.WEBHOOK,
-    SPLUNK: IntegrationType.SPLUNK,
-    ANYCAMEL: IntegrationType.ANYCAMEL
+    SPLUNK: IntegrationType.SPLUNK
 } as const;
 
 export type Subtypes<U, S extends string> = U extends `${S}:${string}` ? U : never;

--- a/src/types/adapters/IntegrationAdapter.ts
+++ b/src/types/adapters/IntegrationAdapter.ts
@@ -14,9 +14,12 @@ import {
     ServerIntegrationResponse
 } from '../Integration';
 
+// Todo: Make it easier to add types
 const CAMEL_SUBTYPE_SPLUNK = 'splunk';
+const CAMEL_SUBTYPE_ANYCAMEL = 'anycamel';
 const CAMEL_SUBTYPES = [
-    CAMEL_SUBTYPE_SPLUNK
+    CAMEL_SUBTYPE_SPLUNK,
+    CAMEL_SUBTYPE_ANYCAMEL
 ];
 
 const getIntegrationType = (serverIntegration: ServerIntegrationResponse): IntegrationType => {
@@ -25,7 +28,9 @@ const getIntegrationType = (serverIntegration: ServerIntegrationResponse): Integ
             const subType = (serverIntegration.properties as Schemas.CamelProperties).sub_type;
             if (subType === CAMEL_SUBTYPE_SPLUNK) {
                 return IntegrationType.SPLUNK;
-            }
+            } else if (subType === CAMEL_SUBTYPE_ANYCAMEL) {
+                return IntegrationType.ANYCAMEL;
+            } // Todo: Make it easier to add more types
 
             throw new Error(`Unexpected type: ${serverIntegration.type} with subtype: ${subType}`);
         case Schemas.EndpointType.Enum.webhook:
@@ -45,6 +50,7 @@ export const getEndpointType = (type: IntegrationType): Schemas.EndpointType => 
         case IntegrationType.WEBHOOK:
             return Schemas.EndpointType.Enum.webhook;
         case IntegrationType.SPLUNK:
+        case IntegrationType.ANYCAMEL: // Todo: Make it easier to add types
             return Schemas.EndpointType.Enum.camel;
         case IntegrationType.EMAIL_SUBSCRIPTION:
             return Schemas.EndpointType.Enum.email_subscription;
@@ -55,8 +61,10 @@ export const getEndpointType = (type: IntegrationType): Schemas.EndpointType => 
 
 export const getCamelEndpointSubType = (type: CamelIntegrationType): string => {
     switch (type) {
-        case IntegrationType.SPLUNK:
+        case IntegrationType.SPLUNK: // Todo: Make it easier to add types
             return CAMEL_SUBTYPE_SPLUNK;
+        case IntegrationType.ANYCAMEL:
+            return CAMEL_SUBTYPE_ANYCAMEL;
         default:
             assertNever(type);
     }
@@ -121,7 +129,9 @@ export const toIntegration = (serverIntegration: ServerIntegrationResponse): Int
                 serverIntegration.properties as Schemas.WebhookProperties
             );
 
-        case IntegrationType.SPLUNK: {
+        case IntegrationType.SPLUNK:
+        case IntegrationType.ANYCAMEL:
+        { // Todo: Make it easier to add types
             return toIntegrationCamel(
                 integrationBase as IntegrationBase<CamelIntegrationType>,
                 serverIntegration.properties as Schemas.CamelProperties
@@ -157,7 +167,8 @@ export const toIntegrationProperties = (integration: Integration | NewIntegratio
                 disable_ssl_verification: !integrationHttp.sslVerificationEnabled,
                 secret_token: integrationHttp.secretToken
             };
-        case IntegrationType.SPLUNK:
+        case IntegrationType.SPLUNK: // Todo: Make it easier to add types
+        case IntegrationType.ANYCAMEL:
             const integrationCamel: IntegrationCamel = integration as IntegrationCamel;
             return {
                 url: integrationCamel.url,

--- a/src/types/adapters/IntegrationAdapter.ts
+++ b/src/types/adapters/IntegrationAdapter.ts
@@ -33,8 +33,12 @@ export const getIntegrationType = (serverIntegration: ExternalCompositeTyped): I
     throw new Error(`Unexpected type: ${serverIntegration.type} with subtype: ${serverIntegration.sub_type}`);
 };
 
-export const getEndpointType = (type: IntegrationType): [ Schemas.EndpointType, string] => {
-    return type.split(':', 2) as [ Schemas.EndpointType, string ];
+const getEndpointType = (type: IntegrationType): { type: Schemas.EndpointType, subType?: string } => {
+    const splitType = type.split(':', 2);
+    return {
+        type: splitType[0] as Schemas.EndpointType,
+        subType: splitType.length === 2 ? splitType[1] : undefined
+    };
 };
 
 type NotNullType = {
@@ -161,7 +165,7 @@ export const toIntegrationProperties = (integration: Integration | NewIntegratio
 
 export const toServerIntegrationRequest =
     (integration: Integration | NewIntegration): ServerIntegrationRequest => {
-        const [ type, subType ] = getEndpointType(integration.type);
+        const { type, subType } = getEndpointType(integration.type);
         return {
             id: integration.id,
             name: integration.name,

--- a/src/types/adapters/NotificationEventAdapter.ts
+++ b/src/types/adapters/NotificationEventAdapter.ts
@@ -2,8 +2,8 @@ import { fromUtc } from '@redhat-cloud-services/insights-common-typescript';
 
 import { Schemas } from '../../generated/OpenapiNotifications';
 import { NotificationEvent, NotificationEventAction, NotificationEventStatus } from '../Event';
-import { IntegrationType } from '../Integration';
 import { UUID } from '../Notification';
+import { getIntegrationType } from './IntegrationAdapter';
 
 type ServerEvent = Schemas.EventLogEntry;
 
@@ -46,23 +46,11 @@ const groupActions = (actions: ServerEvent['actions']): ReadonlyArray<Notificati
 
 const initAction = (action: ServerEvent['actions'][number]): NotificationEventAction => ({
     id: action.endpoint_id ?? undefined,
-    endpointType: toNotificationEventAction(action.endpoint_type),
+    endpointType: getIntegrationType({
+        type: action.endpoint_type,
+        sub_type: action.endpoint_sub_type
+    }),
     status: action.invocation_result ? NotificationEventStatus.SUCCESS : NotificationEventStatus.ERROR,
     successCount: action.invocation_result ? 1 : 0,
     errorCount: action.invocation_result ? 0 : 1
 });
-
-const toNotificationEventAction = (serverEndpointType: ServerEvent['actions'][number]['endpoint_type']) => {
-    switch (serverEndpointType) {
-        // Todo: Need to pull the subtype and have a loading state or something similar for the type.
-        case 'camel':
-            return IntegrationType.SPLUNK; // Todo: Use subtype
-        case 'email_subscription':
-            return IntegrationType.EMAIL_SUBSCRIPTION;
-        case 'webhook':
-            return IntegrationType.WEBHOOK;
-        case 'default':
-        default:
-            throw new Error(`unknown endpoint type: ${serverEndpointType}`);
-    }
-};

--- a/src/types/adapters/NotificationEventAdapter.ts
+++ b/src/types/adapters/NotificationEventAdapter.ts
@@ -56,7 +56,7 @@ const toNotificationEventAction = (serverEndpointType: ServerEvent['actions'][nu
     switch (serverEndpointType) {
         // Todo: Need to pull the subtype and have a loading state or something similar for the type.
         case 'camel':
-            return IntegrationType.SPLUNK;
+            return IntegrationType.SPLUNK; // Todo: Use subtype
         case 'email_subscription':
             return IntegrationType.EMAIL_SUBSCRIPTION;
         case 'webhook':

--- a/src/types/adapters/NotificationEventAdapter.ts
+++ b/src/types/adapters/NotificationEventAdapter.ts
@@ -54,8 +54,9 @@ const initAction = (action: ServerEvent['actions'][number]): NotificationEventAc
 
 const toNotificationEventAction = (serverEndpointType: ServerEvent['actions'][number]['endpoint_type']) => {
     switch (serverEndpointType) {
+        // Todo: Need to pull the subtype and have a loading state or something similar for the type.
         case 'camel':
-            return IntegrationType.CAMEL;
+            return IntegrationType.SPLUNK;
         case 'email_subscription':
             return IntegrationType.EMAIL_SUBSCRIPTION;
         case 'webhook':

--- a/src/types/adapters/__tests__/IntegrationAdapter.test.ts
+++ b/src/types/adapters/__tests__/IntegrationAdapter.test.ts
@@ -8,6 +8,7 @@ import {
     ServerIntegrationResponse
 } from '../../Integration';
 import { toIntegration, toIntegrations, toServerIntegrationRequest } from '../IntegrationAdapter';
+import EndpointType = Schemas.EndpointType;
 
 describe('src/types/adapters/IntegrationAdapter', () => {
     describe('toIntegration', () => {
@@ -71,7 +72,7 @@ describe('src/types/adapters/IntegrationAdapter', () => {
                 enabled: true,
                 name: 'abc',
                 description: 'dragons be here',
-                type: undefined as unknown as IntegrationType,
+                type: undefined as unknown as EndpointType,
                 properties: {
                     url: 'https://foobarbaz.com',
                     disable_ssl_verification: false,


### PR DESCRIPTION
![Peek 2021-12-20 12-48](https://user-images.githubusercontent.com/3845764/146941996-6f43eefa-6715-43ea-9510-26084ee8ef13.gif)

![Peek 2022-01-20 10-54](https://user-images.githubusercontent.com/3845764/150394956-64e400ca-9822-4e63-ac16-4f5f3d0390ca.gif)

![Screenshot_2022-01-20_12-32-45](https://user-images.githubusercontent.com/3845764/150409340-7c86f8f5-328c-4b32-bd61-de6c5d286070.png)


"AnyCamel" is just a madeup camel integration to test that it won't be really hard to add more types

Instead of using `Camel` as a type, use it's subtype (`Splunk`).
~There are some places where this isn't yet changed (EventLog is one place, there might be others)~