### PR TITLE
[EVNT-341] Wizard for Splunk Automated Setup

### DIFF
--- a/src/pages/Integrations/SplunkSetup/SplunkSetupFinished.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupFinished.tsx
@@ -1,0 +1,26 @@
+import {
+    Button,
+    EmptyState,
+    EmptyStateBody,
+    EmptyStateIcon,
+    Title
+} from '@patternfly/react-core';
+import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+import React, { Dispatch, SetStateAction } from 'react';
+
+interface SplunkSetupFinishedProps {
+  setStep: Dispatch<SetStateAction<number>>;
+}
+
+export const SplunkSetupFinished: React.FunctionComponent<SplunkSetupFinishedProps> = ({ setStep }) => (
+    <EmptyState>
+        <EmptyStateIcon icon={ CheckCircleIcon } color='var(--pf-global--success-color--200)' />
+        <Title headingLevel="h4" size="lg">
+        Splunk integration in Insights completed
+        </Title>
+        <EmptyStateBody>
+        Splunk integration in Insights was completed. To confirm these changes, go back to Splunk application.
+        </EmptyStateBody>
+        <Button variant="primary" onClick={ () => setStep(prevStep => prevStep - 1) }>Go back to Splunk application</Button>
+    </EmptyState>
+);

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupForm.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupForm.tsx
@@ -29,8 +29,8 @@ interface SplunkSetupFormProps {
     setHecToken: Dispatch<SetStateAction<string>>;
     splunkServerHostName: string;
     setHostName: Dispatch<SetStateAction<string>>;
-    automationLogs: string;
-    setAutomationLogs: Dispatch<SetStateAction<string>>;
+    automationLogs: React.ReactChild[];
+    setAutomationLogs: Dispatch<SetStateAction<React.ReactChild[]>>;
 }
 
 export const SplunkSetupForm: React.FunctionComponent<SplunkSetupFormProps> = ({
@@ -41,17 +41,22 @@ export const SplunkSetupForm: React.FunctionComponent<SplunkSetupFormProps> = ({
 
     const startSplunkAutomation = useSplunkSetup();
 
-    const onProgress = (message) => {
-        setAutomationLogs(prevLogs => `${prevLogs}${message}\n`);
+    const onProgress = (message, className?) => {
+        let newLog = message;
+        if (className) {
+            newLog = <span className={ className }>{ message }</span>;
+        }
+
+        setAutomationLogs(prevLogs => [ ...prevLogs, newLog ]);
     };
 
     const onStart = async () => {
         setStepIsInProgress(true);
-        setAutomationLogs('');
+        setAutomationLogs([]);
         try {
             await startSplunkAutomation({ hecToken, splunkServerHostName }, onProgress);
         } catch (error) {
-            onProgress(`ERROR: ${error}`);
+            onProgress(`\n${error}`, 'pf-u-danger-color-200');
             setStepIsInProgress(false);
             setStepVariant('danger');
             return;
@@ -60,7 +65,7 @@ export const SplunkSetupForm: React.FunctionComponent<SplunkSetupFormProps> = ({
         setStepIsInProgress(false);
         setStepVariant('success');
 
-        onProgress('DONE!\n');
+        onProgress('\nDONE!', 'pf-u-success-color-200');
     };
 
     const onFinish = () => {

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupForm.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupForm.tsx
@@ -1,0 +1,121 @@
+import {
+    ActionGroup,
+    Button,
+    CodeBlock,
+    CodeBlockCode,
+    Form,
+    FormGroup,
+    Grid,
+    GridItem,
+    Popover,
+    TextInput
+ } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+import React, { useState } from 'react';
+
+import { useSplunkSetup } from './useSplunkSetup';
+
+const SPLUNK_CLOUD_HEC_DOC =
+    'https://docs.splunk.com/Documentation/SplunkCloud/latest/Data/UsetheHTTPEventCollector#Send_data_to_HTTP_Event_Collector';
+
+export const SplunkSetupForm: React.FunctionComponent = () => {
+
+    const [ hecToken, setHecToken ] = useState('');
+    const [ splunkServerHostName, setHostName ] = useState('');
+    const [ automationLogs, setAutomationLogs ] = useState(`CLICK THE BUTTON TO START THE AUTOMATION\n`);
+    const [ disableSubmit, setDisableSubmit ] = useState(false);
+    const startSplunkAutomation = useSplunkSetup();
+
+    const onProgress = (message) => {
+        setAutomationLogs(prevLogs => `${prevLogs}${message}\n`);
+    };
+
+    const onStart = async () => {
+        setDisableSubmit(true);
+        setAutomationLogs('');
+        try {
+            await startSplunkAutomation({ hecToken, splunkServerHostName }, onProgress);
+        } catch (error) {
+            onProgress(`ERROR: ${error}`);
+        }
+
+        onProgress('DONE!\n');
+    };
+
+    return (
+        <Grid>
+            <GridItem span={ 6 }>
+                <Form className='pf-u-mr-md'>
+                    <FormGroup
+                        label="Server hostname/IP Address and port (hostname:port)"
+                        labelIcon={ <Popover
+                            headerContent={ <div>
+                                The server <b>hostname/IP Address</b> and <b>port</b> of your splunk HTTP Event Collector
+                            </div> }
+                            bodyContent={ <div>
+                                For Splunk Enterprise the port is by default 8088.<br />
+                                For Splunk Cloud Platform see
+                                {' '}
+                                <a
+                                    target='_blank'
+                                    rel='noreferrer'
+                                    href={ SPLUNK_CLOUD_HEC_DOC }>
+                                    documentation
+                                </a>.
+                            </div> }
+                        >
+                            <button
+                                type="button"
+                                aria-label="More info for name field"
+                                onClick={ e => e.preventDefault() }
+                                aria-describedby="splunk-server-hostname"
+                                className="pf-c-form__group-label-help"
+                            >
+                                <HelpIcon noVerticalAlign />
+                            </button>
+                        </Popover> }
+                        isRequired
+                        fieldId="splunk-server-hostname"
+                    >
+                        <TextInput
+                            isRequired
+                            type="text"
+                            id="splunk-server-hostname"
+                            name="splunk-server-hostname"
+                            aria-describedby="splunk-server-hostname-helper"
+                            value={ splunkServerHostName }
+                            onChange={ (value) => setHostName(value) }
+                        />
+                    </FormGroup>
+                    <FormGroup
+                        label="Splunk HEC Token"
+                        fieldId="splunk-hec-token"
+                    >
+                        <TextInput
+                            isRequired
+                            type="text"
+                            id="splunk-hec-token"
+                            name="splunk-hec-token"
+                            aria-describedby="splunk-hec-token-helper"
+                            value={ hecToken }
+                            onChange={ (value) => setHecToken(value) }
+                        />
+                    </FormGroup>
+                    <ActionGroup>
+                        <Button variant="primary"
+                            onClick={ onStart }
+                            isDisabled={ disableSubmit }>
+                            Start Setup
+                        </Button>
+                    </ActionGroup>
+                </Form>
+            </GridItem>
+
+            <GridItem span={ 6 }>
+                <CodeBlock>
+                    <CodeBlockCode>{automationLogs}</CodeBlockCode>
+                </CodeBlock>
+            </GridItem>
+        </Grid>
+    );
+};

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
@@ -1,10 +1,18 @@
 import {
     Button,
-    Popover
+    Card,
+    CardBody,
+    Divider,
+    Popover,
+    ProgressStep,
+    ProgressStepper,
+    ProgressStepProps,
+    Split,
+    SplitItem
 } from '@patternfly/react-core';
-import { ExternalLinkSquareAltIcon, HelpIcon } from '@patternfly/react-icons';
+import { ExternalLinkSquareAltIcon, HelpIcon, InProgressIcon } from '@patternfly/react-icons';
 import { Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
-import React from 'react';
+import React, { useState } from 'react';
 
 import { Messages } from '../../../properties/Messages';
 import { SplunkSetupForm } from './SplunkSetupForm';
@@ -34,13 +42,70 @@ const SplunkSetupTitle: React.FunctionComponent = () => (
 );
 
 export const SplunkSetupPage: React.FunctionComponent = () => {
+
+    const [ step, setStep ] = useState(2);
+    const [ stepIsInProgress, setStepIsInProgress ] = useState(false);
+    const [ stepVariant, setStepVariant ] = useState<ProgressStepProps['variant']>('info');
+
+    const [ hecToken, setHecToken ] = useState('');
+    const [ splunkServerHostName, setHostName ] = useState('');
+    const [ automationLogs, setAutomationLogs ] = useState(`CLICK THE BUTTON TO START THE AUTOMATION\n`);
+
     return (
         <>
             <PageHeader>
                 <SplunkSetupTitle />
             </PageHeader>
             <Main>
-                <SplunkSetupForm />
+                <Card>
+                    <CardBody>
+                        <Split hasGutter>
+                            <SplitItem>
+                                <ProgressStepper isVertical>
+                                    <ProgressStep
+                                        isCurrent={ step === 1 }
+                                        variant="success"
+                                        description="Create HEC"
+                                        id="step1-splunk-app-step"
+                                        titleId="step1-splunk-app-step"
+                                        aria-label="completed Splunk app step (step 1)"
+                                    >
+                                        Step 1 (Splunk app)
+                                    </ProgressStep>
+                                    <ProgressStep
+                                        isCurrent={ step === 2 }
+                                        icon={ step === 2 && stepIsInProgress ? <InProgressIcon /> : undefined }
+                                        variant={ step < 2 ? 'info' : (step > 2 ? 'success' : stepVariant) }
+                                        description="Configure Splunk integration in Insights"
+                                        id="step2-setup-step"
+                                        titleId="step2-setup-step"
+                                        aria-label="setup step (step 2)"
+                                    >
+                                        Step 2
+                                    </ProgressStep>
+                                    <ProgressStep
+                                        isCurrent={ step === 3 }
+                                        variant="pending"
+                                        description="Review"
+                                        id="step3-review-step"
+                                        titleId="step3-review-step"
+                                        aria-label="review step (step 3)"
+                                    >
+                                        Step 3
+                                    </ProgressStep>
+                                </ProgressStepper>
+                            </SplitItem>
+                            <Divider isVertical />
+                            <SplitItem isFilled>
+                                { step === 2
+                                    && <SplunkSetupForm { ...{ setStep, stepIsInProgress, setStepIsInProgress, stepVariant, setStepVariant,
+                                        hecToken, setHecToken, splunkServerHostName, setHostName,
+                                        automationLogs, setAutomationLogs
+                                    } } /> }
+                            </SplitItem>
+                        </Split>
+                    </CardBody>
+                </Card>
             </Main>
         </>
     );

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
@@ -1,23 +1,13 @@
 import {
-    ActionGroup,
     Button,
-    CodeBlock,
-    CodeBlockCode,
-    Form,
-    FormGroup,
-    Grid,
-    GridItem,
-    Popover,
-    TextInput } from '@patternfly/react-core';
+    Popover
+} from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon, HelpIcon } from '@patternfly/react-icons';
 import { Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
-import React, { useState } from 'react';
+import React from 'react';
 
 import { Messages } from '../../../properties/Messages';
-import { useSplunkSetup } from './useSplunkSetup';
-
-const SPLUNK_CLOUD_HEC_DOC =
-    'https://docs.splunk.com/Documentation/SplunkCloud/latest/Data/UsetheHTTPEventCollector#Send_data_to_HTTP_Event_Collector';
+import { SplunkSetupForm } from './SplunkSetupForm';
 
 const SplunkSetupTitle: React.FunctionComponent = () => (
     <>
@@ -44,109 +34,13 @@ const SplunkSetupTitle: React.FunctionComponent = () => (
 );
 
 export const SplunkSetupPage: React.FunctionComponent = () => {
-
-    const [ hecToken, setHecToken ] = useState('');
-    const [ splunkServerHostName, setHostName ] = useState('');
-    const [ automationLogs, setAutomationLogs ] = useState(`CLICK THE BUTTON TO START THE AUTOMATION\n`);
-    const [ disableSubmit, setDisableSubmit ] = useState(false);
-    const startSplunkAutomation = useSplunkSetup();
-
-    const onProgress = (message) => {
-        setAutomationLogs(prevLogs => `${prevLogs}${message}\n`);
-    };
-
-    const onStart = async () => {
-        setDisableSubmit(true);
-        setAutomationLogs('');
-        try {
-            await startSplunkAutomation({ hecToken, splunkServerHostName }, onProgress);
-        } catch (error) {
-            onProgress(`ERROR: ${error}`);
-        }
-
-        onProgress('DONE!\n');
-    };
-
     return (
         <>
             <PageHeader>
                 <SplunkSetupTitle />
             </PageHeader>
             <Main>
-                <Grid>
-                    <GridItem span={ 6 }>
-                        <Form className='pf-u-mr-md'>
-                            <FormGroup
-                                label="Server hostname/IP Address and port (hostname:port)"
-                                labelIcon={ <Popover
-                                    headerContent={ <div>
-                                        The server <b>hostname/IP Address</b> and <b>port</b> of your splunk HTTP Event Collector
-                                    </div> }
-                                    bodyContent={ <div>
-                                        For Splunk Enterprise the port is by default 8088.<br />
-                                        For Splunk Cloud Platform see
-                                        {' '}
-                                        <a
-                                            target='_blank'
-                                            rel='noreferrer'
-                                            href={ SPLUNK_CLOUD_HEC_DOC }>
-                                            documentation
-                                        </a>.
-                                    </div> }
-                                >
-                                    <button
-                                        type="button"
-                                        aria-label="More info for name field"
-                                        onClick={ e => e.preventDefault() }
-                                        aria-describedby="splunk-server-hostname"
-                                        className="pf-c-form__group-label-help"
-                                    >
-                                        <HelpIcon noVerticalAlign />
-                                    </button>
-                                </Popover> }
-                                isRequired
-                                fieldId="splunk-server-hostname"
-                            >
-                                <TextInput
-                                    isRequired
-                                    type="text"
-                                    id="splunk-server-hostname"
-                                    name="splunk-server-hostname"
-                                    aria-describedby="splunk-server-hostname-helper"
-                                    value={ splunkServerHostName }
-                                    onChange={ (value) => setHostName(value) }
-                                />
-                            </FormGroup>
-                            <FormGroup
-                                label="Splunk HEC Token"
-                                fieldId="splunk-hec-token"
-                            >
-                                <TextInput
-                                    isRequired
-                                    type="text"
-                                    id="splunk-hec-token"
-                                    name="splunk-hec-token"
-                                    aria-describedby="splunk-hec-token-helper"
-                                    value={ hecToken }
-                                    onChange={ (value) => setHecToken(value) }
-                                />
-                            </FormGroup>
-                            <ActionGroup>
-                                <Button variant="primary"
-                                    onClick={ onStart }
-                                    isDisabled={ disableSubmit }>
-                                    Start Setup
-                                </Button>
-                            </ActionGroup>
-                        </Form>
-                    </GridItem>
-
-                    <GridItem span={ 6 }>
-                        <CodeBlock>
-                            <CodeBlockCode>{automationLogs}</CodeBlockCode>
-                        </CodeBlock>
-                    </GridItem>
-                </Grid>
+                <SplunkSetupForm />
             </Main>
         </>
     );

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
@@ -50,7 +50,7 @@ export const SplunkSetupPage: React.FunctionComponent = () => {
 
     const [ hecToken, setHecToken ] = useState('');
     const [ splunkServerHostName, setHostName ] = useState('');
-    const [ automationLogs, setAutomationLogs ] = useState(`CLICK THE BUTTON TO START THE AUTOMATION\n`);
+    const [ automationLogs, setAutomationLogs ] = useState<React.ReactChild[]>([ `Logs from the automation would appear here\n` ]);
 
     return (
         <>

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
@@ -15,6 +15,7 @@ import { Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/fronte
 import React, { useState } from 'react';
 
 import { Messages } from '../../../properties/Messages';
+import { SplunkSetupFinished } from './SplunkSetupFinished';
 import { SplunkSetupForm } from './SplunkSetupForm';
 
 const SplunkSetupTitle: React.FunctionComponent = () => (
@@ -85,7 +86,7 @@ export const SplunkSetupPage: React.FunctionComponent = () => {
                                     </ProgressStep>
                                     <ProgressStep
                                         isCurrent={ step === 3 }
-                                        variant="pending"
+                                        variant={ step < 3 ? 'pending' : 'success' }
                                         description="Review"
                                         id="step3-review-step"
                                         titleId="step3-review-step"
@@ -102,6 +103,7 @@ export const SplunkSetupPage: React.FunctionComponent = () => {
                                         hecToken, setHecToken, splunkServerHostName, setHostName,
                                         automationLogs, setAutomationLogs
                                     } } /> }
+                                { step === 3 && <SplunkSetupFinished setStep={ setStep } /> }
                             </SplitItem>
                         </Split>
                     </CardBody>

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
@@ -9,7 +9,7 @@ import {
     GridItem,
     Popover,
     TextInput } from '@patternfly/react-core';
-import HelpIcon from '@patternfly/react-icons/dist/js/icons/help-icon';
+import { ExternalLinkSquareAltIcon, HelpIcon } from '@patternfly/react-icons';
 import { Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
 import React, { useState } from 'react';
 
@@ -18,6 +18,30 @@ import { useSplunkSetup } from './useSplunkSetup';
 
 const SPLUNK_CLOUD_HEC_DOC =
     'https://docs.splunk.com/Documentation/SplunkCloud/latest/Data/UsetheHTTPEventCollector#Send_data_to_HTTP_Event_Collector';
+
+const SplunkSetupTitle: React.FunctionComponent = () => (
+    <>
+        <PageHeaderTitle title={ <>
+            { Messages.pages.splunk.page.title }
+            <Popover
+                bodyContent={ Messages.pages.splunk.page.help }
+                footerContent={ Messages.pages.splunk.page.helpUrl &&
+                            <a target="_blank" rel="noopener noreferrer" href={ Messages.pages.splunk.page.helpUrl || '' }>
+                                Learn more <ExternalLinkSquareAltIcon />
+                            </a> }
+            >
+                <Button
+                    variant='plain'
+                    aria-label="Help description"
+                    className="title-help-label"
+                >
+                    <HelpIcon noVerticalAlign />
+                </Button>
+            </Popover>
+        </> } />
+        { Messages.pages.splunk.page.description }
+    </>
+);
 
 export const SplunkSetupPage: React.FunctionComponent = () => {
 
@@ -46,7 +70,7 @@ export const SplunkSetupPage: React.FunctionComponent = () => {
     return (
         <>
             <PageHeader>
-                <PageHeaderTitle title={ Messages.pages.splunk.page.title } />
+                <SplunkSetupTitle />
             </PageHeader>
             <Main>
                 <Grid>

--- a/src/pages/Integrations/SplunkSetup/useSplunkSetup.tsx
+++ b/src/pages/Integrations/SplunkSetup/useSplunkSetup.tsx
@@ -72,19 +72,20 @@ export const useSplunkSetup = () => {
         const bundleName = BUNDLE_NAME;
         const events = DEFAULT_SPLUNK_EVENTS;
 
-        onProgress('Creating Splunk Integration...');
+        onProgress(`Creating Integration ${integrationName}...`);
         const integration = await createSplunkIntegration({ integrationName, hecToken, splunkServerHostName });
-        onProgress(`  ${integrationName} integration created.`);
+        onProgress(' OK', 'pf-u-success-color-200');
 
-        onProgress('Creating Splunk Behavior Group...');
+        onProgress(`\nCreating Behavior Group ${behaviorGroupName}...`);
         const behaviorGroup = await createSplunkBehaviorGroup({ behaviorGroupName, bundleName });
-        onProgress(`  ${behaviorGroupName} behavior group created.`);
+        onProgress(' OK', 'pf-u-success-color-200');
 
-        onProgress('Adding Splunk integration as an action behavior group...');
+        onProgress('\nAssociating integration as an action for the behavior group...');
         await updateSplunkBehaviorActions(behaviorGroup, integration);
-        onProgress('  Added.');
 
-        onProgress('Adding evets to the behavior group:');
+        onProgress(' OK', 'pf-u-success-color-200');
+        onProgress('\n\nAssociating events to the behavior group:\n');
+
         await attachEvents(behaviorGroup, events, onProgress);
     };
 };
@@ -210,12 +211,12 @@ const useAttachEventsToSplunk = () => {
         });
 
         for (const eventType of selectedEventTypes) {
-            onProgress(`  ${eventType.application?.display_name} - ${eventType.display_name}`);
+            onProgress(`  ${eventType.application?.display_name} - ${eventType.display_name}...`);
             try {
                 await appendActionToNotification(eventType, behaviorGroup);
-                onProgress(`    LINKED`);
+                onProgress(' ASSOCIATED\n', 'pf-u-success-color-200');
             } catch (error) {
-                onProgress(`    ERROR!`);
+                onProgress(' ERROR!\n', 'pf-u-danger-color-200');
                 console.log(error);
             }
 

--- a/src/properties/Messages.ts
+++ b/src/properties/Messages.ts
@@ -30,7 +30,11 @@ const MutableMessages = {
         },
         splunk: {
             page: {
-                title: 'Splunk Setup'
+                title: 'Red Hat Insights application for Splunk',
+                description: 'To finish the Splunk configuration, follow the instructions to start the automation process.',
+                help: 'Red Hat Insights application for Splunk configure the integration between your Splunk instance' +
+                      ' and Red Hat Insights to allow you to receive events from Insights.',
+                helpUrl: null
             }
         },
         notifications: {


### PR DESCRIPTION
Updates and enhances the Splunk Automation Setup page to match with the mocks (available at EVNT-341) to have wizard styling.
Improves overall user experience and log messages.

Step 2
![Screen Shot 2022-04-21 at 11 48 21](https://user-images.githubusercontent.com/7695766/164430356-e1eb863e-58c9-45ce-9849-7bcbdc9bf59f.png)

In progress
![Screen Shot 2022-04-21 at 11 48 25](https://user-images.githubusercontent.com/7695766/164430372-af543032-b1ee-4550-bf81-33b32490b373.png)

All success
![Screen Shot 2022-04-21 at 11 48 39](https://user-images.githubusercontent.com/7695766/164430395-ddb515eb-89d5-40db-9bf0-ce37239768d6.png)

Main error
![Screen Shot 2022-04-21 at 11 51 37](https://user-images.githubusercontent.com/7695766/164430436-ed79ae55-1b72-4f2d-91df-b7913699fb59.png)

Partial event association error
![Screen Shot 2022-04-21 at 11 50 43](https://user-images.githubusercontent.com/7695766/164430439-340940fc-e3d7-47e1-a0ae-4a651c36de34.png)

Finished state
![Screen Shot 2022-04-21 at 11 48 42](https://user-images.githubusercontent.com/7695766/164430441-c319ca46-94ed-4379-8090-af7e51b21567.png)

Also fixes: EVNT-372, EVNT-395, EVNT-396, EVNT-397, EVNT-398

