### PR TITLE
Include actions in eventlog

### DIFF
--- a/src/generated/OpenapiIntegrations.ts
+++ b/src/generated/OpenapiIntegrations.ts
@@ -24,8 +24,8 @@ export namespace Schemas {
 
   export const BasicAuthentication = zodSchemaBasicAuthentication();
   export type BasicAuthentication = {
-    password?: string | undefined | null;
-    username?: string | undefined | null;
+    password: string;
+    username: string;
   };
 
   export const BehaviorGroup = zodSchemaBehaviorGroup();
@@ -260,8 +260,8 @@ export namespace Schemas {
   function zodSchemaBasicAuthentication() {
       return z
       .object({
-          password: z.string().optional().nullable(),
-          username: z.string().optional().nullable()
+          password: z.string(),
+          username: z.string()
       })
       .nonstrict();
   }

--- a/src/generated/OpenapiNotifications.ts
+++ b/src/generated/OpenapiNotifications.ts
@@ -24,8 +24,8 @@ export namespace Schemas {
 
   export const BasicAuthentication = zodSchemaBasicAuthentication();
   export type BasicAuthentication = {
-    password?: string | undefined | null;
-    username?: string | undefined | null;
+    password: string;
+    username: string;
   };
 
   export const BehaviorGroup = zodSchemaBehaviorGroup();
@@ -260,8 +260,8 @@ export namespace Schemas {
   function zodSchemaBasicAuthentication() {
       return z
       .object({
-          password: z.string().optional().nullable(),
-          username: z.string().optional().nullable()
+          password: z.string(),
+          username: z.string()
       })
       .nonstrict();
   }
@@ -953,6 +953,8 @@ export namespace Operations {
     type EndpointTypes = Array<Schemas.EndpointType>;
     const EventTypeDisplayName = z.string();
     type EventTypeDisplayName = string;
+    const IncludeActions = z.boolean();
+    type IncludeActions = boolean;
     const IncludeDetails = z.boolean();
     type IncludeDetails = boolean;
     const IncludePayload = z.boolean();
@@ -973,6 +975,7 @@ export namespace Operations {
       endDate?: EndDate;
       endpointTypes?: EndpointTypes;
       eventTypeDisplayName?: EventTypeDisplayName;
+      includeActions?: IncludeActions;
       includeDetails?: IncludeDetails;
       includePayload?: IncludePayload;
       invocationResults?: InvocationResults;
@@ -1009,6 +1012,10 @@ export namespace Operations {
 
         if (params.eventTypeDisplayName !== undefined) {
             query.eventTypeDisplayName = params.eventTypeDisplayName;
+        }
+
+        if (params.includeActions !== undefined) {
+            query.includeActions = params.includeActions;
         }
 
         if (params.includeDetails !== undefined) {

--- a/src/generated/OpenapiPrivate.ts
+++ b/src/generated/OpenapiPrivate.ts
@@ -24,8 +24,8 @@ export namespace Schemas {
 
   export const BasicAuthentication = zodSchemaBasicAuthentication();
   export type BasicAuthentication = {
-    password?: string | undefined | null;
-    username?: string | undefined | null;
+    password: string;
+    username: string;
   };
 
   export const BehaviorGroup = zodSchemaBehaviorGroup();
@@ -257,8 +257,8 @@ export namespace Schemas {
   function zodSchemaBasicAuthentication() {
       return z
       .object({
-          password: z.string().optional().nullable(),
-          username: z.string().optional().nullable()
+          password: z.string(),
+          username: z.string()
       })
       .nonstrict();
   }

--- a/src/services/EventLog/GetNotificationEvents.ts
+++ b/src/services/EventLog/GetNotificationEvents.ts
@@ -34,7 +34,8 @@ export const useGetEvents = (page?: Page) => {
             startDate: query.filterStart as string,
             endDate: query.filterEnd as string,
             eventTypeDisplayName: query.filterEvent as string,
-            sortBy: `${query.sortColumn}:${query.sortDirection}`
+            sortBy: `${query.sortColumn}:${query.sortDirection}`,
+            includeActions: true
         })),
         eventDecoder
     );

--- a/src/types/adapters/IntegrationAdapter.ts
+++ b/src/types/adapters/IntegrationAdapter.ts
@@ -135,10 +135,10 @@ export const toIntegrationProperties = (integration: Integration | NewIntegratio
             url: integrationCamel.url,
             disable_ssl_verification: !integrationCamel.sslVerificationEnabled,
             secret_token: toSecretToken(integrationCamel.secretToken),
-            basic_authentication: {
-                username: integrationCamel.basicAuth?.user,
-                password: integrationCamel.basicAuth?.pass
-            },
+            basic_authentication: integrationCamel.basicAuth ? {
+                username: integrationCamel.basicAuth.user,
+                password: integrationCamel.basicAuth.pass
+            } : undefined,
             extras: integrationCamel.extras
         };
     }


### PR DESCRIPTION
A new param `includeActions` was added to prevent from collecting the actions when it's not needed. In our case, we need the actions.