### PR TITLE
NOTIF-347 Preparations for groups as recipients (email)

### DIFF
--- a/src/components/Notifications/Form/IntegrationRecipientTypeahead.tsx
+++ b/src/components/Notifications/Form/IntegrationRecipientTypeahead.tsx
@@ -1,4 +1,4 @@
-import { Select, SelectOptionObject, SelectVariant } from '@patternfly/react-core';
+import { Select, SelectOption, SelectOptionObject, SelectVariant } from '@patternfly/react-core';
 import { OuiaComponentProps } from '@redhat-cloud-services/insights-common-typescript';
 import { useFormikContext } from 'formik';
 import * as React from 'react';
@@ -68,7 +68,22 @@ export const IntegrationRecipientTypeahead: React.FunctionComponent<IntegrationR
         return new Set<string>(integrationActions);
     }, [ values ]);
 
-    const options = useRecipientOptionMemo(state, existingIntegrations);
+    const integrationsMapper = React.useCallback((recipients: ReadonlyArray<IntegrationRecipient>) => {
+        return recipients.map(r => {
+            const isDisabled = existingIntegrations?.has(r.integration.id);
+
+            return (
+                <SelectOption
+                    key={ r.getKey() + Math.random() + '' }
+                    value={ new RecipientOption(r) }
+                    description={ isDisabled ? 'This integration has already been added' : undefined }
+                    isDisabled={ isDisabled }
+                />
+            );
+        });
+    }, [ existingIntegrations ]);
+
+    const options = useRecipientOptionMemo(state, integrationsMapper);
 
     const onFilter = React.useCallback((e: React.ChangeEvent<HTMLInputElement> | null) => {
         // Ignore filter calls with null event

--- a/src/components/Notifications/Form/IntegrationRecipientTypeahead.tsx
+++ b/src/components/Notifications/Form/IntegrationRecipientTypeahead.tsx
@@ -74,7 +74,7 @@ export const IntegrationRecipientTypeahead: React.FunctionComponent<IntegrationR
 
             return (
                 <SelectOption
-                    key={ r.getKey() + Math.random() + '' }
+                    key={ r.getKey() }
                     value={ new RecipientOption(r) }
                     description={ isDisabled ? 'This integration has already been added' : undefined }
                     isDisabled={ isDisabled }

--- a/src/components/Notifications/Form/useRecipientOptionMemo.tsx
+++ b/src/components/Notifications/Form/useRecipientOptionMemo.tsx
@@ -2,50 +2,39 @@ import { SelectOption } from '@patternfly/react-core';
 import assertNever from 'assert-never';
 import * as React from 'react';
 
-import { IntegrationRecipient, NotificationRecipient, Recipient } from '../../../types/Recipient';
-import { RecipientOption } from './RecipientOption';
+import { Recipient } from '../../../types/Recipient';
 import { ReducerState } from './useTypeaheadReducer';
 
-const mapper = (r: Recipient, existingIntegrations?: Set<string>) => {
-    let isDisabled = false;
-    let description: string | undefined = undefined;
+type Mapper<R> = (recipients: ReadonlyArray<R>) => React.ReactElement[];
 
-    if (r instanceof NotificationRecipient) {
-        description = r.description;
+const getOptions = <R extends Recipient>(values: ReadonlyArray<R>, mapper: Mapper<R>, isLoading: boolean) => {
+    if (isLoading) {
+        return [ <SelectOption
+            key="loading-option"
+            isNoResultsOption={ true }
+            value="Loading..."
+        /> ];
     }
 
-    else if (r instanceof IntegrationRecipient) {
-        isDisabled = !!existingIntegrations?.has(r.integration.id);
-        description = isDisabled ? 'This integration has already been added' : description;
-    }
-
-    return <SelectOption key={ r.getKey() } value={ new RecipientOption(r) } description={ description } isDisabled={ isDisabled } />;
+    return mapper(values);
 };
 
-export const useRecipientOptionMemo = (state: ReducerState<Recipient>, existingIntegrations?: Set<string>) => {
+export const useRecipientOptionMemo = <R extends Recipient>(state: ReducerState<R>, mapper: Mapper<R>) => {
     return React.useMemo(() => {
         if (state.show === 'default') {
-            if (state.loadingDefault) {
-                return [ <SelectOption
-                    key="loading-option"
-                    isNoResultsOption={ true }
-                    value="Loading..."
-                /> ];
-            } else {
-                return state.defaultValues.map(recipient => mapper(recipient, existingIntegrations));
-            }
+            return getOptions(
+                state.defaultValues,
+                mapper,
+                state.loadingDefault
+            );
         } else if (state.show === 'filter') {
-            if (state.loadingFilter) {
-                return [ <SelectOption
-                    key="loading-option"
-                    isNoResultsOption={ true }
-                    value="Loading..."
-                /> ];
-            } else {
-                return state.filterValues.map(recipient => mapper(recipient, existingIntegrations));
-            }
+            return getOptions(
+                state.filterValues,
+                mapper,
+                state.loadingFilter
+            );
         }
 
         assertNever(state.show);
-    }, [ state, existingIntegrations ]);
+    }, [ state, mapper ]);
 };

--- a/src/components/Notifications/RecipientContext.ts
+++ b/src/components/Notifications/RecipientContext.ts
@@ -2,10 +2,10 @@ import { createContext, useContext } from 'react';
 
 import { UserIntegrationType } from '../../types/Integration';
 import { IntegrationRef } from '../../types/Notification';
-import { Recipient } from '../../types/Recipient';
+import { BaseNotificationRecipient } from '../../types/Recipient';
 
 export type GetIntegrations = (type: UserIntegrationType, search?: string) => Promise<ReadonlyArray<IntegrationRef>>;
-export type GetNotificationRecipients = (filter?: string) => Promise<ReadonlyArray<Recipient>>;
+export type GetNotificationRecipients = (filter?: string) => Promise<ReadonlyArray<BaseNotificationRecipient>>;
 
 export interface RecipientContext {
     getIntegrations: GetIntegrations,

--- a/src/types/Notification.ts
+++ b/src/types/Notification.ts
@@ -1,6 +1,6 @@
 import { Schemas } from '../generated/OpenapiNotifications';
 import { UserIntegration } from './Integration';
-import { NotificationRecipient } from './Recipient';
+import { BaseNotificationRecipient, NotificationRecipient } from './Recipient';
 
 export type UUID = Schemas.UUID;
 
@@ -36,7 +36,7 @@ export interface ActionIntegration extends ActionBase {
 
 export interface ActionNotify extends ActionBase {
     type: NotificationType.EMAIL_SUBSCRIPTION | NotificationType.DRAWER;
-    recipient: ReadonlyArray<NotificationRecipient>;
+    recipient: ReadonlyArray<BaseNotificationRecipient>;
 }
 
 export type Action = ActionIntegration | ActionNotify;
@@ -76,7 +76,7 @@ export type EmailSystemProperties = {
     props: {
         onlyAdmins: boolean;
         ignorePreferences: false;
-        groupId: undefined;
+        groupId: undefined | UUID;
     }
 }
 export type SystemProperties = EmailSystemProperties;

--- a/src/types/Notification.ts
+++ b/src/types/Notification.ts
@@ -1,6 +1,6 @@
 import { Schemas } from '../generated/OpenapiNotifications';
 import { UserIntegration } from './Integration';
-import { BaseNotificationRecipient, NotificationRecipient } from './Recipient';
+import { BaseNotificationRecipient } from './Recipient';
 
 export type UUID = Schemas.UUID;
 


### PR DESCRIPTION
This prepares/refactor some of the code to make it easier to review future PRs with the recipient as admin.

- Fixes some immer usage (using original object instead of proxied to prevent building proxies)
- Extracts mapper of the options hook to allow each class to customize without affecting the others
- Prepares for new email recipient (group) 
  - Adds a new email recipient base
  - New type (not being used yet)