### PR TITLE
[EVNT-408] Input Validation, Error Toast, and fixes for Splunk Automation

### DIFF
--- a/src/pages/Integrations/SplunkSetup/Constants.ts
+++ b/src/pages/Integrations/SplunkSetup/Constants.ts
@@ -1,0 +1,10 @@
+// Constatns, like link to docs and cases
+
+import { Messages } from '../../../properties/Messages';
+
+export const DOCUMENTATION_URL = Messages.pages.splunk.page.helpUrl || 'https://example.com';
+export const SPLUNK_CLOUD_HEC_DOC = 'https://docs.splunk.com/Documentation/SplunkCloud/latest/Data/'
+                                   + 'UsetheHTTPEventCollector#Send_data_to_HTTP_Event_Collector';
+export const OPEN_CASE_URL = 'https://access.redhat.com/support/cases/#/case/new/open-case/describe-issue'
+                           + '?intcmp=hp|a|a3|case&caseCreate=true&product=Red%20Hat%20Insights'
+                           + '&version=Red%20Hat%20Insights';

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupFinished.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupFinished.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 
 export const SplunkSetupFinished: React.FunctionComponent = () => (
     <EmptyState>
-        <EmptyStateIcon icon={ CheckCircleIcon } color='var(--pf-global--success-color--200)' />
+        <EmptyStateIcon icon={ CheckCircleIcon } color='var(--pf-global--success-color--100)' />
         <Title headingLevel="h4" size="lg">
         Splunk integration in Insights completed
         </Title>

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupFinished.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupFinished.tsx
@@ -1,26 +1,21 @@
 import {
-    Button,
     EmptyState,
     EmptyStateBody,
     EmptyStateIcon,
     Title
 } from '@patternfly/react-core';
 import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
-import React, { Dispatch, SetStateAction } from 'react';
+import React from 'react';
 
-interface SplunkSetupFinishedProps {
-  setStep: Dispatch<SetStateAction<number>>;
-}
-
-export const SplunkSetupFinished: React.FunctionComponent<SplunkSetupFinishedProps> = ({ setStep }) => (
+export const SplunkSetupFinished: React.FunctionComponent = () => (
     <EmptyState>
         <EmptyStateIcon icon={ CheckCircleIcon } color='var(--pf-global--success-color--200)' />
         <Title headingLevel="h4" size="lg">
         Splunk integration in Insights completed
         </Title>
         <EmptyStateBody>
-        Splunk integration in Insights was completed. To confirm these changes, go back to Splunk application.
+        Splunk integration in Insights was completed.
+        To confirm these changes, <strong>go back to Splunk application</strong>.
         </EmptyStateBody>
-        <Button variant="primary" onClick={ () => setStep(prevStep => prevStep - 1) }>Go back to Splunk application</Button>
     </EmptyState>
 );

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupFinished.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupFinished.tsx
@@ -1,21 +1,63 @@
 import {
+    Button,
     EmptyState,
     EmptyStateBody,
     EmptyStateIcon,
+    EmptyStateSecondaryActions,
     Title
 } from '@patternfly/react-core';
-import CheckCircleIcon from '@patternfly/react-icons/dist/js/icons/check-circle-icon';
+import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
 
-export const SplunkSetupFinished: React.FunctionComponent = () => (
+import { DOCUMENTATION_URL, OPEN_CASE_URL } from './Constants';
+
+interface SplunkSetupFinishedProps {
+    isSuccess: boolean;
+    error: Error | undefined
+}
+
+export const SplunkSetupFinished: React.FunctionComponent<SplunkSetupFinishedProps> = ({ isSuccess, error }) => (
+    isSuccess
+        ? <SplunkSetupFinishedSuccess />
+        : <SplunkSetupFinishedFailure error={ error } />
+);
+
+export const SplunkSetupFinishedSuccess: React.FunctionComponent = () => (
     <EmptyState>
         <EmptyStateIcon icon={ CheckCircleIcon } color='var(--pf-global--success-color--100)' />
         <Title headingLevel="h4" size="lg">
-        Splunk integration in Insights completed
+            Splunk integration in Insights completed
         </Title>
         <EmptyStateBody>
-        Splunk integration in Insights was completed.
-        To confirm these changes, <strong>go back to Splunk application</strong>.
+            Splunk integration in Insights was completed.
+            To confirm these changes, <strong>go back to Splunk application</strong>.
         </EmptyStateBody>
     </EmptyState>
 );
+
+export const SplunkSetupFinishedFailure: React.FunctionComponent<{ error: Error | undefined }> = ({ error }) =>
+    (
+        <EmptyState>
+            <EmptyStateIcon icon={ ExclamationCircleIcon } color='var(--pf-global--danger-color--100)' />
+            <Title headingLevel="h4" size="lg">
+            Configuration failed
+            </Title>
+            <EmptyStateBody>
+                <p className='pf-u-mb-md'>
+                There was a problem processing the request. Please try again. If the problem persists, contact Red Hat support by opening the ticket.
+                </p>
+                { error && <p>{ `${error}` }</p> }
+            </EmptyStateBody>
+            <Button variant="primary" component="a" href={ OPEN_CASE_URL } target="_blank" rel="noopener noreferrer">
+            Open a Red Hat Support ticket
+            </Button>
+            <EmptyStateSecondaryActions>
+                { DOCUMENTATION_URL &&
+                <Button variant="link" component="a" href={ DOCUMENTATION_URL || '' }
+                    target="_blank" rel="noopener noreferrer">
+                    Go to documentation
+                </Button>
+                }
+            </EmptyStateSecondaryActions>
+        </EmptyState>
+    );

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupForm.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupForm.tsx
@@ -34,12 +34,13 @@ interface SplunkSetupFormProps {
     setHostName: Dispatch<SetStateAction<string>>;
     automationLogs: React.ReactChild[];
     setAutomationLogs: Dispatch<SetStateAction<React.ReactChild[]>>;
+    setError: Dispatch<SetStateAction<Error | undefined>>;
 }
 
 export const SplunkSetupForm: React.FunctionComponent<SplunkSetupFormProps> = ({
     setStep, stepIsInProgress, setStepIsInProgress, stepVariant, setStepVariant,
     hecToken, setHecToken, splunkServerHostName, setHostName,
-    automationLogs, setAutomationLogs
+    automationLogs, setAutomationLogs, setError
 }) => {
 
     const startSplunkAutomation = useSplunkSetup();
@@ -104,6 +105,7 @@ export const SplunkSetupForm: React.FunctionComponent<SplunkSetupFormProps> = ({
             setStepVariant('danger');
 
             addDangerNotification('Configuration failed', <SplunkSetupFailedToast />, true);
+            setError(error as Error);
             return;
         }
 
@@ -201,10 +203,14 @@ export const SplunkSetupForm: React.FunctionComponent<SplunkSetupFormProps> = ({
 const SplunkAutomationButton = ({ onStart, onFinish, stepIsInProgress, stepVariant, isDisabled }) => {
     if (stepIsInProgress) {
         return <Button variant="primary" isLoading={ true }>Configuration in progress</Button>;
-    } else if (stepVariant === 'success') {
-        return <Button variant="primary" onClick={ onFinish }><CheckCircleIcon /> Next: Review</Button>;
-    } else if (stepVariant === 'danger') {
-        return <Button variant="primary"><ExclamationCircleIcon /> Next: Review</Button>;
+    } else if (stepVariant === 'success' || stepVariant === 'danger') {
+        return (
+            <Button variant="primary" onClick={ onFinish }>
+                { stepVariant === 'success' ? <CheckCircleIcon /> : <ExclamationCircleIcon /> }
+                {' '}
+                Next: Review
+            </Button>
+        );
     } else {
         return (
             <Button variant="primary" isDisabled={ isDisabled } onClick={ onStart }>

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupForm.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupForm.tsx
@@ -15,7 +15,7 @@ import {
     TextInput,
     ValidatedOptions
 } from '@patternfly/react-core';
-import { CheckCircleIcon, ExclamationCircleIcon, HelpIcon, InProgressIcon } from '@patternfly/react-icons';
+import { CheckCircleIcon, ExclamationCircleIcon, HelpIcon } from '@patternfly/react-icons';
 import { addDangerNotification } from '@redhat-cloud-services/insights-common-typescript';
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
@@ -206,7 +206,7 @@ export const SplunkSetupForm: React.FunctionComponent<SplunkSetupFormProps> = ({
 
 const SplunkAutomationButton = ({ onStart, onFinish, stepIsInProgress, stepVariant, isDisabled }) => {
     if (stepIsInProgress) {
-        return <Button variant="primary"><InProgressIcon /> Configuration in progress</Button>;
+        return <Button variant="primary" isLoading={ true }>Configuration in progress</Button>;
     } else if (stepVariant === 'success') {
         return <Button variant="primary" onClick={ onFinish }><CheckCircleIcon /> Next: Review</Button>;
     } else if (stepVariant === 'danger') {

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupForm.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupForm.tsx
@@ -19,14 +19,8 @@ import { CheckCircleIcon, ExclamationCircleIcon, HelpIcon } from '@patternfly/re
 import { addDangerNotification } from '@redhat-cloud-services/insights-common-typescript';
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
-import { Messages } from '../../../properties/Messages';
+import { DOCUMENTATION_URL, OPEN_CASE_URL, SPLUNK_CLOUD_HEC_DOC } from './Constants';
 import { useSplunkSetup } from './useSplunkSetup';
-
-const SPLUNK_CLOUD_HEC_DOC =
-    'https://docs.splunk.com/Documentation/SplunkCloud/latest/Data/UsetheHTTPEventCollector#Send_data_to_HTTP_Event_Collector';
-const OPEN_CASE_URL = 'https://access.redhat.com/support/cases/#/case/new/open-case/describe-issue'
-                    + '?intcmp=hp|a|a3|case&caseCreate=true&product=Red%20Hat%20Insights'
-                    + '&version=Red%20Hat%20Insights';
 
 interface SplunkSetupFormProps {
     setStep: Dispatch<SetStateAction<number>>;
@@ -230,9 +224,9 @@ const SplunkSetupFailedToast = () => (
             <ListItem>
                 <a target="_blank" rel="noopener noreferrer" href={ OPEN_CASE_URL }>Open a Red Hat Support ticket</a>
             </ListItem>
-            { Messages.pages.splunk.page.helpUrl &&
+            { DOCUMENTATION_URL &&
                 <ListItem>
-                    <a target="_blank" rel="noopener noreferrer" href={ Messages.pages.splunk.page.helpUrl || '' }>Go to documentation</a>
+                    <a target="_blank" rel="noopener noreferrer" href={ DOCUMENTATION_URL || '' }>Go to documentation</a>
                 </ListItem>
             }
         </List>

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupForm.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupForm.tsx
@@ -7,18 +7,26 @@ import {
     FormGroup,
     Grid,
     GridItem,
+    List,
+    ListItem,
+    ListVariant,
     Popover,
     ProgressStepProps,
     TextInput,
     ValidatedOptions
 } from '@patternfly/react-core';
 import { CheckCircleIcon, ExclamationCircleIcon, HelpIcon, InProgressIcon } from '@patternfly/react-icons';
+import { addDangerNotification } from '@redhat-cloud-services/insights-common-typescript';
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 
+import { Messages } from '../../../properties/Messages';
 import { useSplunkSetup } from './useSplunkSetup';
 
 const SPLUNK_CLOUD_HEC_DOC =
     'https://docs.splunk.com/Documentation/SplunkCloud/latest/Data/UsetheHTTPEventCollector#Send_data_to_HTTP_Event_Collector';
+const OPEN_CASE_URL = 'https://access.redhat.com/support/cases/#/case/new/open-case/describe-issue'
+                    + '?intcmp=hp|a|a3|case&caseCreate=true&product=Red%20Hat%20Insights'
+                    + '&version=Red%20Hat%20Insights';
 
 interface SplunkSetupFormProps {
     setStep: Dispatch<SetStateAction<number>>;
@@ -100,6 +108,8 @@ export const SplunkSetupForm: React.FunctionComponent<SplunkSetupFormProps> = ({
             onProgress(`\n${error}`, 'pf-u-danger-color-200');
             setStepIsInProgress(false);
             setStepVariant('danger');
+
+            addDangerNotification('Configuration failed', <SplunkSetupFailedToast />, true);
             return;
         }
 
@@ -209,3 +219,22 @@ const SplunkAutomationButton = ({ onStart, onFinish, stepIsInProgress, stepVaria
         );
     }
 };
+
+const SplunkSetupFailedToast = () => (
+    <>
+        <p className='pf-u-mb-md'>
+            There was a problem processing the request. Please try again.
+            If the problem persists, contact Red Hat support by opening the ticket.
+        </p>
+        <List variant={ ListVariant.inline }>
+            <ListItem>
+                <a target="_blank" rel="noopener noreferrer" href={ OPEN_CASE_URL }>Open a Red Hat Support ticket</a>
+            </ListItem>
+            { Messages.pages.splunk.page.helpUrl &&
+                <ListItem>
+                    <a target="_blank" rel="noopener noreferrer" href={ Messages.pages.splunk.page.helpUrl || '' }>Go to documentation</a>
+                </ListItem>
+            }
+        </List>
+    </>
+);

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
@@ -103,7 +103,7 @@ export const SplunkSetupPage: React.FunctionComponent = () => {
                                         hecToken, setHecToken, splunkServerHostName, setHostName,
                                         automationLogs, setAutomationLogs
                                     } } /> }
-                                { step === 3 && <SplunkSetupFinished setStep={ setStep } /> }
+                                { step === 3 && <SplunkSetupFinished /> }
                             </SplitItem>
                         </Split>
                     </CardBody>

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
@@ -52,6 +52,7 @@ export const SplunkSetupPage: React.FunctionComponent = () => {
     const [ hecToken, setHecToken ] = useState('');
     const [ splunkServerHostName, setHostName ] = useState('');
     const [ automationLogs, setAutomationLogs ] = useState<React.ReactChild[]>([ `Logs from the automation would appear here\n` ]);
+    const [ error, setError ] = useState<Error | undefined>();
 
     return (
         <>
@@ -77,7 +78,7 @@ export const SplunkSetupPage: React.FunctionComponent = () => {
                                     <ProgressStep
                                         isCurrent={ step === 2 }
                                         icon={ step === 2 && stepIsInProgress ? <InProgressIcon /> : undefined }
-                                        variant={ step < 2 ? 'info' : (step > 2 ? 'success' : stepVariant) }
+                                        variant={ step < 2 ? 'info' : stepVariant }
                                         description="Configure Splunk integration in Insights"
                                         id="step2-setup-step"
                                         titleId="step2-setup-step"
@@ -87,7 +88,7 @@ export const SplunkSetupPage: React.FunctionComponent = () => {
                                     </ProgressStep>
                                     <ProgressStep
                                         isCurrent={ step === 3 }
-                                        variant={ step < 3 ? 'pending' : 'success' }
+                                        variant={ step < 3 ? 'pending' : stepVariant }
                                         description="Review"
                                         id="step3-review-step"
                                         titleId="step3-review-step"
@@ -102,9 +103,12 @@ export const SplunkSetupPage: React.FunctionComponent = () => {
                                 { step === 2
                                     && <SplunkSetupForm { ...{ setStep, stepIsInProgress, setStepIsInProgress, stepVariant, setStepVariant,
                                         hecToken, setHecToken, splunkServerHostName, setHostName,
-                                        automationLogs, setAutomationLogs
+                                        automationLogs, setAutomationLogs, setError
                                     } } /> }
-                                { step === 3 && <SplunkSetupFinished /> }
+                                { step === 3 &&
+                                    <SplunkSetupFinished
+                                        isSuccess={ stepVariant === 'success' } error={ error } />
+                                }
                             </SplitItem>
                         </Split>
                     </CardBody>

--- a/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
@@ -15,6 +15,7 @@ import { Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/fronte
 import React, { useState } from 'react';
 
 import { Messages } from '../../../properties/Messages';
+import { DOCUMENTATION_URL } from './Constants';
 import { SplunkSetupFinished } from './SplunkSetupFinished';
 import { SplunkSetupForm } from './SplunkSetupForm';
 
@@ -24,8 +25,8 @@ const SplunkSetupTitle: React.FunctionComponent = () => (
             { Messages.pages.splunk.page.title }
             <Popover
                 bodyContent={ Messages.pages.splunk.page.help }
-                footerContent={ Messages.pages.splunk.page.helpUrl &&
-                            <a target="_blank" rel="noopener noreferrer" href={ Messages.pages.splunk.page.helpUrl || '' }>
+                footerContent={ DOCUMENTATION_URL &&
+                            <a target="_blank" rel="noopener noreferrer" href={ DOCUMENTATION_URL || '' }>
                                 Learn more <ExternalLinkSquareAltIcon />
                             </a> }
             >


### PR DESCRIPTION
Adds Input validation to the Splunk Automation form:
![Screen Shot 2022-04-26 at 10 17 50](https://user-images.githubusercontent.com/7695766/165255948-93a9af6d-0a1d-4b79-858b-e3a027f3c3a5.png)

Adds toast on error:
![Screen Shot 2022-04-25 at 16 53 18](https://user-images.githubusercontent.com/7695766/165117621-a570e31e-053b-4555-a9e0-18e882a32aba.png)

Added failure review on Step 3:
![Screen Shot 2022-04-26 at 11 52 40](https://user-images.githubusercontent.com/7695766/165274841-94832736-4169-47d0-9025-1da877d83853.png)

Updates the spinner within the button when in progress:
![Screen Shot 2022-04-26 at 10 22 19](https://user-images.githubusercontent.com/7695766/165256077-b4ebb653-5536-4296-b408-12c80a763411.png)

Updates the Finished step by removing the button and fixing the icon color:
![Screen Shot 2022-04-25 at 17 14 32](https://user-images.githubusercontent.com/7695766/165119306-de79eedc-c010-4a92-a7f2-fe8b2a6800e4.png)

Note, that the documentation link on the Toast would appear if the URL would be set in config (once known).

EVNT-408, EVNT-419

