### PR TITLE
NOTIF-735 Adds service-now integration (experimental)

### DIFF
--- a/src/components/Integrations/Form/IntegrationTypeCamelExtrasForm.tsx
+++ b/src/components/Integrations/Form/IntegrationTypeCamelExtrasForm.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { getOuiaProps } from '../../../utils/getOuiaProps';
 import { IntegrationTypeForm } from './IntegrationTypeForm';
 
-export const IntegrationTypeSplunkForm: React.FunctionComponent<IntegrationTypeForm> = (props) => {
+export const IntegrationTypeCamelExtrasForm: React.FunctionComponent<IntegrationTypeForm> = (props) => {
     return (
         <div className="pf-c-form" { ...getOuiaProps('Integrations/Camel/Splunk', props) } >
             <FormTextInput

--- a/src/components/Integrations/Form/IntegrationTypeForm.tsx
+++ b/src/components/Integrations/Form/IntegrationTypeForm.tsx
@@ -3,10 +3,10 @@ import { assertNever } from 'assert-never';
 import * as React from 'react';
 
 import { IntegrationType, isCamelType, UserIntegrationType } from '../../../types/Integration';
+import { IntegrationTypeCamelExtrasForm } from './IntegrationTypeCamelExtrasForm';
 import { IntegrationTypeCamelForm } from './IntegrationTypeCamelForm';
 import { IntegrationTypeHttpForm } from './IntegrationTypeHttpForm';
 import { IntegrationTypeSlackForm } from './IntegrationTypeSlackForm';
-import { IntegrationTypeSplunkForm } from './IntegrationTypeSplunkForm';
 
 export interface IntegrationTypeForm extends OuiaComponentProps {
     type: UserIntegrationType;
@@ -17,7 +17,8 @@ export const IntegrationTypeForm: React.FunctionComponent<IntegrationTypeForm> =
     if (isCamelType(props.type)) {
         switch (props.type) {
             case UserIntegrationType.SPLUNK:
-                return <IntegrationTypeSplunkForm { ...props } />;
+            case UserIntegrationType.SERVICE_NOW:
+                return <IntegrationTypeCamelExtrasForm { ...props } />;
             case UserIntegrationType.SLACK:
                 return <IntegrationTypeSlackForm { ...props } />;
         }

--- a/src/components/Notifications/EventLog/EventLogToolbar.tsx
+++ b/src/components/Notifications/EventLog/EventLogToolbar.tsx
@@ -9,10 +9,10 @@ import * as React from 'react';
 import { Dispatch } from 'react';
 import { SetStateAction } from 'react';
 
+import Config from '../../../config/Config';
 import { useIntegrations } from '../../../hooks/useIntegrations';
 import { useNotifications } from '../../../hooks/useNotifications';
 import { EventPeriod } from '../../../types/Event';
-import { IntegrationType } from '../../../types/Integration';
 import { Facet, NotificationType } from '../../../types/Notification';
 import { getOuiaProps } from '../../../utils/getOuiaProps';
 import { EventLogDateFilter, EventLogDateFilterValue } from './EventLogDateFilter';
@@ -53,21 +53,6 @@ const notificationTypes: Record<NotificationType, { name: string }> = {
     }
 };
 
-const integrationTypes: Record<IntegrationType, { name: string }> = {
-    [IntegrationType.SPLUNK]: {
-        name: 'Integration: Splunk'
-    },
-    [IntegrationType.SLACK]: {
-        name: 'Integration: Slack'
-    },
-    [IntegrationType.WEBHOOK]: {
-        name: 'Integration: Webhook'
-    },
-    [IntegrationType.EMAIL_SUBSCRIPTION]: {
-        name: 'Email'
-    }
-};
-
 const actionStatusMetadata = [
     {
         value: 'true',
@@ -93,8 +78,8 @@ export const EventLogToolbar: React.FunctionComponent<EventLogToolbarProps> = (p
         })).concat(
             integrations.map(integration => ({
                 value: integration.toUpperCase(),
-                chipValue: integrationTypes[integration].name,
-                label: integrationTypes[integration].name
+                chipValue: Config.integrations.types[integration].name,
+                label: Config.integrations.types[integration].name
             })));
     }, [ notifications, integrations ]);
 

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -24,6 +24,9 @@ const integrationTypes: Record<IntegrationType, IntegrationTypeConfigBase> = {
     [IntegrationType.SPLUNK]: {
         name: 'Splunk'
     },
+    [IntegrationType.SERVICE_NOW]: {
+        name: 'Service now'
+    },
     [IntegrationType.SLACK]: {
         name: 'Slack'
     },
@@ -78,7 +81,8 @@ const Config = {
             experimental: [
                 UserIntegrationType.WEBHOOK,
                 UserIntegrationType.SPLUNK,
-                UserIntegrationType.SLACK
+                UserIntegrationType.SLACK,
+                UserIntegrationType.SERVICE_NOW
             ]
         }
     },

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -25,7 +25,7 @@ const integrationTypes: Record<IntegrationType, IntegrationTypeConfigBase> = {
         name: 'Splunk'
     },
     [IntegrationType.SERVICE_NOW]: {
-        name: 'Service now'
+        name: 'ServiceNow'
     },
     [IntegrationType.SLACK]: {
         name: 'Slack'

--- a/src/types/Integration.ts
+++ b/src/types/Integration.ts
@@ -8,7 +8,7 @@ export enum IntegrationType {
     EMAIL_SUBSCRIPTION = 'email_subscription',
     SPLUNK = 'camel:splunk',
     SLACK = 'camel:slack',
-    SERVICE_NOW = 'camel:service_now'
+    SERVICE_NOW = 'camel:servicenow'
 }
 
 export const UserIntegrationType = {

--- a/src/types/Integration.ts
+++ b/src/types/Integration.ts
@@ -7,12 +7,14 @@ export enum IntegrationType {
     WEBHOOK = 'webhook',
     EMAIL_SUBSCRIPTION = 'email_subscription',
     SPLUNK = 'camel:splunk',
-    SLACK = 'camel:slack'
+    SLACK = 'camel:slack',
+    SERVICE_NOW = 'camel:service_now'
 }
 
 export const UserIntegrationType = {
     WEBHOOK: IntegrationType.WEBHOOK,
     SPLUNK: IntegrationType.SPLUNK,
+    SERVICE_NOW: IntegrationType.SERVICE_NOW,
     SLACK: IntegrationType.SLACK
 } as const;
 


### PR DESCRIPTION
The Service now integration type can only be accessed behind the experimental switch.
Internally, it is a `camel` type with the subtype `service_now`

![Screenshot_2022-08-09_14-06-23](https://user-images.githubusercontent.com/3845764/183751060-6ece0ba6-b593-4eed-8b8e-63eb89bc7ff4.png)

// cc: @vkrizan @jeromemarc @jpramos123 