### PR TITLE
Fix: calling undefined/wrong type object

### DIFF
--- a/src/components/Notifications/Form/IntegrationRecipientTypeahead.tsx
+++ b/src/components/Notifications/Form/IntegrationRecipientTypeahead.tsx
@@ -3,10 +3,11 @@ import { OuiaComponentProps } from '@redhat-cloud-services/insights-common-types
 import { useFormikContext } from 'formik';
 import * as React from 'react';
 import { usePrevious } from 'react-use';
+import { DeepPartial } from 'ts-essentials';
 
 import Config from '../../../config/Config';
 import { UserIntegrationType } from '../../../types/Integration';
-import { ActionIntegration, BehaviorGroup, IntegrationRef } from '../../../types/Notification';
+import { ActionIntegration, BehaviorGroup, IntegrationRef, NotificationType } from '../../../types/Notification';
 import { IntegrationRecipient } from '../../../types/Recipient';
 import { getOuiaProps } from '../../../utils/getOuiaProps';
 import { useRecipientContext } from '../RecipientContext';
@@ -28,7 +29,7 @@ export const IntegrationRecipientTypeahead: React.FunctionComponent<IntegrationR
     const prevOpen = usePrevious(isOpen);
 
     const { getIntegrations } = useRecipientContext();
-    const { values } = useFormikContext<Partial<BehaviorGroup>>();
+    const { values } = useFormikContext<DeepPartial<BehaviorGroup>>();
 
     const [ state, dispatchers ] = useTypeaheadReducer<IntegrationRecipient>();
 
@@ -60,7 +61,10 @@ export const IntegrationRecipientTypeahead: React.FunctionComponent<IntegrationR
     }, [ getIntegrations, props.integrationType, state.loadingFilter, state.lastSearch, dispatchers ]);
 
     const existingIntegrations = React.useMemo(() => {
-        const integrationActions = ((values.actions ?? []) as readonly ActionIntegration[]).map(action => action?.integration.id);
+        const integrationActions = (values.actions ?? [])
+        .filter(action => action?.type === NotificationType.INTEGRATION)
+        .map(action => (action as ActionIntegration)?.integration.id);
+
         return new Set<string>(integrationActions);
     }, [ values ]);
 

--- a/src/components/Notifications/Form/__tests__/IntegrationRecipientTypeahead.test.tsx
+++ b/src/components/Notifications/Form/__tests__/IntegrationRecipientTypeahead.test.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 
 import { waitForAsyncEvents } from '../../../../../test/TestUtils';
 import { IntegrationType } from '../../../../types/Integration';
-import { ActionIntegration, BehaviorGroup, IntegrationRef } from '../../../../types/Notification';
+import { ActionIntegration, BehaviorGroup, IntegrationRef, NotificationType } from '../../../../types/Notification';
 import { GetIntegrations, RecipientContext, RecipientContextProvider } from '../../RecipientContext';
 import { IntegrationRecipientTypeahead } from '../IntegrationRecipientTypeahead';
 
@@ -166,7 +166,7 @@ describe('src/components/Notifications/Form/IntegrationRecipientTypeAhead', () =
 
     it('Integration recipients that have been previously used in the form are disabled', async () => {
         const formikValues: Partial<BehaviorGroup> = {
-            actions: [{ integration: ref1 }] as ActionIntegration[]
+            actions: [{ integration: ref1, type: NotificationType.INTEGRATION }] as ActionIntegration[]
         };
 
         render(<IntegrationRecipientTypeahead


### PR DESCRIPTION
This was happening when opening a behavior group that had both email and a integration. There were other scenarios that triggered this error - creating a new behavior group and adding emails and integrations also made this fail.

