### PR TITLE
Add settings-navigation.json items to CRD

### DIFF
--- a/.rhcicd/frontend.yaml
+++ b/.rhcicd/frontend.yaml
@@ -38,7 +38,7 @@ objects:
               title: "Console"
               href: "/settings/notifications/console"
         - appID: "notifications"
-          title: "integrations"
+          title: "Integrations"
           href: "/settings/integrations"
           product: "Red Hat Insights"
       module:

--- a/.rhcicd/frontend.yaml
+++ b/.rhcicd/frontend.yaml
@@ -19,10 +19,24 @@ objects:
           - /apps/notifications
       image: ${IMAGE}:${IMAGE_TAG}
       navItems:
-        - appId: "notifications"
-          title: "notifications"
-          href: "/settings/notifications"
-          product: "Red Hat Insights"
+        - title: "Notifications"
+          expandable: true
+          routes:
+            - appId: "notifications"
+              title: "Application Services"
+              href: "/settings/notifications/application-services"
+            - appId: "notifications"
+              title: "Openshift"
+              href: "/settings/notifications/openshift"
+            - appId: "notifications"
+              title: "Red Hat Enterprise Linux"
+              href: "/settings/notifications/rhel"
+            - appId: "notifications"
+              title: "Edge"
+              href: "/settings/notifications/edge"
+            - appId: "notifications"
+              title: "Console"
+              href: "/settings/notifications/console"
         - appID: "notifications"
           title: "integrations"
           href: "/settings/integrations"


### PR DESCRIPTION
In order to match [the settings nav from chrome](https://github.com/RedHatInsights/cloud-services-config/blob/ci-beta/chrome/settings-navigation.json#L53), we need to move that into the CRD so that the expandable nav will work.