### PR TITLE
[EVNT-486] Making Spunk integration steps consistent

### DIFF
--- a/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
+++ b/src/pages/Integrations/SplunkSetup/SplunkSetupPage.tsx
@@ -68,12 +68,12 @@ export const SplunkSetupPage: React.FunctionComponent = () => {
                                     <ProgressStep
                                         isCurrent={ step === 1 }
                                         variant="success"
-                                        description="Create HEC"
+                                        description="Create Index and HEC"
                                         id="step1-splunk-app-step"
                                         titleId="step1-splunk-app-step"
                                         aria-label="completed Splunk app step (step 1)"
                                     >
-                                        Step 1 (Splunk app)
+                                        Step 1
                                     </ProgressStep>
                                     <ProgressStep
                                         isCurrent={ step === 2 }


### PR DESCRIPTION
Steps in backend automation should have the same name than steps in Splunk wizard.