### PR TITLE
[EVNT-358] Splunk Automation Setup Page

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -7,6 +7,7 @@ import { CheckReadPermissions } from './components/CheckReadPermissions';
 import { RedirectToDefaultBundle } from './components/RedirectToDefaultBundle';
 import { ErrorPage } from './pages/Error/Page';
 import { ConnectedIntegrationsListPage } from './pages/Integrations/List/Page';
+import { SplunkSetupPage } from './pages/Integrations/SplunkSetup/SplunkSetupPage';
 import { EventLogPage } from './pages/Notifications/EventLog/EventLogPage';
 import { NotificationsListPage } from './pages/Notifications/List/Page';
 import { getBaseName } from './utils/Basename';
@@ -19,7 +20,8 @@ interface Path {
 export const linkTo = {
     integrations: () => '/integrations',
     notifications: (bundle: string) => `/notifications/${bundle}`,
-    eventLog: (bundle?: string) => `/notifications/eventlog${bundle ? `?bundle=${bundle}` : ''}`
+    eventLog: (bundle?: string) => `/notifications/eventlog${bundle ? `?bundle=${bundle}` : ''}`,
+    splunk: () => '/integrations/splunk-setup'
 };
 
 const EmptyPage: React.FunctionComponent = () => null;
@@ -40,6 +42,10 @@ const pathRoutes: Path[] = [
     {
         path: linkTo.notifications(':bundleName'),
         component: NotificationsListPage
+    },
+    {
+        path: linkTo.splunk(),
+        component: SplunkSetupPage
     }
 ];
 

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
@@ -14,66 +14,7 @@ import { Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/fronte
 import React, { useState } from 'react';
 
 import { Messages } from '../../../properties/Messages';
-
-/*
-Steps:
-
-1) Create a group under /api/rbac/v1/groups/ with the payload:
-
-{
-  "name": "GroupA",
-  "description": "A description of GroupA"
-}
-
-2) Add user to group under /api/rbac/v1/groups/{uuid}/principals/ with the payload:
-
-{
-  "principals": [
-    {
-      "username": "smithj"
-    }
-  ]
-}
-
-3) Add role to group under /api/rbac/v1/groups/{uuid}/roles/ with the payload:
-
-{
-  "roles": [
-    "94846f2f-cced-474f-b7f3-47e2ec51dd11"
-  ]
-}
-
-4) [POST] Create Integrations under /api/integrations/v1.0/endpoints with the payload:
-{
-    "name": "Splunk Automation",
-    "enabled": true,
-    "type": "camel",
-    "sub_type": "splunk",
-    "description": "",
-    "properties": {
-        "url": "http://decd-187-3-186-244.ngrok.io",
-        "disable_ssl_verification": false,
-        "secret_token": "MYHEC_TOKEN",
-        "basic_authentication": {},
-        "extras": {}
-    }
-}
-
-5) Create behavior group under /api/notifications/v1.0/notifications/behaviorGroups with the payload:
-
-{
-  "bundle_id":"35fd787b-a345-4fe8-a135-7773de15905e",
-  "display_name":"Splunk-automation"
-}
-
-6) [POST] Update behavior group under api/notifications/v1.0/notifications/behaviorGroups/{BEHAVIOR_GROUP_ID}/actions with the payload:
-
-  ["8d8dca57-1834-48dd-b6ac-265c949c5e60"] <<-- Id of the integration
-
-7) [PUT] Update eventType under /api/notifications/v1.0/notifications/eventTypes/{EVENT_TYPE_UUID}/behaviorGroups with the payload:
-
-["ff59b502-da25-4297-bd88-6934ad0e0d63"] <<- Behavior group ID
-*/
+import { useSplunkSetup } from './useSplunkSetup';
 
 const SPLUNK_CLOUD_HEC_DOC =
     'https://docs.splunk.com/Documentation/SplunkCloud/latest/Data/UsetheHTTPEventCollector#Send_data_to_HTTP_Event_Collector';
@@ -84,10 +25,22 @@ export const SplunkSetupPage: React.FunctionComponent = () => {
     const [ splunkServerHostName, setHostName ] = useState('');
     const [ automationLogs, setAutomationLogs ] = useState(`CLICK THE BUTTON TO START THE AUTOMATION\n`);
     const [ disableSubmit, setDisableSubmit ] = useState(false);
+    const startSplunkAutomation = useSplunkSetup();
 
-    const onStart = () => {
+    const onProgress = (message) => {
+        setAutomationLogs(prevLogs => `${prevLogs}${message}\n`);
+    };
+
+    const onStart = async () => {
         setDisableSubmit(true);
-        setAutomationLogs('WIP');
+        setAutomationLogs('');
+        try {
+            await startSplunkAutomation({ hecToken, splunkServerHostName }, onProgress);
+        } catch (error) {
+            onProgress(`ERROR: ${error}`);
+        }
+
+        onProgress('DONE!\n');
     };
 
     return (

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
@@ -1,0 +1,176 @@
+import {
+    ActionGroup,
+    Button,
+    CodeBlock,
+    CodeBlockCode,
+    Form,
+    FormGroup,
+    Grid,
+    GridItem,
+    Popover,
+    TextInput } from '@patternfly/react-core';
+import HelpIcon from '@patternfly/react-icons/dist/js/icons/help-icon';
+import { Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
+import React, { useState } from 'react';
+
+import { Messages } from '../../../properties/Messages';
+
+/*
+Steps:
+
+1) Create a group under /api/rbac/v1/groups/ with the payload:
+
+{
+  "name": "GroupA",
+  "description": "A description of GroupA"
+}
+
+2) Add user to group under /api/rbac/v1/groups/{uuid}/principals/ with the payload:
+
+{
+  "principals": [
+    {
+      "username": "smithj"
+    }
+  ]
+}
+
+3) Add role to group under /api/rbac/v1/groups/{uuid}/roles/ with the payload:
+
+{
+  "roles": [
+    "94846f2f-cced-474f-b7f3-47e2ec51dd11"
+  ]
+}
+
+4) [POST] Create Integrations under /api/integrations/v1.0/endpoints with the payload:
+{
+    "name": "Splunk Automation",
+    "enabled": true,
+    "type": "camel",
+    "sub_type": "splunk",
+    "description": "",
+    "properties": {
+        "url": "http://decd-187-3-186-244.ngrok.io",
+        "disable_ssl_verification": false,
+        "secret_token": "MYHEC_TOKEN",
+        "basic_authentication": {},
+        "extras": {}
+    }
+}
+
+5) Create behavior group under /api/notifications/v1.0/notifications/behaviorGroups with the payload:
+
+{
+  "bundle_id":"35fd787b-a345-4fe8-a135-7773de15905e",
+  "display_name":"Splunk-automation"
+}
+
+6) [POST] Update behavior group under api/notifications/v1.0/notifications/behaviorGroups/{BEHAVIOR_GROUP_ID}/actions with the payload:
+
+  ["8d8dca57-1834-48dd-b6ac-265c949c5e60"] <<-- Id of the integration
+
+7) [PUT] Update eventType under /api/notifications/v1.0/notifications/eventTypes/{EVENT_TYPE_UUID}/behaviorGroups with the payload:
+
+["ff59b502-da25-4297-bd88-6934ad0e0d63"] <<- Behavior group ID
+*/
+
+const SPLUNK_CLOUD_HEC_DOC =
+    'https://docs.splunk.com/Documentation/SplunkCloud/latest/Data/UsetheHTTPEventCollector#Send_data_to_HTTP_Event_Collector';
+
+export const SplunkSetupPage: React.FunctionComponent = () => {
+
+    const [ hecToken, setHecToken ] = useState('');
+    const [ splunkServerHostName, setHostName ] = useState('');
+    const [ automationLogs, setAutomationLogs ] = useState(`CLICK THE BUTTON TO START THE AUTOMATION\n`);
+    const [ disableSubmit, setDisableSubmit ] = useState(false);
+
+    const onStart = () => {
+        setDisableSubmit(true);
+        setAutomationLogs('WIP');
+    };
+
+    return (
+        <>
+            <PageHeader>
+                <PageHeaderTitle title={ Messages.pages.splunk.page.title } />
+            </PageHeader>
+            <Main>
+                <Grid>
+                    <GridItem span={ 6 }>
+                        <Form className='pf-u-mr-md'>
+                            <FormGroup
+                                label="Server hostname/IP Address and port (hostname:port)"
+                                labelIcon={ <Popover
+                                    headerContent={ <div>
+                                        The server <b>hostname/IP Address</b> and <b>port</b> of your splunk HTTP Event Collector
+                                    </div> }
+                                    bodyContent={ <div>
+                                        For Splunk Enterprise the port is by default 8088.<br />
+                                        For Splunk Cloud Platform see
+                                        {' '}
+                                        <a
+                                            target='_blank'
+                                            rel='noreferrer'
+                                            href={ SPLUNK_CLOUD_HEC_DOC }>
+                                            documentation
+                                        </a>.
+                                    </div> }
+                                >
+                                    <button
+                                        type="button"
+                                        aria-label="More info for name field"
+                                        onClick={ e => e.preventDefault() }
+                                        aria-describedby="splunk-server-hostname"
+                                        className="pf-c-form__group-label-help"
+                                    >
+                                        <HelpIcon noVerticalAlign />
+                                    </button>
+                                </Popover> }
+                                isRequired
+                                fieldId="splunk-server-hostname"
+                            >
+                                <TextInput
+                                    isRequired
+                                    type="text"
+                                    id="splunk-server-hostname"
+                                    name="splunk-server-hostname"
+                                    aria-describedby="splunk-server-hostname-helper"
+                                    value={ splunkServerHostName }
+                                    onChange={ (value) => setHostName(value) }
+                                />
+                            </FormGroup>
+                            <FormGroup
+                                label="Splunk HEC Token"
+                                fieldId="splunk-hec-token"
+                            >
+                                <TextInput
+                                    isRequired
+                                    type="text"
+                                    id="splunk-hec-token"
+                                    name="splunk-hec-token"
+                                    aria-describedby="splunk-hec-token-helper"
+                                    value={ hecToken }
+                                    onChange={ (value) => setHecToken(value) }
+                                />
+                            </FormGroup>
+                            <ActionGroup>
+                                <Button variant="primary"
+                                    onClick={ onStart }
+                                    isDisabled={ disableSubmit }>
+                                    Start Setup
+                                </Button>
+                            </ActionGroup>
+                        </Form>
+                    </GridItem>
+
+                    <GridItem span={ 6 }>
+                        <CodeBlock>
+                            <CodeBlockCode>{automationLogs}</CodeBlockCode>
+                        </CodeBlock>
+                    </GridItem>
+                </Grid>
+            </Main>
+        </>
+    );
+};

--- a/src/pages/Integrations/SplunkSetup/useSplunkSetup.tsx
+++ b/src/pages/Integrations/SplunkSetup/useSplunkSetup.tsx
@@ -1,0 +1,224 @@
+/*
+Steps:
+
+1) [POST] Create Integrations under /api/integrations/v1.0/endpoints with the payload:
+{
+    "name": "Splunk Automation",
+    "enabled": true,
+    "type": "camel",
+    "sub_type": "splunk",
+    "description": "",
+    "properties": {
+        "url": "http://decd-187-3-186-244.ngrok.io",
+        "disable_ssl_verification": false,
+        "secret_token": "MYHEC_TOKEN",
+        "basic_authentication": {},
+        "extras": {}
+    }
+}
+
+2) Create behavior group under /api/notifications/v1.0/notifications/behaviorGroups with the payload:
+
+{
+  "bundle_id":"35fd787b-a345-4fe8-a135-7773de15905e",
+  "display_name":"Splunk-automation"
+}
+
+3) [POST] Update behavior group under api/notifications/v1.0/notifications/behaviorGroups/{BEHAVIOR_GROUP_ID}/actions with the payload:
+
+  ["8d8dca57-1834-48dd-b6ac-265c949c5e60"] <<-- Id of the integration
+
+4) [PUT] Update eventType under /api/notifications/v1.0/notifications/eventTypes/{EVENT_TYPE_UUID}/behaviorGroups with the payload:
+
+["ff59b502-da25-4297-bd88-6934ad0e0d63"] <<- Behavior group ID
+*/
+
+import { useClient } from 'react-fetching-library';
+
+import { useGetAllEventTypes } from '../../../services/GetEventTypes';
+import { useGetAnyBehaviorGroupByNotification } from '../../../services/Notifications/GetBehaviorGroupByNotificationId';
+import { useGetBundleByName } from '../../../services/Notifications/GetBundles';
+import { linkBehaviorGroupAction } from '../../../services/Notifications/LinkBehaviorGroup';
+import { useSaveBehaviorGroupMutation } from '../../../services/Notifications/SaveBehaviorGroup';
+import { useUpdateBehaviorGroupActionsMutation } from '../../../services/Notifications/UpdateBehaviorGroupActions';
+import { useSaveIntegrationMutation } from '../../../services/useSaveIntegration';
+import { Integration, IntegrationCamel, IntegrationType, NewIntegrationTemplate } from '../../../types/Integration';
+import { BehaviorGroup, BehaviorGroupRequest, UUID } from '../../../types/Notification';
+
+export const SPLUNK_GROUP_NAME = 'SPLUNK_INTEGRATION';
+export const SPLUNK_INTEGRATION_NAME = 'SPLUNK_AUTOMATION';
+export const SPLUNK_BEHAVIOR_GROUP_NAME = 'SPLUNK_AUTOMATION_GROUP';
+export const BUNDLE_NAME = 'rhel';
+
+interface SplunkEventsDef {
+    [Identifier: string]: string | string[]
+}
+
+const DEFAULT_SPLUNK_EVENTS : SplunkEventsDef = {
+    advisor: '*',
+    policies: '*',
+    drift: '*'
+};
+
+export const useSplunkSetup = () => {
+    const createSplunkIntegration = useCreateSplunkIntegration();
+    const createSplunkBehaviorGroup = useCreateSplunkBehaviorGroup();
+    const updateSplunkBehaviorActions = useUpdateSplunkBehaviorActions();
+    const attachEvents = useAttachEventsToSplunk();
+
+    return async ({ hecToken, splunkServerHostName }, onProgress) => {
+        const integrationName = SPLUNK_INTEGRATION_NAME;
+        const behaviorGroupName = SPLUNK_BEHAVIOR_GROUP_NAME;
+        const bundleName = BUNDLE_NAME;
+        const events = DEFAULT_SPLUNK_EVENTS;
+
+        onProgress('Creating Splunk Integration...');
+        const integration = await createSplunkIntegration({ integrationName, hecToken, splunkServerHostName });
+        onProgress(`  ${integrationName} integration created.`);
+
+        onProgress('Creating Splunk Behavior Group...');
+        const behaviorGroup = await createSplunkBehaviorGroup({ behaviorGroupName, bundleName });
+        onProgress(`  ${behaviorGroupName} behavior group created.`);
+
+        onProgress('Adding Splunk integration as an action behavior group...');
+        await updateSplunkBehaviorActions(behaviorGroup, integration);
+        onProgress('  Added.');
+
+        onProgress('Adding evets to the behavior group:');
+        await attachEvents(behaviorGroup, events, onProgress);
+    };
+};
+
+const useCreateSplunkIntegration = () => {
+    const { mutate } = useSaveIntegrationMutation();
+    return async ({ integrationName, splunkServerHostName, hecToken }) : Promise<Integration | undefined> => {
+        const newIntegration : NewIntegrationTemplate<IntegrationCamel> = {
+            type: IntegrationType.SPLUNK,
+            name: integrationName,
+            url: splunkServerHostName,
+            secretToken: hecToken,
+            isEnabled: true,
+            sslVerificationEnabled: true
+        };
+
+        const { payload, error, errorObject } = await mutate(newIntegration);
+        if (errorObject) {
+            throw errorObject;
+        }
+
+        if (error) {
+            throw new Error(`Error when creating integration ${integrationName}`);
+        }
+
+        return payload?.value as Integration;
+    };
+};
+
+const useCreateSplunkBehaviorGroup = () => {
+    const { mutate } = useSaveBehaviorGroupMutation();
+    const getBundleByName = useGetBundleByName();
+
+    return async ({ behaviorGroupName, bundleName }) : Promise<BehaviorGroup> => {
+        const bundle = await getBundleByName(bundleName);
+        if (!bundle) {
+            throw new Error(`Unable to find bundle ${bundleName}`);
+        }
+
+        const behaviorGroup : BehaviorGroupRequest = {
+            bundleId: bundle.id as UUID,
+            displayName: behaviorGroupName,
+            actions: [] // ignored
+        };
+
+        const { payload, error, errorObject } = await mutate(behaviorGroup);
+        if (errorObject) {
+            throw errorObject;
+        }
+
+        if (error) {
+            throw new Error(`Error when creating behavior group ${behaviorGroupName}`);
+        }
+
+        return payload?.value as BehaviorGroup;
+    };
+};
+
+const useUpdateSplunkBehaviorActions = () => {
+    const { mutate } = useUpdateBehaviorGroupActionsMutation();
+    return async (behaviorGroup, integration) => {
+        const endpointIds = behaviorGroup.actions || [];
+        endpointIds.push(integration.id);
+
+        const params = {
+            behaviorGroupId: behaviorGroup.id,
+            endpointIds
+        };
+        const { payload, error, errorObject } = await mutate(params);
+        if (errorObject) {
+            throw errorObject;
+        }
+
+        if (error) {
+            throw new Error(`Error when linking behavior group ${behaviorGroup.id}`
+                            + ` with integration ${integration.id}`);
+        }
+
+        return payload?.value;
+    };
+};
+
+const useAttachEventsToSplunk = () => {
+    const getAllEventTypes = useGetAllEventTypes();
+    const client = useClient();
+    const getAnyBehaviorGroupByNotification = useGetAnyBehaviorGroupByNotification();
+
+    const appendActionToNotification = async (eventType, behaviorGroup) => {
+        const existingActions = await getAnyBehaviorGroupByNotification(eventType.id as UUID);
+        const existingActionIds = existingActions.value as UUID[];
+        const newActionIds = [ ...existingActionIds, behaviorGroup.id ];
+
+        const { payload, errorObject, error } = await client.query(linkBehaviorGroupAction(eventType.id, newActionIds));
+        if (errorObject) {
+            throw errorObject;
+        }
+
+        if (error) {
+            throw new Error(`Unsuccessful linking of event type ${eventType.id}`);
+        }
+
+        return payload;
+    };
+
+    return async (behaviorGroup, events, onProgress) => {
+        const eventTypes = await getAllEventTypes();
+
+        const selectedEventTypes = eventTypes.filter(eventType => {
+            if (!eventType?.application) {
+                return false;
+            }
+
+            if (eventType.application.bundle_id !== behaviorGroup.bundleId) {
+                return false;
+            }
+
+            const expectEvents = events[eventType.application.name];
+            if (!expectEvents || (expectEvents !== '*' && !expectEvents.includes(eventType.name))) {
+                return false;
+            }
+
+            return true;
+        });
+
+        for (const eventType of selectedEventTypes) {
+            onProgress(`  ${eventType.application?.display_name} - ${eventType.display_name}`);
+            try {
+                await appendActionToNotification(eventType, behaviorGroup);
+                onProgress(`    LINKED`);
+            } catch (error) {
+                onProgress(`    ERROR!`);
+                console.log(error);
+            }
+
+        }
+    };
+};

--- a/src/properties/Messages.ts
+++ b/src/properties/Messages.ts
@@ -28,6 +28,11 @@ const MutableMessages = {
                 title: 'Edit integration'
             }
         },
+        splunk: {
+            page: {
+                title: 'Splunk Setup'
+            }
+        },
         notifications: {
             list: {
                 title: 'Notifications',

--- a/src/services/GetEventTypes.ts
+++ b/src/services/GetEventTypes.ts
@@ -1,0 +1,32 @@
+import { Direction, Page, Sort } from '@redhat-cloud-services/insights-common-typescript';
+import { useClient } from 'react-fetching-library';
+
+import { Schemas } from '../generated/OpenapiNotifications';
+import { listNotificationsActionCreator } from './useListNotifications';
+
+export const useGetAllEventTypes = () => {
+    const { query } = useClient();
+    const fetchPage = async (page?: Page) : Promise<Schemas.EventType[]> => {
+        if (!page) {
+            page = Page.defaultPage().withSort(Sort.by('e.id', Direction.ASCENDING));
+        }
+
+        const { errorObject, payload } = await query(listNotificationsActionCreator(page));
+        if (errorObject) {
+            throw errorObject;
+        }
+
+        if (payload?.type === 'PageEventType') {
+            const events = payload?.value?.data as Schemas.EventType[];
+            if (events.length === 0) {
+                return [];
+            }
+
+            return [ ...events, ...await fetchPage(page.nextPage()) ];
+        }
+
+        throw new Error(`Unknow payload type for eventTypes ${payload?.type}`);
+    };
+
+    return fetchPage;
+};

--- a/src/services/Notifications/GetBehaviorGroupByNotificationId.ts
+++ b/src/services/Notifications/GetBehaviorGroupByNotificationId.ts
@@ -1,6 +1,6 @@
 import { useTransformQueryResponse } from '@redhat-cloud-services/insights-common-typescript';
 import { validatedResponse, validationResponseTransformer } from 'openapi2typescript';
-import { useQuery } from 'react-fetching-library';
+import { useClient, useQuery } from 'react-fetching-library';
 
 import { Operations } from '../../generated/OpenapiNotifications';
 import { UUID } from '../../types/Notification';
@@ -30,4 +30,18 @@ export const useGetBehaviorGroupByNotification = (notificationId: UUID) => {
         useQuery(getBehaviorGroupByNotificationAction(notificationId)),
         getBehaviorGroupByNotificationDecoder
     );
+};
+
+export const useGetAnyBehaviorGroupByNotification = () => {
+    const client = useClient();
+    return async (notificationId: UUID) => {
+        const { errorObject, payload } = await client.query(getBehaviorGroupByNotificationAction(notificationId));
+        if (errorObject) {
+            throw errorObject;
+        }
+
+        return getBehaviorGroupByNotificationDecoder(
+            payload as Operations.NotificationServiceGetLinkedBehaviorGroups.Payload
+        );
+    };
 };

--- a/src/services/Notifications/GetBundles.ts
+++ b/src/services/Notifications/GetBundles.ts
@@ -1,7 +1,26 @@
 import { useQuery } from 'react-fetching-library';
 
-import { Operations } from '../../generated/OpenapiNotifications';
+import { Operations, Schemas } from '../../generated/OpenapiNotifications';
 
 const getBundlesAction = (includeApplications: boolean) => Operations.NotificationServiceGetBundleFacets.actionCreator(includeApplications);
 
-export const useGetBundles = (includeApplications?: boolean) => useQuery(getBundlesAction(!!includeApplications));
+export const useGetBundles = (includeApplications?: boolean, initFetch = true) =>
+    useQuery(getBundlesAction(!!includeApplications), initFetch);
+
+export const useGetBundleByName = () => {
+    const { query } = useGetBundles(false, false);  // includeApplications = false, initFetch = false
+    return async (bundleName: string)  => {
+        const response = await query();
+        const payload = response.payload as Operations.NotificationServiceGetApplicationsFacets.Payload;
+        if (response.errorObject) {
+            throw response.errorObject;
+        }
+
+        if (response.error || !payload) {
+            throw new Error(`Unable to retrieve bundles, status ${payload.status}`);
+        }
+
+        const value = payload.value as Schemas.Bundle[];
+        return value.find(bundle => bundle.name === bundleName);
+    };
+};

--- a/src/types/Notification.ts
+++ b/src/types/Notification.ts
@@ -63,7 +63,7 @@ export type BehaviorGroup = {
     readonly actions: ReadonlyArray<Action>;
     readonly bundleId: UUID,
     readonly displayName: string;
-    readonly bundleName: string;
+    readonly bundleName?: string;
     readonly isDefault: boolean;
 }
 


### PR DESCRIPTION
Creates a new page for automated Splunk integration set up.

The automation:
* creates new Integration
* creates new Behavior Group for `rhel` bundle
* Links the integration and behavior group (by adding it as an action)
* Adds an action to selected event types within rhel bundle (Insights)

![Screenshot 2022-04-12 at 19-36-07 Integrations Settings](https://user-images.githubusercontent.com/7695766/163021610-0ca04f30-60f5-4c78-9259-d4f79fff0c35.png)

Besides that adds and/or refactors services:
* creates `useGetBundleByName`
* makes `bundleName` of `BehaviorGroup` optional
* creates `useGetAllEventTypes`
* create `useGetAnyBehaviorGroupByNotification`

Co-authored by @jpramos123
Replaces #264