### PR TITLE
NOTIF-644 & NOTIF-645 Considers permissions of notifications:events:read

### DIFF
--- a/src/app/AppContext.tsx
+++ b/src/app/AppContext.tsx
@@ -9,6 +9,7 @@ export interface AppContext {
         canReadIntegrationsEndpoints: boolean;
         canWriteNotifications: boolean;
         canReadNotifications: boolean;
+        canReadEvents: boolean;
     },
     isOrgAdmin: boolean,
     server: Server
@@ -19,7 +20,8 @@ export const AppContext = React.createContext<AppContext>({
         canReadIntegrationsEndpoints: false,
         canReadNotifications: false,
         canWriteIntegrationsEndpoints: false,
-        canWriteNotifications: false
+        canWriteNotifications: false,
+        canReadEvents: false
     },
     isOrgAdmin: false,
     server: {

--- a/src/app/useApp.ts
+++ b/src/app/useApp.ts
@@ -52,7 +52,8 @@ export const useApp = (): Partial<AppContext> => {
             canWriteNotifications: rbac.hasPermission('notifications', 'notifications', 'write'),
             canReadNotifications: rbac.hasPermission('notifications', 'notifications', 'read'),
             canWriteIntegrationsEndpoints: rbac.hasPermission('integrations', 'endpoints', 'write'),
-            canReadIntegrationsEndpoints: rbac.hasPermission('integrations', 'endpoints', 'read')
+            canReadIntegrationsEndpoints: rbac.hasPermission('integrations', 'endpoints', 'read'),
+            canReadEvents: rbac.hasPermission('notifications', 'events', 'read')
         } : undefined,
         isOrgAdmin,
         server

--- a/src/components/ButtonLink.tsx
+++ b/src/components/ButtonLink.tsx
@@ -1,6 +1,18 @@
-import { Button, ButtonVariant } from '@patternfly/react-core';
+import { Button, ButtonProps } from '@patternfly/react-core';
 import * as React from 'react';
+import { Link, LinkProps } from 'react-router-dom';
 
-export const ButtonLink: React.FunctionComponent<{ navigate: () => void }> = (props) => {
-    return <Button variant={ ButtonVariant.secondary } onClick={ props.navigate }>{ props.children }</Button>;
+type ButtonLinkProps = ButtonProps & Omit<LinkProps, 'component'>;
+
+export const ButtonLink: React.FunctionComponent<ButtonLinkProps> = props => {
+
+    const InternalButtonLink: React.FunctionComponent<{ navigate: () => void }> = internalProps => {
+        return <Button { ...props } onClick={ internalProps.navigate }>
+            { props.children }
+        </Button>;
+    };
+
+    return <Link { ...props } component={ InternalButtonLink }>
+        { props.children }
+    </Link>;
 };

--- a/src/components/CheckReadPermissions.tsx
+++ b/src/components/CheckReadPermissions.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router-dom';
 
 import { useAppContext } from '../app/AppContext';
 import Config from '../config/Config';
+import { linkTo } from '../Routes';
 import { getSubApp } from '../utils/Basename';
 import { NotAuthorizedPage } from './NotAuthorized';
 
@@ -16,6 +17,10 @@ export const CheckReadPermissions: React.FunctionComponent = (props) => {
             case Config.integrations.subAppId:
                 return rbac?.canReadIntegrationsEndpoints;
             case Config.notifications.subAppId:
+                if (location.pathname === linkTo.eventLog()) {
+                    return rbac?.canReadEvents;
+                }
+
                 return rbac?.canReadNotifications;
         }
 

--- a/src/components/NotAuthorized.tsx
+++ b/src/components/NotAuthorized.tsx
@@ -8,6 +8,7 @@ import { useLocation, useParams } from 'react-router-dom';
 
 import Config from '../config/Config';
 import messages from '../properties/DefinedMessages';
+import { linkTo } from '../Routes';
 import { useGetBundles } from '../services/Notifications/GetBundles';
 import { Facet } from '../types/Notification';
 import { getSubApp } from '../utils/Basename';
@@ -15,6 +16,8 @@ import { getSubApp } from '../utils/Basename';
 interface NotificationListPageParams {
     bundleName: string;
 }
+
+const eventLogService = 'Event Log';
 
 export const NotAuthorizedPage: React.FunctionComponent = () => {
 
@@ -39,6 +42,10 @@ export const NotAuthorizedPage: React.FunctionComponent = () => {
             case Config.integrations.subAppId:
                 return intl.formatMessage(messages.integrations);
             case Config.notifications.subAppId:
+                if (location.pathname === linkTo.eventLog()) {
+                    return eventLogService;
+                }
+
                 return intl.formatMessage(messages.notifications);
             default:
                 return '';

--- a/src/pages/Integrations/List/__tests__/Page.test.tsx
+++ b/src/pages/Integrations/List/__tests__/Page.test.tsx
@@ -53,10 +53,7 @@ describe('src/pages/Integrations/List/Page', () => {
                     wrapper: getConfiguredAppWrapper({
                         appContext: {
                             rbac: {
-                                canWriteNotifications: true,
-                                canWriteIntegrationsEndpoints: false,
-                                canReadIntegrationsEndpoints: true,
-                                canReadNotifications: true
+                                canWriteIntegrationsEndpoints: false
                             }
                         }
                     })
@@ -96,16 +93,7 @@ describe('src/pages/Integrations/List/Page', () => {
             render(
                 <ConnectedIntegrationsListPage />
                 , {
-                    wrapper: getConfiguredAppWrapper({
-                        appContext: {
-                            rbac: {
-                                canWriteNotifications: true,
-                                canWriteIntegrationsEndpoints: true,
-                                canReadIntegrationsEndpoints: true,
-                                canReadNotifications: true
-                            }
-                        }
-                    })
+                    wrapper: getConfiguredAppWrapper()
                 }
             );
 
@@ -145,10 +133,7 @@ describe('src/pages/Integrations/List/Page', () => {
                     wrapper: getConfiguredAppWrapper({
                         appContext: {
                             rbac: {
-                                canWriteNotifications: true,
-                                canWriteIntegrationsEndpoints: false,
-                                canReadIntegrationsEndpoints: true,
-                                canReadNotifications: true
+                                canWriteIntegrationsEndpoints: false
                             }
                         }
                     })
@@ -191,16 +176,7 @@ describe('src/pages/Integrations/List/Page', () => {
             render(
                 <ConnectedIntegrationsListPage />
                 , {
-                    wrapper: getConfiguredAppWrapper({
-                        appContext: {
-                            rbac: {
-                                canWriteNotifications: true,
-                                canWriteIntegrationsEndpoints: true,
-                                canReadIntegrationsEndpoints: true,
-                                canReadNotifications: true
-                            }
-                        }
-                    })
+                    wrapper: getConfiguredAppWrapper()
                 }
             );
 
@@ -242,10 +218,7 @@ describe('src/pages/Integrations/List/Page', () => {
                     wrapper: getConfiguredAppWrapper({
                         appContext: {
                             rbac: {
-                                canWriteNotifications: true,
-                                canWriteIntegrationsEndpoints: false,
-                                canReadIntegrationsEndpoints: true,
-                                canReadNotifications: true
+                                canWriteIntegrationsEndpoints: false
                             }
                         }
                     })
@@ -303,16 +276,7 @@ describe('src/pages/Integrations/List/Page', () => {
             render(
                 <ConnectedIntegrationsListPage />
                 , {
-                    wrapper: getConfiguredAppWrapper({
-                        appContext: {
-                            rbac: {
-                                canWriteNotifications: true,
-                                canWriteIntegrationsEndpoints: true,
-                                canReadIntegrationsEndpoints: true,
-                                canReadNotifications: true
-                            }
-                        }
-                    })
+                    wrapper: getConfiguredAppWrapper()
                 }
             );
 

--- a/src/pages/Notifications/EventLog/EventLogPage.tsx
+++ b/src/pages/Notifications/EventLog/EventLogPage.tsx
@@ -1,10 +1,11 @@
+import { ButtonVariant } from '@patternfly/react-core';
 import { Main } from '@redhat-cloud-services/frontend-components';
 import { Direction, Sort } from '@redhat-cloud-services/insights-common-typescript';
 import assertNever from 'assert-never';
 import * as React from 'react';
 import { useParameterizedQuery } from 'react-fetching-library';
-import { Link } from 'react-router-dom';
 
+import { useAppContext } from '../../../app/AppContext';
 import { ButtonLink } from '../../../components/ButtonLink';
 import { EventLogDateFilterValue } from '../../../components/Notifications/EventLog/EventLogDateFilter';
 import { EventLogFilters } from '../../../components/Notifications/EventLog/EventLogFilter';
@@ -32,6 +33,7 @@ const RETENTION_DAYS = 14;
 
 export const EventLogPage: React.FunctionComponent = () => {
     const getEndpoint = useParameterizedQuery(getEndpointAction);
+    const { rbac } = useAppContext();
 
     const getBundles = useGetBundles(true);
     const bundles = React.useMemo(() => {
@@ -128,9 +130,9 @@ export const EventLogPage: React.FunctionComponent = () => {
             <PageHeader
                 title={ Messages.pages.notifications.eventLog.title }
                 subtitle={ Messages.pages.notifications.eventLog.subtitle }
-                action={ <Link component={ ButtonLink } to={ eventNotificationPageUrl } >
+                action={ <ButtonLink isDisabled={ !rbac.canReadEvents } to={ eventNotificationPageUrl } variant={ ButtonVariant.secondary }>
                     { Messages.pages.notifications.eventLog.viewNotifications }
-                </Link> }
+                </ButtonLink> }
             />
             <Main>
                 <EventLogToolbar

--- a/src/pages/Notifications/List/BundlePage.tsx
+++ b/src/pages/Notifications/List/BundlePage.tsx
@@ -1,11 +1,12 @@
+import { ButtonVariant } from '@patternfly/react-core';
 import { Main } from '@redhat-cloud-services/frontend-components';
 import {
     getInsights,
     localUrl
 } from '@redhat-cloud-services/insights-common-typescript';
 import { default as React } from 'react';
-import { Link } from 'react-router-dom';
 
+import { useAppContext } from '../../../app/AppContext';
 import { ButtonLink } from '../../../components/ButtonLink';
 import { PageHeader } from '../../../components/PageHeader';
 import { Messages } from '../../../properties/Messages';
@@ -20,6 +21,7 @@ interface NotificationListBundlePageProps {
 
 export const NotificationListBundlePage: React.FunctionComponent<NotificationListBundlePageProps> = (props) => {
 
+    const { rbac } = useAppContext();
     const eventLogPageUrl = React.useMemo(() => linkTo.eventLog(props.bundle.name), [ props.bundle.name ]);
 
     return (
@@ -31,12 +33,9 @@ export const NotificationListBundlePage: React.FunctionComponent<NotificationLis
                     them to different events. Users will be able to opt-in or out of receiving authorized event notifications in their
                 <a href={ localUrl(`/user-preferences/notifications/${props.bundle.name}`,
                     getInsights().chrome.isBeta()) }> User Preferences</a>.</span> }
-                action={ <Link
-                    component={ ButtonLink }
-                    to={ eventLogPageUrl }
-                >
+                action={ <ButtonLink isDisabled={ !rbac.canReadEvents } to={ eventLogPageUrl } variant={ ButtonVariant.secondary }>
                     { Messages.pages.notifications.list.viewHistory }
-                </Link> }
+                </ButtonLink> }
             />
             <Main>
                 <BundlePageBehaviorGroupContent applications={ props.applications } bundle={ props.bundle } />

--- a/src/pages/Notifications/List/__tests__/BundlePageBehaviorGroupContent.test.tsx
+++ b/src/pages/Notifications/List/__tests__/BundlePageBehaviorGroupContent.test.tsx
@@ -247,16 +247,7 @@ describe('src/pages/Notifications/List/BundlePageBehaviorGroupContent', () => {
         mockBehaviorGroups(behaviorGroups);
 
         render(<BundlePageBehaviorGroupContent applications={ applications } bundle={ bundle } />, {
-            wrapper: getConfiguredAppWrapper({
-                appContext: {
-                    rbac: {
-                        canWriteNotifications: true,
-                        canWriteIntegrationsEndpoints: true,
-                        canReadNotifications: true,
-                        canReadIntegrationsEndpoints: true
-                    }
-                }
-            })
+            wrapper: getConfiguredAppWrapper()
         });
 
         await waitForAsyncEvents();
@@ -283,9 +274,7 @@ describe('src/pages/Notifications/List/BundlePageBehaviorGroupContent', () => {
                 appContext: {
                     rbac: {
                         canWriteNotifications: false,
-                        canWriteIntegrationsEndpoints: false,
-                        canReadNotifications: true,
-                        canReadIntegrationsEndpoints: true
+                        canWriteIntegrationsEndpoints: false
                     }
                 }
             })
@@ -313,9 +302,7 @@ describe('src/pages/Notifications/List/BundlePageBehaviorGroupContent', () => {
                 appContext: {
                     rbac: {
                         canWriteNotifications: false,
-                        canWriteIntegrationsEndpoints: false,
-                        canReadNotifications: true,
-                        canReadIntegrationsEndpoints: true
+                        canWriteIntegrationsEndpoints: false
                     },
                     isOrgAdmin: false
                 }
@@ -348,9 +335,7 @@ describe('src/pages/Notifications/List/BundlePageBehaviorGroupContent', () => {
                 appContext: {
                     rbac: {
                         canWriteNotifications: false,
-                        canWriteIntegrationsEndpoints: false,
-                        canReadNotifications: true,
-                        canReadIntegrationsEndpoints: true
+                        canWriteIntegrationsEndpoints: false
                     },
                     isOrgAdmin: true
                 }

--- a/src/pages/Notifications/List/__tests__/Page.test.tsx
+++ b/src/pages/Notifications/List/__tests__/Page.test.tsx
@@ -609,10 +609,7 @@ describe('src/pages/Notifications/List/Page', () => {
                 ...routePropsPageForBundle('rhel'),
                 appContext: {
                     rbac: {
-                        canWriteNotifications: false,
-                        canWriteIntegrationsEndpoints: true,
-                        canReadIntegrationsEndpoints: true,
-                        canReadNotifications: true
+                        canWriteNotifications: false
                     }
                 },
                 skipIsBetaMock: true
@@ -644,15 +641,7 @@ describe('src/pages/Notifications/List/Page', () => {
         mockBehaviorGroupsOfEventTypes();
         render(<NotificationsListPage />, {
             wrapper: getConfiguredAppWrapper({
-                ...routePropsPageForBundle('rhel'),
-                appContext: {
-                    rbac: {
-                        canWriteNotifications: true,
-                        canWriteIntegrationsEndpoints: true,
-                        canReadIntegrationsEndpoints: true,
-                        canReadNotifications: true
-                    }
-                }
+                ...routePropsPageForBundle('rhel')
             })
         });
 
@@ -683,15 +672,7 @@ describe('src/pages/Notifications/List/Page', () => {
 
             render(<NotificationsListPage />, {
                 wrapper: getConfiguredAppWrapper({
-                    ...routePropsPageForBundle('rhel'),
-                    appContext: {
-                        rbac: {
-                            canWriteNotifications: true,
-                            canWriteIntegrationsEndpoints: true,
-                            canReadIntegrationsEndpoints: true,
-                            canReadNotifications: true
-                        }
-                    }
+                    ...routePropsPageForBundle('rhel')
                 })
             });
 
@@ -719,15 +700,7 @@ describe('src/pages/Notifications/List/Page', () => {
 
             render(<NotificationsListPage />, {
                 wrapper: getConfiguredAppWrapper({
-                    ...routePropsPageForBundle('rhel'),
-                    appContext: {
-                        rbac: {
-                            canWriteNotifications: true,
-                            canWriteIntegrationsEndpoints: true,
-                            canReadIntegrationsEndpoints: true,
-                            canReadNotifications: true
-                        }
-                    }
+                    ...routePropsPageForBundle('rhel')
                 })
             });
 
@@ -755,15 +728,7 @@ describe('src/pages/Notifications/List/Page', () => {
 
             render(<NotificationsListPage />, {
                 wrapper: getConfiguredAppWrapper({
-                    ...routePropsPageForBundle('rhel'),
-                    appContext: {
-                        rbac: {
-                            canWriteNotifications: true,
-                            canWriteIntegrationsEndpoints: true,
-                            canReadIntegrationsEndpoints: true,
-                            canReadNotifications: true
-                        }
-                    }
+                    ...routePropsPageForBundle('rhel')
                 })
             });
 
@@ -772,6 +737,37 @@ describe('src/pages/Notifications/List/Page', () => {
             userEvent.click(screen.getByText(/create new group/i));
             await waitForAsyncEvents();
             expect(screen.getByText(/Create new behavior group/i)).toBeVisible();
+        });
+
+        it('View Event Log is disabled if canReadEvents is false', async () => {
+            fetchMock.get('/api/notifications/v1.0/notifications/defaults', {
+                body: [] as Array<Schemas.Endpoint>
+            });
+            fetchMock.get(
+                `/api/notifications/v1.0/notifications/eventTypes/${defaultEventTypeId}`,
+                {
+                    body: []
+                }
+            );
+            mockEventTypes();
+            mockBehaviorGroupsOfEventTypes();
+            mockFacets();
+            mockBehaviorGroup();
+
+            render(<NotificationsListPage />, {
+                wrapper: getConfiguredAppWrapper({
+                    ...routePropsPageForBundle('rhel'),
+                    appContext: {
+                        rbac: {
+                            canReadEvents: false
+                        }
+                    }
+                })
+            });
+
+            await waitForAsyncEvents();
+
+            expect(screen.getByText(/view event log/i)).toBeDisabled();
         });
 
         it.each<[Environment, boolean]>([
@@ -805,15 +801,7 @@ describe('src/pages/Notifications/List/Page', () => {
 
             render(<NotificationsListPage />, {
                 wrapper: getConfiguredAppWrapper({
-                    ...routePropsPageForBundle('rhel'),
-                    appContext: {
-                        rbac: {
-                            canWriteNotifications: true,
-                            canWriteIntegrationsEndpoints: true,
-                            canReadIntegrationsEndpoints: true,
-                            canReadNotifications: true
-                        }
-                    }
+                    ...routePropsPageForBundle('rhel')
                 })
             });
 


### PR DESCRIPTION
## NOTIF-644 Disable "Show Event log" button if the user doesn't have permission

#### Before
![Screenshot_2022-06-03_11-04-18](https://user-images.githubusercontent.com/3845764/171937657-4f221f0d-0d52-4236-880b-a29079a3eaa8.png)

#### After
![Screenshot_2022-06-03_11-54-26](https://user-images.githubusercontent.com/3845764/171937656-ddc507ad-6099-4b05-837e-692b83cd9acf.png)

## NOTIF-645 Show an unauthorized access screen on event log page if user doesn't have access

![Screenshot_2022-06-03_11-58-44](https://user-images.githubusercontent.com/3845764/171937654-254f8440-c4de-47bb-b34e-622a953c8bd0.png)
