### PR TITLE
[EVNT-487] Change splunk integration title

### DIFF
--- a/src/properties/Messages.ts
+++ b/src/properties/Messages.ts
@@ -30,7 +30,7 @@ const MutableMessages = {
         },
         splunk: {
             page: {
-                title: 'Red Hat Insights application for Splunk',
+                title: 'Red Hat Insights integration for Splunk',
                 description: 'To finish the Splunk configuration, follow the instructions to start the automation process.',
                 help: 'Configure the integration between your Splunk instance' +
                       ' and Red Hat Insights to allow you to receive events from Insights.',


### PR DESCRIPTION
The backend wizard is located in Integrations, should be called `Red Hat Insights integration for Splunk`