### PR TITLE
NOTIF-386 Show relative time for integration and event log

### DIFF
--- a/src/components/Integrations/Table/ConnectionAttempt.tsx
+++ b/src/components/Integrations/Table/ConnectionAttempt.tsx
@@ -1,10 +1,10 @@
 import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { global_danger_color_100, global_spacer_xs, global_success_color_100 } from '@patternfly/react-tokens';
-import { toUtc } from '@redhat-cloud-services/insights-common-typescript';
 import { assertNever } from 'assert-never';
-import format from 'date-fns/format';
 import * as React from 'react';
 import { style } from 'typestyle';
+
+import { DateFormat } from '@redhat-cloud-services/frontend-components';
 
 export interface ConnectionAttemptProps {
     type: ConnectionAttemptType;
@@ -20,8 +20,6 @@ const dateClassName = style({
     marginLeft: global_spacer_xs.var
 });
 
-const dateFormatString = 'MMM d, HH:mm:ss';
-
 const getIcon = (type: ConnectionAttemptType) => {
     switch (type) {
         case ConnectionAttemptType.SUCCESS:
@@ -34,10 +32,12 @@ const getIcon = (type: ConnectionAttemptType) => {
 };
 
 export const ConnectionAttempt: React.FunctionComponent<ConnectionAttemptProps> = (props) => {
-    const formattedDate = format(toUtc(props.date), dateFormatString);
     return (
         <>
-            { getIcon(props.type) } <span className={ dateClassName }> { formattedDate } UTC </span>
+            { getIcon(props.type) }
+            <span className={ dateClassName }>
+                <DateFormat type="relative" date={ props.date } />
+            </span>
         </>
     );
 };

--- a/src/components/Integrations/Table/ConnectionAttempt.tsx
+++ b/src/components/Integrations/Table/ConnectionAttempt.tsx
@@ -1,10 +1,9 @@
 import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
 import { global_danger_color_100, global_spacer_xs, global_success_color_100 } from '@patternfly/react-tokens';
+import { DateFormat } from '@redhat-cloud-services/frontend-components';
 import { assertNever } from 'assert-never';
 import * as React from 'react';
 import { style } from 'typestyle';
-
-import { DateFormat } from '@redhat-cloud-services/frontend-components';
 
 export interface ConnectionAttemptProps {
     type: ConnectionAttemptType;

--- a/src/components/Notifications/EventLog/EventLogTable.tsx
+++ b/src/components/Notifications/EventLog/EventLogTable.tsx
@@ -2,11 +2,11 @@ import { EmptyStateVariant, Label, LabelGroup, LabelProps, Popover, Skeleton } f
 import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons';
 import { IExtraColumnData, SortByDirection, TableComposable, Tbody, Td, Th, Thead, ThProps, Tr } from '@patternfly/react-table';
 import { c_alert_m_warning__icon_Color } from '@patternfly/react-tokens';
+import { DateFormat } from '@redhat-cloud-services/frontend-components';
 import assertNever from 'assert-never';
 import * as React from 'react';
 import { style } from 'typestyle';
 
-import { DateFormat } from '@redhat-cloud-services/frontend-components';
 import Config from '../../../config/Config';
 import { Messages } from '../../../properties/Messages';
 import { NotificationEvent, NotificationEventStatus } from '../../../types/Event';

--- a/src/components/Notifications/EventLog/EventLogTable.tsx
+++ b/src/components/Notifications/EventLog/EventLogTable.tsx
@@ -6,12 +6,12 @@ import assertNever from 'assert-never';
 import * as React from 'react';
 import { style } from 'typestyle';
 
+import { DateFormat } from '@redhat-cloud-services/frontend-components';
 import Config from '../../../config/Config';
 import { Messages } from '../../../properties/Messages';
 import { NotificationEvent, NotificationEventStatus } from '../../../types/Event';
 import { GetIntegrationRecipient } from '../../../types/Integration';
 import { EmptyStateSearch } from '../../EmptyStateSearch';
-import { UtcDate } from '../../UtcDate';
 import { EventLogActionPopoverContent } from './EventLogActionPopoverContent';
 
 export type SortDirection = 'asc' | 'desc';
@@ -120,7 +120,7 @@ export const EventLogTable: React.FunctionComponent<EventLogTableProps> = props 
                         ) : ('No actions')}
 
                     </Td>
-                    <Td><UtcDate date={ e.date } /></Td>
+                    <Td><DateFormat type="relative" date={ e.date } /></Td>
                 </Tr>
             ));
         }

--- a/src/pages/Integrations/List/useIntegrationRows.ts
+++ b/src/pages/Integrations/List/useIntegrationRows.ts
@@ -1,4 +1,4 @@
-import { addDangerNotification } from '@redhat-cloud-services/insights-common-typescript';
+import { addDangerNotification, fromUtc } from '@redhat-cloud-services/insights-common-typescript';
 import pLimit from 'p-limit';
 import { useCallback, useContext, useEffect, useState } from 'react';
 import { ClientContext } from 'react-fetching-library';
@@ -76,7 +76,7 @@ export const useIntegrationRows = (
                         if (response.payload && response.payload.status === 200) {
                             const last5 = response.payload.value.map(p => ({
                                 isSuccess: p.invocationResult,
-                                date: new Date(p.created as string)
+                                date: fromUtc(new Date(p.created as string))
                             }));
                             setIntegrationRowById(integrationId, {
                                 isConnectionAttemptLoading: false,


### PR DESCRIPTION
## Integration
#### Before
![Screenshot_2022-06-03_10-25-54](https://user-images.githubusercontent.com/3845764/171907682-40137db1-2043-415a-854b-2f435137d70b.png)

#### After
![Screenshot_2022-06-03_10-26-08](https://user-images.githubusercontent.com/3845764/171907681-7aba40ff-133a-4e2b-8829-f66e1c2719b5.png)

## Event log
#### Before
![Screenshot_2022-06-03_10-31-25](https://user-images.githubusercontent.com/3845764/171907896-64b54ef3-abed-4c77-a03b-a30172d17b9e.png)

#### After
![Screenshot_2022-06-03_10-31-09](https://user-images.githubusercontent.com/3845764/171907902-1154801e-20dc-4183-b049-98b849446c39.png)

Additionally fixed a bug - The integration time wasn't displaying correctly.