### PR TITLE
NOTIF-436 Limit behavior group name length to 150 characters

### DIFF
--- a/src/pages/Notifications/BehaviorGroupWizard/Steps/BasicInformationStep.tsx
+++ b/src/pages/Notifications/BehaviorGroupWizard/Steps/BasicInformationStep.tsx
@@ -28,7 +28,7 @@ const BasicInformationStep: React.FunctionComponent = () => {
 };
 
 export const schema = Yup.object({
-    displayName: Yup.string().min(1).required('Behavior group name is required')
+    displayName: Yup.string().min(1).max(150, 'Must be 150 characters or less').required('Behavior group name is required')
 });
 
 export const useBasicInformationStep: CreateWizardStep = () => {


### PR DESCRIPTION

![Screenshot from 2022-07-11 18-15-08](https://user-images.githubusercontent.com/32950636/178267665-285aa6f9-8683-4567-83bd-2feefc821b87.png)

