### PR TITLE
NOTIF-802 Display the endpoint status

### DIFF
--- a/src/components/Integrations/Table.tsx
+++ b/src/components/Integrations/Table.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonVariant, EmptyStateVariant, Popover, Spinner, Switch } from '@patternfly/react-core';
+import { Button, ButtonVariant, EmptyStateVariant, Spinner, Switch } from '@patternfly/react-core';
 import { CubesIcon, HelpIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';

--- a/src/components/Integrations/Table.tsx
+++ b/src/components/Integrations/Table.tsx
@@ -41,6 +41,7 @@ import { EmptyStateSearch } from '../EmptyStateSearch';
 import { ConnectionDegraded } from './Table/ConnectionDegraded';
 import { ConnectionFailed } from './Table/ConnectionFailed';
 import { ExpandedContent } from './Table/ExpandedContent';
+import { IntegrationStatus } from './Table/IntegrationStatus';
 
 export type OnEnable = (integration: IntegrationRow, index: number, isChecked: boolean) => void;
 
@@ -215,6 +216,9 @@ const toTableRows = (integrations: Array<IntegrationRow>, onEnable?: OnEnable): 
                             />
                         )}
                     </>
+                },
+                {
+                    title: <><IntegrationStatus status={ integration.status } /></>
                 }
             ]
         });
@@ -256,6 +260,10 @@ const columns: Array<ICell> = [
     {
         title: Messages.components.integrations.table.columns.enabled,
         transforms: [ sortable ]
+    },
+    {
+        title: Messages.components.integrations.table.columns.status,
+        transforms: []
     }
 ];
 

--- a/src/components/Integrations/Table.tsx
+++ b/src/components/Integrations/Table.tsx
@@ -1,5 +1,5 @@
-import { EmptyStateVariant, Spinner, Switch, Text } from '@patternfly/react-core';
-import { CheckCircleIcon, CubesIcon, ExclamationCircleIcon, OffIcon } from '@patternfly/react-icons';
+import { Button, ButtonVariant, EmptyStateVariant, Popover, Spinner, Switch } from '@patternfly/react-core';
+import { CubesIcon, HelpIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import {
@@ -18,11 +18,7 @@ import {
     TableHeader
 } from '@patternfly/react-table';
 import {
-    global_danger_color_100,
-    global_spacer_md,
-    global_spacer_sm,
-    global_success_color_100,
-    global_warning_color_200
+    global_spacer_md
 } from '@patternfly/react-tokens';
 import { SkeletonTable } from '@redhat-cloud-services/frontend-components';
 import { Direction, OuiaComponentProps, Sort, UseSortReturn } from '@redhat-cloud-services/insights-common-typescript';
@@ -36,12 +32,15 @@ import Config from '../../config/Config';
 import messages from '../../properties/DefinedMessages';
 import { Messages } from '../../properties/Messages';
 import { IntegrationConnectionAttempt, UserIntegration } from '../../types/Integration';
+import { aggregateConnectionAttemptStatus, AggregatedConnectionAttemptStatus } from '../../utils/ConnectionAttemptStatus';
 import { getOuiaProps } from '../../utils/getOuiaProps';
 import { EmptyStateSearch } from '../EmptyStateSearch';
 import { ConnectionDegraded } from './Table/ConnectionDegraded';
 import { ConnectionFailed } from './Table/ConnectionFailed';
 import { ExpandedContent } from './Table/ExpandedContent';
 import { IntegrationStatus } from './Table/IntegrationStatus';
+import { LastConnectionHelpPopover } from './Table/LastConnectionHelpPopover';
+import { StatusUnknown } from './Table/Status';
 
 export type OnEnable = (integration: IntegrationRow, index: number, isChecked: boolean) => void;
 
@@ -64,13 +63,6 @@ export type IntegrationRow = UserIntegration & {
     lastConnectionAttempts?: Array<IntegrationConnectionAttempt>;
 }
 
-enum LastConnectionAttemptStatus {
-    UNKNOWN,
-    SUCCESS,
-    WARNING,
-    ERROR
-}
-
 const connectionAlertClassName = style({
     paddingBottom: global_spacer_md.var
 });
@@ -84,101 +76,24 @@ const isEnabledLoadingClassName = style({
     marginLeft: 10
 });
 
-const smallMarginLeft = style({
-    marginLeft: global_spacer_sm.var
-});
-
-const degradedClassName = style({
-    fontWeight: 600,
-    color: global_warning_color_200.var,
-    fontSize: 'var(--pf-global--FontSize--sm)'
-});
-
-const getLastConnectionAttemptStatus = (attempts: Array<IntegrationConnectionAttempt>): LastConnectionAttemptStatus => {
-    if (attempts.length === 0) {
-        return LastConnectionAttemptStatus.UNKNOWN;
-    }
-
-    const failures = attempts.filter(a => !a.isSuccess).length;
-
-    if (failures === attempts.length) {
-        return LastConnectionAttemptStatus.ERROR;
-    } else if (failures > 0) {
-        return LastConnectionAttemptStatus.WARNING;
-    }
-
-    return LastConnectionAttemptStatus.SUCCESS;
-};
-
 const getConnectionAlert = (attempts: Array<IntegrationConnectionAttempt>) => {
-    const status = getLastConnectionAttemptStatus(attempts);
+    const status = aggregateConnectionAttemptStatus(attempts);
     switch (status) {
-        case LastConnectionAttemptStatus.UNKNOWN:
-        case LastConnectionAttemptStatus.SUCCESS:
+        case AggregatedConnectionAttemptStatus.UNKNOWN:
+        case AggregatedConnectionAttemptStatus.SUCCESS:
             return null;
-        case LastConnectionAttemptStatus.ERROR:
+        case AggregatedConnectionAttemptStatus.ERROR:
             return (
                 <div className={ connectionAlertClassName }>
                     <ConnectionFailed attempts={ attempts } />
                 </div>
             );
-        case LastConnectionAttemptStatus.WARNING:
+        case AggregatedConnectionAttemptStatus.WARNING:
             return (
                 <div className={ connectionAlertClassName }>
                     <ConnectionDegraded attempts={ attempts } />
                 </div>
             );
-        default:
-            assertNever(status);
-    }
-};
-
-const LastConnectionAttemptSuccess: React.FunctionComponent = () => (
-    <>
-        <span>
-            <CheckCircleIcon color={ global_success_color_100.value } data-testid="success-icon" />
-            <span className={ smallMarginLeft }>Success</span>
-        </span>
-    </>
-);
-
-const LastConnectionAttemptError: React.FunctionComponent = () => (
-    <>
-        <span>
-            <ExclamationCircleIcon color={ global_danger_color_100.value } data-testid="fail-icon" />
-            <span className={ smallMarginLeft }>Failure</span>
-        </span>
-    </>
-);
-
-const getConnectionAttemptCell = (attempts: Array<IntegrationConnectionAttempt> | undefined, isLoading: boolean) => {
-    if (attempts === undefined) {
-        return 'Error fetching connection attempts';
-    }
-
-    if (isLoading) {
-        return <Spinner size="md" />;
-    }
-
-    const status = getLastConnectionAttemptStatus(attempts);
-    switch (status) {
-        case LastConnectionAttemptStatus.UNKNOWN:
-            return <>
-                <span>
-                    <OffIcon data-testid="off-icon" />
-                    <span className={ smallMarginLeft }>Unknown</span>
-                </span>
-            </>;
-        case LastConnectionAttemptStatus.SUCCESS:
-            return <><LastConnectionAttemptSuccess /></>;
-        case LastConnectionAttemptStatus.ERROR:
-            return <><LastConnectionAttemptError /></>;
-        case LastConnectionAttemptStatus.WARNING:
-            return <>
-                { attempts[0].isSuccess ? <LastConnectionAttemptSuccess /> : <LastConnectionAttemptError />}
-                <br />
-                <Text className={ degradedClassName }>Degraded connection</Text>
-            </>;
         default:
             assertNever(status);
     }
@@ -199,7 +114,12 @@ const toTableRows = (integrations: Array<IntegrationRow>, onEnable?: OnEnable): 
                     title: Config.integrations.types[integration.type].name
                 },
                 {
-                    title: getConnectionAttemptCell(integration.lastConnectionAttempts, integration.isConnectionAttemptLoading)
+                    title: <>
+                        { integration.lastConnectionAttempts === undefined ? <StatusUnknown /> : <IntegrationStatus
+                            status={ integration.status }
+                            lastConnectionAttempts={ integration.isConnectionAttemptLoading ? undefined : integration.lastConnectionAttempts }
+                        /> }
+                    </>
                 },
                 {
                     title: <>
@@ -216,9 +136,6 @@ const toTableRows = (integrations: Array<IntegrationRow>, onEnable?: OnEnable): 
                             />
                         )}
                     </>
-                },
-                {
-                    title: <><IntegrationStatus status={ integration.status } /></>
                 }
             ]
         });
@@ -254,16 +171,19 @@ const columns: Array<ICell> = [
         transforms: [ ]
     },
     {
-        title: Messages.components.integrations.table.columns.lastConnectionAttempt,
+        title: <>
+            <span>{ Messages.components.integrations.table.columns.lastConnectionAttempt }</span>
+            <LastConnectionHelpPopover>
+                <Button variant={ ButtonVariant.plain }>
+                    <HelpIcon />
+                </Button>
+            </LastConnectionHelpPopover>
+        </>,
         transforms: []
     },
     {
         title: Messages.components.integrations.table.columns.enabled,
         transforms: [ sortable ]
-    },
-    {
-        title: Messages.components.integrations.table.columns.status,
-        transforms: []
     }
 ];
 

--- a/src/components/Integrations/Table/IntegrationStatus.tsx
+++ b/src/components/Integrations/Table/IntegrationStatus.tsx
@@ -1,0 +1,43 @@
+import { Spinner } from '@patternfly/react-core';
+import { CheckCircleIcon, ErrorCircleOIcon, ExclamationCircleIcon, UnknownIcon } from '@patternfly/react-icons';
+import { global_danger_color_100, global_spacer_sm, global_success_color_100 } from '@patternfly/react-tokens';
+import React from 'react';
+import { style } from 'typestyle';
+
+import { Integration } from '../../../types/Integration';
+
+const smallMarginLeft = style({
+    marginLeft: global_spacer_sm.var
+});
+
+interface StatusProps {
+    text: string;
+}
+
+const Status: React.FunctionComponent<StatusProps> = (props) => (
+    <span>
+        { props.children }
+        <span className={ smallMarginLeft }>{ props.text }</span>
+    </span>
+);
+
+export interface IntegrationStatusProps {
+    status: Integration['status'];
+}
+
+export const IntegrationStatus: React.FunctionComponent<IntegrationStatusProps> = props => {
+    switch (props.status ?? 'UNKNOWN') {
+        case 'UNKNOWN':
+            return <Status text="Unknown"><UnknownIcon /></Status>;
+        case 'DELETING':
+            return <Status text="Deleting"><ExclamationCircleIcon color={ global_danger_color_100.value } /></Status>;
+        case 'FAILED':
+            return <Status text="Failed"><ErrorCircleOIcon color={ global_danger_color_100.value } /></Status>;
+        case 'PROVISIONING':
+            return <Status text="Provisioning"><Spinner size="md" /></Status>;
+        case 'READY':
+            return <Status text="Ready"><CheckCircleIcon color={ global_success_color_100.value } /></Status>;
+        case 'NEW':
+            return <Status text="New"><Spinner size="md" /></Status>;
+    }
+};

--- a/src/components/Integrations/Table/IntegrationStatus.tsx
+++ b/src/components/Integrations/Table/IntegrationStatus.tsx
@@ -1,43 +1,43 @@
-import { Spinner } from '@patternfly/react-core';
-import { CheckCircleIcon, ErrorCircleOIcon, ExclamationCircleIcon, UnknownIcon } from '@patternfly/react-icons';
-import { global_danger_color_100, global_spacer_sm, global_success_color_100 } from '@patternfly/react-tokens';
+import { Skeleton } from '@patternfly/react-core';
 import React from 'react';
-import { style } from 'typestyle';
 
-import { Integration } from '../../../types/Integration';
-
-const smallMarginLeft = style({
-    marginLeft: global_spacer_sm.var
-});
-
-interface StatusProps {
-    text: string;
-}
-
-const Status: React.FunctionComponent<StatusProps> = (props) => (
-    <span>
-        { props.children }
-        <span className={ smallMarginLeft }>{ props.text }</span>
-    </span>
-);
+import { Integration, IntegrationConnectionAttempt } from '../../../types/Integration';
+import { aggregateConnectionAttemptStatus, AggregatedConnectionAttemptStatus } from '../../../utils/ConnectionAttemptStatus';
+import { StatusCreationFailure, StatusEventFailure, StatusProcessing, StatusReady, StatusSuccess } from './Status';
 
 export interface IntegrationStatusProps {
     status: Integration['status'];
+    lastConnectionAttempts: Array<IntegrationConnectionAttempt> | undefined;
 }
 
 export const IntegrationStatus: React.FunctionComponent<IntegrationStatusProps> = props => {
-    switch (props.status ?? 'UNKNOWN') {
-        case 'UNKNOWN':
-            return <Status text="Unknown"><UnknownIcon /></Status>;
-        case 'DELETING':
-            return <Status text="Deleting"><ExclamationCircleIcon color={ global_danger_color_100.value } /></Status>;
-        case 'FAILED':
-            return <Status text="Failed"><ErrorCircleOIcon color={ global_danger_color_100.value } /></Status>;
-        case 'PROVISIONING':
-            return <Status text="Provisioning"><Spinner size="md" /></Status>;
-        case 'READY':
-            return <Status text="Ready"><CheckCircleIcon color={ global_success_color_100.value } /></Status>;
-        case 'NEW':
-            return <Status text="New"><Spinner size="md" /></Status>;
+    const status = props.status ?? 'UNKNOWN';
+    if (status === 'FAILED' || status === 'PROVISIONING' || status === 'DELETING') {
+        switch (status) {
+            case 'FAILED':
+                return <StatusCreationFailure />;
+            case 'DELETING':
+            case 'PROVISIONING':
+                return <StatusProcessing />;
+        }
+    }
+
+    if (!props.lastConnectionAttempts) {
+        return <Skeleton data-testid="skeleton-loading" width="80%" />;
+    }
+
+    const aggregatedConnectionAttemptStatus = aggregateConnectionAttemptStatus(props.lastConnectionAttempts);
+
+    // No attempts found
+    if (aggregatedConnectionAttemptStatus === AggregatedConnectionAttemptStatus.UNKNOWN) {
+        return <StatusReady />;
+    }
+
+    const lastConnectionAttemptStatus = props.lastConnectionAttempts[0].isSuccess;
+    const isDegraded = aggregatedConnectionAttemptStatus === AggregatedConnectionAttemptStatus.WARNING;
+    if (lastConnectionAttemptStatus) {
+        return <StatusSuccess isDegraded={ isDegraded } />;
+    } else {
+        return <StatusEventFailure isDegraded={ isDegraded } />;
     }
 };

--- a/src/components/Integrations/Table/LastConnectionHelpPopover.tsx
+++ b/src/components/Integrations/Table/LastConnectionHelpPopover.tsx
@@ -1,0 +1,57 @@
+import { Popover, Text, TextContent } from '@patternfly/react-core';
+import { TableComposable, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import { important } from 'csx';
+import * as React from 'react';
+import { style } from 'typestyle';
+
+import { StatusCreationFailure, StatusEventFailure, StatusProcessing, StatusReady, StatusSuccess } from './Status';
+
+const removeBorderBottomClass = style({
+    borderBottom: important('none')
+});
+
+export const LastConnectionHelpPopover: React.FunctionComponent<unknown> = props => {
+    return <Popover
+        hasAutoWidth
+        headerContent={ <TextContent>
+            <Text component="h6">
+                Last connection attempt status meanings
+            </Text>
+        </TextContent> }
+        bodyContent={ <TableComposable
+            variant={ TableVariant.compact }
+            borders={ false }
+        >
+            <Thead>
+                <Tr className={ removeBorderBottomClass }>
+                    <Th>Status</Th>
+                    <Th>Meaning</Th>
+                </Tr>
+            </Thead>
+            <Tbody>
+                <Tr>
+                    <Td><StatusSuccess /></Td>
+                    <Td>The last connection attempt succeeded</Td>
+                </Tr>
+                <Tr>
+                    <Td><StatusEventFailure /></Td>
+                    <Td>The last connection attempt failed</Td>
+                </Tr>
+                <Tr>
+                    <Td><StatusCreationFailure /></Td>
+                    <Td>Integration creation failed. Configuration error</Td>
+                </Tr>
+                <Tr>
+                    <Td><StatusReady /></Td>
+                    <Td>Your integration configuration was successful</Td>
+                </Tr>
+                <Tr>
+                    <Td><StatusProcessing /></Td>
+                    <Td>Integration configuration processing</Td>
+                </Tr>
+            </Tbody>
+        </TableComposable> }
+    >
+        <>{ props.children }</>
+    </Popover>;
+};

--- a/src/components/Integrations/Table/Status.tsx
+++ b/src/components/Integrations/Table/Status.tsx
@@ -1,0 +1,62 @@
+import { HelperText, HelperTextItem } from '@patternfly/react-core';
+import { CheckCircleIcon, ExclamationCircleIcon, InProgressIcon, UnknownIcon } from '@patternfly/react-icons';
+import { global_danger_color_100, global_spacer_sm, global_success_color_100 } from '@patternfly/react-tokens';
+import React from 'react';
+import { style } from 'typestyle';
+
+const smallMarginLeft = style({
+    marginLeft: global_spacer_sm.var
+});
+
+const degradedClassName = style({
+    fontWeight: 600
+});
+
+interface StatusProps {
+    text: string;
+    isDegraded?: boolean;
+}
+
+interface SpecificStatusProps {
+    isDegraded?: boolean;
+}
+
+const Status: React.FunctionComponent<StatusProps> = (props) => (
+    <span>
+        { props.children }
+        <span className={ smallMarginLeft }>{ props.text }</span>
+        { props.isDegraded && <HelperText>
+            <HelperTextItem className={ degradedClassName } variant="warning">Degraded connection</HelperTextItem>
+        </HelperText> }
+    </span>
+);
+
+export const StatusSuccess: React.FunctionComponent<SpecificStatusProps> = props =>
+    <Status text="Success" isDegraded={ props.isDegraded }>
+        <CheckCircleIcon data-testid="success-icon" color={ global_success_color_100.value } />
+    </Status>;
+
+export const StatusEventFailure: React.FunctionComponent<SpecificStatusProps> = props =>
+    <Status text="Event failure" isDegraded={ props.isDegraded }>
+        <ExclamationCircleIcon data-testid="fail-icon" color={ global_danger_color_100.value } />
+    </Status>;
+
+export const StatusReady: React.FunctionComponent<unknown> = () =>
+    <Status text="Ready">
+        <CheckCircleIcon data-testid="success-icon" color={ global_success_color_100.value } />
+    </Status>;
+
+export const StatusCreationFailure: React.FunctionComponent<unknown> = () =>
+    <Status text="Creation failure">
+        <ExclamationCircleIcon data-testid="fail-icon" color={ global_danger_color_100.value } />
+    </Status>;
+
+export const StatusProcessing: React.FunctionComponent<unknown> = () =>
+    <Status text="Processing">
+        <InProgressIcon data-testid="in-progress-icon" />
+    </Status>;
+
+export const StatusUnknown: React.FunctionComponent<unknown> = () =>
+    <Status text="Error loading status">
+        <UnknownIcon data-testid="unknown-icon" />
+    </Status>;

--- a/src/components/Integrations/__tests__/DeleteModal.test.tsx
+++ b/src/components/Integrations/__tests__/DeleteModal.test.tsx
@@ -24,7 +24,9 @@ describe('src/components/Integrations/DeleteModal', () => {
                     id: '123',
                     secretToken: 'foo',
                     method: Schemas.HttpType.Enum.GET,
-                    sslVerificationEnabled: false
+                    sslVerificationEnabled: false,
+                    status: 'READY',
+                    serverErrors: 5
                 } }
             />
         );
@@ -84,7 +86,9 @@ describe('src/components/Integrations/DeleteModal', () => {
                     id: '123',
                     secretToken: 'foo',
                     method: Schemas.HttpType.Enum.GET,
-                    sslVerificationEnabled: false
+                    sslVerificationEnabled: false,
+                    status: 'READY',
+                    serverErrors: 5
                 } }
             />
         );
@@ -108,7 +112,9 @@ describe('src/components/Integrations/DeleteModal', () => {
                     id: '123',
                     secretToken: 'foo',
                     method: Schemas.HttpType.Enum.GET,
-                    sslVerificationEnabled: false
+                    sslVerificationEnabled: false,
+                    status: 'READY',
+                    serverErrors: 5
                 } }
             />
         );
@@ -169,7 +175,9 @@ describe('src/components/Integrations/DeleteModal', () => {
                     id: '123',
                     secretToken: 'foo',
                     method: Schemas.HttpType.Enum.GET,
-                    sslVerificationEnabled: false
+                    sslVerificationEnabled: false,
+                    status: 'READY',
+                    serverErrors: 5
                 } }
             />
         );
@@ -209,7 +217,9 @@ describe('src/components/Integrations/DeleteModal', () => {
                     id: '123',
                     secretToken: 'foo',
                     method: Schemas.HttpType.Enum.GET,
-                    sslVerificationEnabled: false
+                    sslVerificationEnabled: false,
+                    status: 'READY',
+                    serverErrors: 5
                 } }
             />
         );
@@ -237,7 +247,9 @@ describe('src/components/Integrations/DeleteModal', () => {
                     id: '123',
                     secretToken: 'foo',
                     method: Schemas.HttpType.Enum.GET,
-                    sslVerificationEnabled: false
+                    sslVerificationEnabled: false,
+                    status: 'READY',
+                    serverErrors: 5
                 } }
             />
         );

--- a/src/components/Integrations/__tests__/Table.test.tsx
+++ b/src/components/Integrations/__tests__/Table.test.tsx
@@ -250,10 +250,10 @@ describe('components/Integrations/Table', () => {
             actionResolver={ jest.fn(() => []) }
         /></IntlProvider>);
 
-        const lastConnectionAttemptText = screen.getByText('Unknown');
-
-        expect(lastConnectionAttemptText).toBeVisible();
-        expect(screen.getByTestId('off-icon')).toBeVisible();
+        const offIcon = screen.getByTestId('off-icon');
+        expect(offIcon).toBeVisible();
+        expect(offIcon.parentElement).toBeTruthy();
+        expect(getByText(offIcon.parentElement as HTMLElement, 'Unknown')).toBeVisible();
         expect(screen.queryByText(/degraded connection/i)).toBeFalsy();
     });
 

--- a/src/generated/OpenapiIntegrations.ts
+++ b/src/generated/OpenapiIntegrations.ts
@@ -28,32 +28,32 @@ export namespace Schemas {
 
   export const AggregationEmailTemplate = zodSchemaAggregationEmailTemplate();
   export type AggregationEmailTemplate = {
-    application?: Application1 | undefined | null;
+    application?: Application | undefined | null;
     application_id?: UUID | undefined | null;
     body_template?: Template | undefined | null;
     body_template_id: UUID;
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     id?: UUID | undefined | null;
     subject_template?: Template | undefined | null;
     subject_template_id: UUID;
     subscription_type: EmailSubscriptionType;
-    updated?: string | undefined | null;
+    updated?: LocalDateTime | undefined | null;
   };
 
   export const Application = zodSchemaApplication();
   export type Application = {
+    bundle_id: UUID;
+    created?: LocalDateTime | undefined | null;
     display_name: string;
-    id: UUID;
+    id?: UUID | undefined | null;
+    name: string;
+    updated?: LocalDateTime | undefined | null;
   };
 
   export const Application1 = zodSchemaApplication1();
   export type Application1 = {
-    bundle_id: UUID;
-    created?: string | undefined | null;
     display_name: string;
-    id?: UUID | undefined | null;
-    name: string;
-    updated?: string | undefined | null;
+    id: UUID;
   };
 
   export const BasicAuthentication = zodSchemaBasicAuthentication();
@@ -68,16 +68,16 @@ export namespace Schemas {
     behaviors?: Array<EventTypeBehavior> | undefined | null;
     bundle?: Bundle | undefined | null;
     bundle_id: UUID;
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     default_behavior?: boolean | undefined | null;
     display_name: string;
     id?: UUID | undefined | null;
-    updated?: string | undefined | null;
+    updated?: LocalDateTime | undefined | null;
   };
 
   export const BehaviorGroupAction = zodSchemaBehaviorGroupAction();
   export type BehaviorGroupAction = {
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     endpoint?: Endpoint | undefined | null;
     id?: BehaviorGroupActionId | undefined | null;
   };
@@ -90,11 +90,11 @@ export namespace Schemas {
 
   export const Bundle = zodSchemaBundle();
   export type Bundle = {
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     display_name: string;
     id?: UUID | undefined | null;
     name: string;
-    updated?: string | undefined | null;
+    updated?: LocalDateTime | undefined | null;
   };
 
   export const CamelProperties = zodSchemaCamelProperties();
@@ -108,7 +108,6 @@ export namespace Schemas {
       | undefined
       | null;
     secret_token?: string | undefined | null;
-    sub_type?: string | undefined | null;
     url: string;
   };
 
@@ -125,7 +124,7 @@ export namespace Schemas {
     zodSchemaCreateBehaviorGroupResponse();
   export type CreateBehaviorGroupResponse = {
     bundle_id: UUID;
-    created: string;
+    created: LocalDateTime;
     display_name: string;
     endpoints: Array<string>;
     event_types: Array<string>;
@@ -134,8 +133,8 @@ export namespace Schemas {
 
   export const CurrentStatus = zodSchemaCurrentStatus();
   export type CurrentStatus = {
-    end_time?: string | undefined | null;
-    start_time?: string | undefined | null;
+    end_time?: LocalDateTime | undefined | null;
+    start_time?: LocalDateTime | undefined | null;
     status: Status;
   };
 
@@ -152,7 +151,7 @@ export namespace Schemas {
 
   export const Endpoint = zodSchemaEndpoint();
   export type Endpoint = {
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     description: string;
     enabled?: boolean | undefined | null;
     id?: UUID | undefined | null;
@@ -161,10 +160,11 @@ export namespace Schemas {
       | (WebhookProperties | EmailSubscriptionProperties | CamelProperties)
       | undefined
       | null;
+    server_errors?: number | undefined | null;
     status?: EndpointStatus | undefined | null;
     sub_type?: string | undefined | null;
     type: EndpointType;
-    updated?: string | undefined | null;
+    updated?: LocalDateTime | undefined | null;
   };
 
   export const EndpointPage = zodSchemaEndpointPage();
@@ -203,7 +203,7 @@ export namespace Schemas {
     actions: Array<EventLogEntryAction>;
     application: string;
     bundle: string;
-    created: string;
+    created: LocalDateTime;
     event_type: string;
     id: UUID;
     payload?: string | undefined | null;
@@ -226,7 +226,7 @@ export namespace Schemas {
 
   export const EventType = zodSchemaEventType();
   export type EventType = {
-    application?: Application1 | undefined | null;
+    application?: Application | undefined | null;
     application_id: UUID;
     description?: string | undefined | null;
     display_name: string;
@@ -236,7 +236,7 @@ export namespace Schemas {
 
   export const EventTypeBehavior = zodSchemaEventTypeBehavior();
   export type EventTypeBehavior = {
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     event_type?: EventType | undefined | null;
     id?: EventTypeBehaviorId | undefined | null;
   };
@@ -262,13 +262,13 @@ export namespace Schemas {
   export type InstantEmailTemplate = {
     body_template?: Template | undefined | null;
     body_template_id: UUID;
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     event_type?: EventType | undefined | null;
     event_type_id?: UUID | undefined | null;
     id?: UUID | undefined | null;
     subject_template?: Template | undefined | null;
     subject_template_id: UUID;
-    updated?: string | undefined | null;
+    updated?: LocalDateTime | undefined | null;
   };
 
   export const InternalApplicationUserPermission =
@@ -288,10 +288,16 @@ export namespace Schemas {
 
   export const InternalUserPermissions = zodSchemaInternalUserPermissions();
   export type InternalUserPermissions = {
-    applications: Array<Application>;
+    applications: Array<Application1>;
     is_admin: boolean;
     roles: Array<string>;
   };
+
+  export const LocalDate = zodSchemaLocalDate();
+  export type LocalDate = string;
+
+  export const LocalDateTime = zodSchemaLocalDateTime();
+  export type LocalDateTime = string;
 
   export const MessageValidationResponse = zodSchemaMessageValidationResponse();
   export type MessageValidationResponse = {
@@ -307,7 +313,7 @@ export namespace Schemas {
 
   export const NotificationHistory = zodSchemaNotificationHistory();
   export type NotificationHistory = {
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     details?:
       | {
           [x: string]: unknown;
@@ -372,12 +378,12 @@ export namespace Schemas {
 
   export const Template = zodSchemaTemplate();
   export type Template = {
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     data: string;
     description: string;
     id?: UUID | undefined | null;
     name: string;
-    updated?: string | undefined | null;
+    updated?: LocalDateTime | undefined | null;
   };
 
   export const UUID = zodSchemaUUID();
@@ -386,7 +392,6 @@ export namespace Schemas {
   export const UpdateBehaviorGroupRequest =
     zodSchemaUpdateBehaviorGroupRequest();
   export type UpdateBehaviorGroupRequest = {
-    bundle_id?: UUID | undefined | null;
     display_name?: string | undefined | null;
     endpoint_ids?: Array<string> | undefined | null;
     event_type_ids?: Array<string> | undefined | null;
@@ -427,16 +432,16 @@ export namespace Schemas {
   function zodSchemaAggregationEmailTemplate() {
       return z
       .object({
-          application: zodSchemaApplication1().optional().nullable(),
+          application: zodSchemaApplication().optional().nullable(),
           application_id: zodSchemaUUID().optional().nullable(),
           body_template: zodSchemaTemplate().optional().nullable(),
           body_template_id: zodSchemaUUID(),
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           id: zodSchemaUUID().optional().nullable(),
           subject_template: zodSchemaTemplate().optional().nullable(),
           subject_template_id: zodSchemaUUID(),
           subscription_type: zodSchemaEmailSubscriptionType(),
-          updated: z.string().optional().nullable()
+          updated: zodSchemaLocalDateTime().optional().nullable()
       })
       .nonstrict();
   }
@@ -444,8 +449,12 @@ export namespace Schemas {
   function zodSchemaApplication() {
       return z
       .object({
+          bundle_id: zodSchemaUUID(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           display_name: z.string(),
-          id: zodSchemaUUID()
+          id: zodSchemaUUID().optional().nullable(),
+          name: z.string(),
+          updated: zodSchemaLocalDateTime().optional().nullable()
       })
       .nonstrict();
   }
@@ -453,12 +462,8 @@ export namespace Schemas {
   function zodSchemaApplication1() {
       return z
       .object({
-          bundle_id: zodSchemaUUID(),
-          created: z.string().optional().nullable(),
           display_name: z.string(),
-          id: zodSchemaUUID().optional().nullable(),
-          name: z.string(),
-          updated: z.string().optional().nullable()
+          id: zodSchemaUUID()
       })
       .nonstrict();
   }
@@ -479,11 +484,11 @@ export namespace Schemas {
           behaviors: z.array(zodSchemaEventTypeBehavior()).optional().nullable(),
           bundle: zodSchemaBundle().optional().nullable(),
           bundle_id: zodSchemaUUID(),
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           default_behavior: z.boolean().optional().nullable(),
           display_name: z.string(),
           id: zodSchemaUUID().optional().nullable(),
-          updated: z.string().optional().nullable()
+          updated: zodSchemaLocalDateTime().optional().nullable()
       })
       .nonstrict();
   }
@@ -491,7 +496,7 @@ export namespace Schemas {
   function zodSchemaBehaviorGroupAction() {
       return z
       .object({
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           endpoint: zodSchemaEndpoint().optional().nullable(),
           id: zodSchemaBehaviorGroupActionId().optional().nullable()
       })
@@ -510,11 +515,11 @@ export namespace Schemas {
   function zodSchemaBundle() {
       return z
       .object({
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           display_name: z.string(),
           id: zodSchemaUUID().optional().nullable(),
           name: z.string(),
-          updated: z.string().optional().nullable()
+          updated: zodSchemaLocalDateTime().optional().nullable()
       })
       .nonstrict();
   }
@@ -528,7 +533,6 @@ export namespace Schemas {
           disable_ssl_verification: z.boolean(),
           extras: z.record(z.string()).optional().nullable(),
           secret_token: z.string().optional().nullable(),
-          sub_type: z.string().optional().nullable(),
           url: z.string()
       })
       .nonstrict();
@@ -549,7 +553,7 @@ export namespace Schemas {
       return z
       .object({
           bundle_id: zodSchemaUUID(),
-          created: z.string(),
+          created: zodSchemaLocalDateTime(),
           display_name: z.string(),
           endpoints: z.array(z.string()),
           event_types: z.array(z.string()),
@@ -561,8 +565,8 @@ export namespace Schemas {
   function zodSchemaCurrentStatus() {
       return z
       .object({
-          end_time: z.string().optional().nullable(),
-          start_time: z.string().optional().nullable(),
+          end_time: zodSchemaLocalDateTime().optional().nullable(),
+          start_time: zodSchemaLocalDateTime().optional().nullable(),
           status: zodSchemaStatus()
       })
       .nonstrict();
@@ -585,7 +589,7 @@ export namespace Schemas {
   function zodSchemaEndpoint() {
       return z
       .object({
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           description: z.string(),
           enabled: z.boolean().optional().nullable(),
           id: zodSchemaUUID().optional().nullable(),
@@ -598,10 +602,11 @@ export namespace Schemas {
           ])
           .optional()
           .nullable(),
+          server_errors: z.number().int().optional().nullable(),
           status: zodSchemaEndpointStatus().optional().nullable(),
           sub_type: z.string().optional().nullable(),
           type: zodSchemaEndpointType(),
-          updated: z.string().optional().nullable()
+          updated: zodSchemaLocalDateTime().optional().nullable()
       })
       .nonstrict();
   }
@@ -645,7 +650,7 @@ export namespace Schemas {
           actions: z.array(zodSchemaEventLogEntryAction()),
           application: z.string(),
           bundle: z.string(),
-          created: z.string(),
+          created: zodSchemaLocalDateTime(),
           event_type: z.string(),
           id: zodSchemaUUID(),
           payload: z.string().optional().nullable()
@@ -669,7 +674,7 @@ export namespace Schemas {
   function zodSchemaEventType() {
       return z
       .object({
-          application: zodSchemaApplication1().optional().nullable(),
+          application: zodSchemaApplication().optional().nullable(),
           application_id: zodSchemaUUID(),
           description: z.string().optional().nullable(),
           display_name: z.string(),
@@ -682,7 +687,7 @@ export namespace Schemas {
   function zodSchemaEventTypeBehavior() {
       return z
       .object({
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           event_type: zodSchemaEventType().optional().nullable(),
           id: zodSchemaEventTypeBehaviorId().optional().nullable()
       })
@@ -721,13 +726,13 @@ export namespace Schemas {
       .object({
           body_template: zodSchemaTemplate().optional().nullable(),
           body_template_id: zodSchemaUUID(),
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           event_type: zodSchemaEventType().optional().nullable(),
           event_type_id: zodSchemaUUID().optional().nullable(),
           id: zodSchemaUUID().optional().nullable(),
           subject_template: zodSchemaTemplate().optional().nullable(),
           subject_template_id: zodSchemaUUID(),
-          updated: z.string().optional().nullable()
+          updated: zodSchemaLocalDateTime().optional().nullable()
       })
       .nonstrict();
   }
@@ -755,11 +760,19 @@ export namespace Schemas {
   function zodSchemaInternalUserPermissions() {
       return z
       .object({
-          applications: z.array(zodSchemaApplication()),
+          applications: z.array(zodSchemaApplication1()),
           is_admin: z.boolean(),
           roles: z.array(z.string())
       })
       .nonstrict();
+  }
+
+  function zodSchemaLocalDate() {
+      return z.string();
+  }
+
+  function zodSchemaLocalDateTime() {
+      return z.string();
   }
 
   function zodSchemaMessageValidationResponse() {
@@ -781,7 +794,7 @@ export namespace Schemas {
   function zodSchemaNotificationHistory() {
       return z
       .object({
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           details: z.record(z.unknown()).optional().nullable(),
           endpointId: zodSchemaUUID().optional().nullable(),
           endpointSubType: z.string().optional().nullable(),
@@ -856,12 +869,12 @@ export namespace Schemas {
   function zodSchemaTemplate() {
       return z
       .object({
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           data: z.string(),
           description: z.string(),
           id: zodSchemaUUID().optional().nullable(),
           name: z.string(),
-          updated: z.string().optional().nullable()
+          updated: zodSchemaLocalDateTime().optional().nullable()
       })
       .nonstrict();
   }
@@ -873,7 +886,6 @@ export namespace Schemas {
   function zodSchemaUpdateBehaviorGroupRequest() {
       return z
       .object({
-          bundle_id: zodSchemaUUID().optional().nullable(),
           display_name: z.string().optional().nullable(),
           endpoint_ids: z.array(z.string()).optional().nullable(),
           event_type_ids: z.array(z.string()).optional().nullable()
@@ -902,6 +914,7 @@ export namespace Schemas {
 
 export namespace Operations {
   // GET /endpoints
+  // List endpoints
   export namespace EndpointResourceGetEndpoints {
     const Active = z.boolean();
     type Active = boolean;
@@ -977,6 +990,7 @@ export namespace Operations {
     };
   }
   // POST /endpoints
+  // Create a new endpoint
   export namespace EndpointResourceCreateEndpoint {
     export interface Params {
       body: Schemas.Endpoint;
@@ -984,6 +998,7 @@ export namespace Operations {
 
     export type Payload =
       | ValidatedResponse<'Endpoint', 200, Schemas.Endpoint>
+      | ValidatedResponse<'__Empty', 400, Schemas.__Empty>
       | ValidatedResponse<'__Empty', 401, Schemas.__Empty>
       | ValidatedResponse<'__Empty', 403, Schemas.__Empty>
       | ValidatedResponse<'unknown', undefined, unknown>;
@@ -997,6 +1012,7 @@ export namespace Operations {
         .config({
             rules: [
                 new ValidateRule(Schemas.Endpoint, 'Endpoint', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 400),
                 new ValidateRule(Schemas.__Empty, '__Empty', 401),
                 new ValidateRule(Schemas.__Empty, '__Empty', 403)
             ]

--- a/src/generated/OpenapiNotifications.ts
+++ b/src/generated/OpenapiNotifications.ts
@@ -28,32 +28,32 @@ export namespace Schemas {
 
   export const AggregationEmailTemplate = zodSchemaAggregationEmailTemplate();
   export type AggregationEmailTemplate = {
-    application?: Application1 | undefined | null;
+    application?: Application | undefined | null;
     application_id?: UUID | undefined | null;
     body_template?: Template | undefined | null;
     body_template_id: UUID;
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     id?: UUID | undefined | null;
     subject_template?: Template | undefined | null;
     subject_template_id: UUID;
     subscription_type: EmailSubscriptionType;
-    updated?: string | undefined | null;
+    updated?: LocalDateTime | undefined | null;
   };
 
   export const Application = zodSchemaApplication();
   export type Application = {
+    bundle_id: UUID;
+    created?: LocalDateTime | undefined | null;
     display_name: string;
-    id: UUID;
+    id?: UUID | undefined | null;
+    name: string;
+    updated?: LocalDateTime | undefined | null;
   };
 
   export const Application1 = zodSchemaApplication1();
   export type Application1 = {
-    bundle_id: UUID;
-    created?: string | undefined | null;
     display_name: string;
-    id?: UUID | undefined | null;
-    name: string;
-    updated?: string | undefined | null;
+    id: UUID;
   };
 
   export const BasicAuthentication = zodSchemaBasicAuthentication();
@@ -68,16 +68,16 @@ export namespace Schemas {
     behaviors?: Array<EventTypeBehavior> | undefined | null;
     bundle?: Bundle | undefined | null;
     bundle_id: UUID;
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     default_behavior?: boolean | undefined | null;
     display_name: string;
     id?: UUID | undefined | null;
-    updated?: string | undefined | null;
+    updated?: LocalDateTime | undefined | null;
   };
 
   export const BehaviorGroupAction = zodSchemaBehaviorGroupAction();
   export type BehaviorGroupAction = {
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     endpoint?: Endpoint | undefined | null;
     id?: BehaviorGroupActionId | undefined | null;
   };
@@ -90,11 +90,11 @@ export namespace Schemas {
 
   export const Bundle = zodSchemaBundle();
   export type Bundle = {
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     display_name: string;
     id?: UUID | undefined | null;
     name: string;
-    updated?: string | undefined | null;
+    updated?: LocalDateTime | undefined | null;
   };
 
   export const CamelProperties = zodSchemaCamelProperties();
@@ -108,7 +108,6 @@ export namespace Schemas {
       | undefined
       | null;
     secret_token?: string | undefined | null;
-    sub_type?: string | undefined | null;
     url: string;
   };
 
@@ -125,7 +124,7 @@ export namespace Schemas {
     zodSchemaCreateBehaviorGroupResponse();
   export type CreateBehaviorGroupResponse = {
     bundle_id: UUID;
-    created: string;
+    created: LocalDateTime;
     display_name: string;
     endpoints: Array<string>;
     event_types: Array<string>;
@@ -134,8 +133,8 @@ export namespace Schemas {
 
   export const CurrentStatus = zodSchemaCurrentStatus();
   export type CurrentStatus = {
-    end_time?: string | undefined | null;
-    start_time?: string | undefined | null;
+    end_time?: LocalDateTime | undefined | null;
+    start_time?: LocalDateTime | undefined | null;
     status: Status;
   };
 
@@ -152,7 +151,7 @@ export namespace Schemas {
 
   export const Endpoint = zodSchemaEndpoint();
   export type Endpoint = {
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     description: string;
     enabled?: boolean | undefined | null;
     id?: UUID | undefined | null;
@@ -161,10 +160,11 @@ export namespace Schemas {
       | (WebhookProperties | EmailSubscriptionProperties | CamelProperties)
       | undefined
       | null;
+    server_errors?: number | undefined | null;
     status?: EndpointStatus | undefined | null;
     sub_type?: string | undefined | null;
     type: EndpointType;
-    updated?: string | undefined | null;
+    updated?: LocalDateTime | undefined | null;
   };
 
   export const EndpointPage = zodSchemaEndpointPage();
@@ -203,7 +203,7 @@ export namespace Schemas {
     actions: Array<EventLogEntryAction>;
     application: string;
     bundle: string;
-    created: string;
+    created: LocalDateTime;
     event_type: string;
     id: UUID;
     payload?: string | undefined | null;
@@ -226,7 +226,7 @@ export namespace Schemas {
 
   export const EventType = zodSchemaEventType();
   export type EventType = {
-    application?: Application1 | undefined | null;
+    application?: Application | undefined | null;
     application_id: UUID;
     description?: string | undefined | null;
     display_name: string;
@@ -236,7 +236,7 @@ export namespace Schemas {
 
   export const EventTypeBehavior = zodSchemaEventTypeBehavior();
   export type EventTypeBehavior = {
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     event_type?: EventType | undefined | null;
     id?: EventTypeBehaviorId | undefined | null;
   };
@@ -262,13 +262,13 @@ export namespace Schemas {
   export type InstantEmailTemplate = {
     body_template?: Template | undefined | null;
     body_template_id: UUID;
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     event_type?: EventType | undefined | null;
     event_type_id?: UUID | undefined | null;
     id?: UUID | undefined | null;
     subject_template?: Template | undefined | null;
     subject_template_id: UUID;
-    updated?: string | undefined | null;
+    updated?: LocalDateTime | undefined | null;
   };
 
   export const InternalApplicationUserPermission =
@@ -288,10 +288,16 @@ export namespace Schemas {
 
   export const InternalUserPermissions = zodSchemaInternalUserPermissions();
   export type InternalUserPermissions = {
-    applications: Array<Application>;
+    applications: Array<Application1>;
     is_admin: boolean;
     roles: Array<string>;
   };
+
+  export const LocalDate = zodSchemaLocalDate();
+  export type LocalDate = string;
+
+  export const LocalDateTime = zodSchemaLocalDateTime();
+  export type LocalDateTime = string;
 
   export const MessageValidationResponse = zodSchemaMessageValidationResponse();
   export type MessageValidationResponse = {
@@ -307,7 +313,7 @@ export namespace Schemas {
 
   export const NotificationHistory = zodSchemaNotificationHistory();
   export type NotificationHistory = {
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     details?:
       | {
           [x: string]: unknown;
@@ -372,12 +378,12 @@ export namespace Schemas {
 
   export const Template = zodSchemaTemplate();
   export type Template = {
-    created?: string | undefined | null;
+    created?: LocalDateTime | undefined | null;
     data: string;
     description: string;
     id?: UUID | undefined | null;
     name: string;
-    updated?: string | undefined | null;
+    updated?: LocalDateTime | undefined | null;
   };
 
   export const UUID = zodSchemaUUID();
@@ -386,7 +392,6 @@ export namespace Schemas {
   export const UpdateBehaviorGroupRequest =
     zodSchemaUpdateBehaviorGroupRequest();
   export type UpdateBehaviorGroupRequest = {
-    bundle_id?: UUID | undefined | null;
     display_name?: string | undefined | null;
     endpoint_ids?: Array<string> | undefined | null;
     event_type_ids?: Array<string> | undefined | null;
@@ -427,16 +432,16 @@ export namespace Schemas {
   function zodSchemaAggregationEmailTemplate() {
       return z
       .object({
-          application: zodSchemaApplication1().optional().nullable(),
+          application: zodSchemaApplication().optional().nullable(),
           application_id: zodSchemaUUID().optional().nullable(),
           body_template: zodSchemaTemplate().optional().nullable(),
           body_template_id: zodSchemaUUID(),
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           id: zodSchemaUUID().optional().nullable(),
           subject_template: zodSchemaTemplate().optional().nullable(),
           subject_template_id: zodSchemaUUID(),
           subscription_type: zodSchemaEmailSubscriptionType(),
-          updated: z.string().optional().nullable()
+          updated: zodSchemaLocalDateTime().optional().nullable()
       })
       .nonstrict();
   }
@@ -444,8 +449,12 @@ export namespace Schemas {
   function zodSchemaApplication() {
       return z
       .object({
+          bundle_id: zodSchemaUUID(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           display_name: z.string(),
-          id: zodSchemaUUID()
+          id: zodSchemaUUID().optional().nullable(),
+          name: z.string(),
+          updated: zodSchemaLocalDateTime().optional().nullable()
       })
       .nonstrict();
   }
@@ -453,12 +462,8 @@ export namespace Schemas {
   function zodSchemaApplication1() {
       return z
       .object({
-          bundle_id: zodSchemaUUID(),
-          created: z.string().optional().nullable(),
           display_name: z.string(),
-          id: zodSchemaUUID().optional().nullable(),
-          name: z.string(),
-          updated: z.string().optional().nullable()
+          id: zodSchemaUUID()
       })
       .nonstrict();
   }
@@ -479,11 +484,11 @@ export namespace Schemas {
           behaviors: z.array(zodSchemaEventTypeBehavior()).optional().nullable(),
           bundle: zodSchemaBundle().optional().nullable(),
           bundle_id: zodSchemaUUID(),
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           default_behavior: z.boolean().optional().nullable(),
           display_name: z.string(),
           id: zodSchemaUUID().optional().nullable(),
-          updated: z.string().optional().nullable()
+          updated: zodSchemaLocalDateTime().optional().nullable()
       })
       .nonstrict();
   }
@@ -491,7 +496,7 @@ export namespace Schemas {
   function zodSchemaBehaviorGroupAction() {
       return z
       .object({
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           endpoint: zodSchemaEndpoint().optional().nullable(),
           id: zodSchemaBehaviorGroupActionId().optional().nullable()
       })
@@ -510,11 +515,11 @@ export namespace Schemas {
   function zodSchemaBundle() {
       return z
       .object({
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           display_name: z.string(),
           id: zodSchemaUUID().optional().nullable(),
           name: z.string(),
-          updated: z.string().optional().nullable()
+          updated: zodSchemaLocalDateTime().optional().nullable()
       })
       .nonstrict();
   }
@@ -528,7 +533,6 @@ export namespace Schemas {
           disable_ssl_verification: z.boolean(),
           extras: z.record(z.string()).optional().nullable(),
           secret_token: z.string().optional().nullable(),
-          sub_type: z.string().optional().nullable(),
           url: z.string()
       })
       .nonstrict();
@@ -549,7 +553,7 @@ export namespace Schemas {
       return z
       .object({
           bundle_id: zodSchemaUUID(),
-          created: z.string(),
+          created: zodSchemaLocalDateTime(),
           display_name: z.string(),
           endpoints: z.array(z.string()),
           event_types: z.array(z.string()),
@@ -561,8 +565,8 @@ export namespace Schemas {
   function zodSchemaCurrentStatus() {
       return z
       .object({
-          end_time: z.string().optional().nullable(),
-          start_time: z.string().optional().nullable(),
+          end_time: zodSchemaLocalDateTime().optional().nullable(),
+          start_time: zodSchemaLocalDateTime().optional().nullable(),
           status: zodSchemaStatus()
       })
       .nonstrict();
@@ -585,7 +589,7 @@ export namespace Schemas {
   function zodSchemaEndpoint() {
       return z
       .object({
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           description: z.string(),
           enabled: z.boolean().optional().nullable(),
           id: zodSchemaUUID().optional().nullable(),
@@ -598,10 +602,11 @@ export namespace Schemas {
           ])
           .optional()
           .nullable(),
+          server_errors: z.number().int().optional().nullable(),
           status: zodSchemaEndpointStatus().optional().nullable(),
           sub_type: z.string().optional().nullable(),
           type: zodSchemaEndpointType(),
-          updated: z.string().optional().nullable()
+          updated: zodSchemaLocalDateTime().optional().nullable()
       })
       .nonstrict();
   }
@@ -645,7 +650,7 @@ export namespace Schemas {
           actions: z.array(zodSchemaEventLogEntryAction()),
           application: z.string(),
           bundle: z.string(),
-          created: z.string(),
+          created: zodSchemaLocalDateTime(),
           event_type: z.string(),
           id: zodSchemaUUID(),
           payload: z.string().optional().nullable()
@@ -669,7 +674,7 @@ export namespace Schemas {
   function zodSchemaEventType() {
       return z
       .object({
-          application: zodSchemaApplication1().optional().nullable(),
+          application: zodSchemaApplication().optional().nullable(),
           application_id: zodSchemaUUID(),
           description: z.string().optional().nullable(),
           display_name: z.string(),
@@ -682,7 +687,7 @@ export namespace Schemas {
   function zodSchemaEventTypeBehavior() {
       return z
       .object({
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           event_type: zodSchemaEventType().optional().nullable(),
           id: zodSchemaEventTypeBehaviorId().optional().nullable()
       })
@@ -721,13 +726,13 @@ export namespace Schemas {
       .object({
           body_template: zodSchemaTemplate().optional().nullable(),
           body_template_id: zodSchemaUUID(),
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           event_type: zodSchemaEventType().optional().nullable(),
           event_type_id: zodSchemaUUID().optional().nullable(),
           id: zodSchemaUUID().optional().nullable(),
           subject_template: zodSchemaTemplate().optional().nullable(),
           subject_template_id: zodSchemaUUID(),
-          updated: z.string().optional().nullable()
+          updated: zodSchemaLocalDateTime().optional().nullable()
       })
       .nonstrict();
   }
@@ -755,11 +760,19 @@ export namespace Schemas {
   function zodSchemaInternalUserPermissions() {
       return z
       .object({
-          applications: z.array(zodSchemaApplication()),
+          applications: z.array(zodSchemaApplication1()),
           is_admin: z.boolean(),
           roles: z.array(z.string())
       })
       .nonstrict();
+  }
+
+  function zodSchemaLocalDate() {
+      return z.string();
+  }
+
+  function zodSchemaLocalDateTime() {
+      return z.string();
   }
 
   function zodSchemaMessageValidationResponse() {
@@ -781,7 +794,7 @@ export namespace Schemas {
   function zodSchemaNotificationHistory() {
       return z
       .object({
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           details: z.record(z.unknown()).optional().nullable(),
           endpointId: zodSchemaUUID().optional().nullable(),
           endpointSubType: z.string().optional().nullable(),
@@ -856,12 +869,12 @@ export namespace Schemas {
   function zodSchemaTemplate() {
       return z
       .object({
-          created: z.string().optional().nullable(),
+          created: zodSchemaLocalDateTime().optional().nullable(),
           data: z.string(),
           description: z.string(),
           id: zodSchemaUUID().optional().nullable(),
           name: z.string(),
-          updated: z.string().optional().nullable()
+          updated: zodSchemaLocalDateTime().optional().nullable()
       })
       .nonstrict();
   }
@@ -873,7 +886,6 @@ export namespace Schemas {
   function zodSchemaUpdateBehaviorGroupRequest() {
       return z
       .object({
-          bundle_id: zodSchemaUUID().optional().nullable(),
           display_name: z.string().optional().nullable(),
           endpoint_ids: z.array(z.string()).optional().nullable(),
           event_type_ids: z.array(z.string()).optional().nullable()
@@ -1126,6 +1138,116 @@ export namespace Operations {
         .build();
     };
   }
+  // GET /notifications/bundles/{bundleName}
+  // Retrieve the bundle by name
+  export namespace NotificationResourceGetBundleByName {
+    const BundleName = z.string();
+    type BundleName = string;
+    export interface Params {
+      bundleName: BundleName;
+    }
+
+    export type Payload =
+      | ValidatedResponse<'Bundle', 200, Schemas.Bundle>
+      | ValidatedResponse<'__Empty', 401, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 403, Schemas.__Empty>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path =
+        '/api/notifications/v1.0/notifications/bundles/{bundleName}'.replace(
+            '{bundleName}',
+            params.bundleName.toString()
+        );
+        const query = {} as Record<string, any>;
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.Bundle, 'Bundle', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 401),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403)
+            ]
+        })
+        .build();
+    };
+  }
+  // GET /notifications/bundles/{bundleName}/applications/{applicationName}
+  // Retrieve the application by name of a given bundle name
+  export namespace NotificationResourceGetApplicationByNameAndBundleName {
+    const ApplicationName = z.string();
+    type ApplicationName = string;
+    const BundleName = z.string();
+    type BundleName = string;
+    export interface Params {
+      applicationName: ApplicationName;
+      bundleName: BundleName;
+    }
+
+    export type Payload =
+      | ValidatedResponse<'Application', 200, Schemas.Application>
+      | ValidatedResponse<'__Empty', 401, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 403, Schemas.__Empty>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path =
+        '/api/notifications/v1.0/notifications/bundles/{bundleName}/applications/{applicationName}'
+        .replace('{applicationName}', params.applicationName.toString())
+        .replace('{bundleName}', params.bundleName.toString());
+        const query = {} as Record<string, any>;
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.Application, 'Application', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 401),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403)
+            ]
+        })
+        .build();
+    };
+  }
+  // GET /notifications/bundles/{bundleName}/applications/{applicationName}/eventTypes/{eventTypeName}
+  // Retrieve the event type by name of a given bundle name and application name
+  export namespace NotificationResourceGetEventTypesByNameAndBundleAndApplicationName {
+    const ApplicationName = z.string();
+    type ApplicationName = string;
+    const BundleName = z.string();
+    type BundleName = string;
+    const EventTypeName = z.string();
+    type EventTypeName = string;
+    export interface Params {
+      applicationName: ApplicationName;
+      bundleName: BundleName;
+      eventTypeName: EventTypeName;
+    }
+
+    export type Payload =
+      | ValidatedResponse<'EventType', 200, Schemas.EventType>
+      | ValidatedResponse<'__Empty', 401, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 403, Schemas.__Empty>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path =
+        '/api/notifications/v1.0/notifications/bundles/{bundleName}/applications/{applicationName}/eventTypes/{eventTypeName}'
+        .replace('{applicationName}', params.applicationName.toString())
+        .replace('{bundleName}', params.bundleName.toString())
+        .replace('{eventTypeName}', params.eventTypeName.toString());
+        const query = {} as Record<string, any>;
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.EventType, 'EventType', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 401),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403)
+            ]
+        })
+        .build();
+    };
+  }
   // GET /notifications/eventTypes
   // Retrieve all event types. The returned list can be filtered by bundle or application.
   export namespace NotificationResourceGetEventTypes {
@@ -1341,8 +1463,6 @@ export namespace Operations {
     type AppIds = Array<string>;
     const BundleIds = z.array(z.string());
     type BundleIds = Array<string>;
-    const EndDate = z.string();
-    type EndDate = string;
     const EndpointTypes = z.array(z.string());
     type EndpointTypes = Array<string>;
     const EventTypeDisplayName = z.string();
@@ -1359,14 +1479,14 @@ export namespace Operations {
     type Limit = number;
     const Offset = z.number().int();
     type Offset = number;
+    const PageNumber = z.number().int();
+    type PageNumber = number;
     const SortBy = z.string();
     type SortBy = string;
-    const StartDate = z.string();
-    type StartDate = string;
     export interface Params {
       appIds?: AppIds;
       bundleIds?: BundleIds;
-      endDate?: EndDate;
+      endDate?: Schemas.LocalDate;
       endpointTypes?: EndpointTypes;
       eventTypeDisplayName?: EventTypeDisplayName;
       includeActions?: IncludeActions;
@@ -1375,8 +1495,9 @@ export namespace Operations {
       invocationResults?: InvocationResults;
       limit?: Limit;
       offset?: Offset;
+      pageNumber?: PageNumber;
       sortBy?: SortBy;
-      startDate?: StartDate;
+      startDate?: Schemas.LocalDate;
     }
 
     export type Payload =
@@ -1430,6 +1551,10 @@ export namespace Operations {
 
         if (params.offset !== undefined) {
             query.offset = params.offset;
+        }
+
+        if (params.pageNumber !== undefined) {
+            query.pageNumber = params.pageNumber;
         }
 
         if (params.sortBy !== undefined) {
@@ -1512,59 +1637,6 @@ export namespace Operations {
         .queryParams(query)
         .config({
             rules: [ new ValidateRule(Response200, 'unknown', 200) ]
-        })
-        .build();
-    };
-  }
-  // DELETE /notifications/{id}
-  export namespace NotificationResourceMarkRead {
-    const Id = z.number().int();
-    type Id = number;
-    const Response204 = z.string();
-    type Response204 = string;
-    export interface Params {
-      id: Id;
-    }
-
-    export type Payload =
-      | ValidatedResponse<'unknown', 204, Response204>
-      | ValidatedResponse<'unknown', undefined, unknown>;
-    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
-    export const actionCreator = (params: Params): ActionCreator => {
-        const path = '/api/notifications/v1.0/notifications/{id}'.replace(
-            '{id}',
-            params.id.toString()
-        );
-        const query = {} as Record<string, any>;
-        return actionBuilder('DELETE', path)
-        .queryParams(query)
-        .config({
-            rules: [ new ValidateRule(Response204, 'unknown', 204) ]
-        })
-        .build();
-    };
-  }
-  // POST /ob/errors
-  export namespace FromObHistoryFillerHandleCallback {
-    const Body = z.string();
-    type Body = string;
-    export interface Params {
-      xRhoseOriginalEventId?: Schemas.UUID;
-      body: Body;
-    }
-
-    export type Payload =
-      | ValidatedResponse<'__Empty', 200, Schemas.__Empty>
-      | ValidatedResponse<'unknown', undefined, unknown>;
-    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
-    export const actionCreator = (params: Params): ActionCreator => {
-        const path = '/api/notifications/v1.0/ob/errors';
-        const query = {} as Record<string, any>;
-        return actionBuilder('POST', path)
-        .queryParams(query)
-        .data(params.body)
-        .config({
-            rules: [ new ValidateRule(Schemas.__Empty, '__Empty', 200) ]
         })
         .build();
     };

--- a/src/properties/Messages.ts
+++ b/src/properties/Messages.ts
@@ -75,7 +75,8 @@ const MutableMessages = {
                     name: 'Name',
                     type: 'Type',
                     lastConnectionAttempt: 'Last connection attempt',
-                    enabled: 'Enabled'
+                    enabled: 'Enabled',
+                    status: 'Status'
                 }
             },
             enableError: {

--- a/src/properties/Messages.ts
+++ b/src/properties/Messages.ts
@@ -75,8 +75,7 @@ const MutableMessages = {
                     name: 'Name',
                     type: 'Type',
                     lastConnectionAttempt: 'Last connection attempt',
-                    enabled: 'Enabled',
-                    status: 'Status'
+                    enabled: 'Enabled'
                 }
             },
             enableError: {

--- a/src/schemas/Integrations/Integration.ts
+++ b/src/schemas/Integrations/Integration.ts
@@ -19,7 +19,8 @@ export const IntegrationSchemaBase: Yup.SchemaOf<NewIntegrationBase> = Yup.objec
     id: Yup.string().optional(),
     name: Yup.string().required('Write a name for this Integration.').max(maxIntegrationNameLength).trim(),
     type: Yup.mixed<IntegrationType>().oneOf(Object.values(IntegrationType)).default(IntegrationType.WEBHOOK).optional(),
-    isEnabled: Yup.boolean().default(true).required()
+    isEnabled: Yup.boolean().default(true).required(),
+    status: Yup.mixed<Schemas.EndpointStatus>().oneOf(Object.values(Schemas.EndpointStatus.Enum)).default(Schemas.EndpointStatus.Enum.UNKNOWN)
 });
 
 export const IntegrationHttpSchema: Yup.SchemaOf<NewIntegrationTemplate<IntegrationHttp>> = IntegrationSchemaBase.concat(Yup.object().shape({

--- a/src/schemas/Integrations/Integration.ts
+++ b/src/schemas/Integrations/Integration.ts
@@ -20,7 +20,8 @@ export const IntegrationSchemaBase: Yup.SchemaOf<NewIntegrationBase> = Yup.objec
     name: Yup.string().required('Write a name for this Integration.').max(maxIntegrationNameLength).trim(),
     type: Yup.mixed<IntegrationType>().oneOf(Object.values(IntegrationType)).default(IntegrationType.WEBHOOK).optional(),
     isEnabled: Yup.boolean().default(true).required(),
-    status: Yup.mixed<Schemas.EndpointStatus>().oneOf(Object.values(Schemas.EndpointStatus.Enum)).default(Schemas.EndpointStatus.Enum.UNKNOWN)
+    status: Yup.mixed<Schemas.EndpointStatus>().oneOf(Object.values(Schemas.EndpointStatus.Enum)).default(Schemas.EndpointStatus.Enum.UNKNOWN),
+    serverErrors: Yup.number().default(0)
 });
 
 export const IntegrationHttpSchema: Yup.SchemaOf<NewIntegrationTemplate<IntegrationHttp>> = IntegrationSchemaBase.concat(Yup.object().shape({

--- a/src/types/Integration.ts
+++ b/src/types/Integration.ts
@@ -35,6 +35,7 @@ export interface IntegrationBase<T extends IntegrationType> {
     name: string;
     type: T;
     isEnabled: boolean;
+    status?: Schemas.EndpointStatus | undefined
 }
 
 export interface IntegrationHttp extends IntegrationBase<IntegrationType.WEBHOOK> {

--- a/src/types/Integration.ts
+++ b/src/types/Integration.ts
@@ -36,6 +36,7 @@ export interface IntegrationBase<T extends IntegrationType> {
     type: T;
     isEnabled: boolean;
     status?: Schemas.EndpointStatus | undefined
+    serverErrors: number;
 }
 
 export interface IntegrationHttp extends IntegrationBase<IntegrationType.WEBHOOK> {
@@ -75,7 +76,7 @@ export type UserIntegration = Extract<Integration, {
     type: UserIntegrationType
 }>;
 
-type NewIntegrationKeys = 'id';
+type NewIntegrationKeys = 'id' | 'serverErrors';
 
 export type NewIntegrationTemplate<
     T extends IntegrationBase<IntegrationType>

--- a/src/types/adapters/IntegrationAdapter.ts
+++ b/src/types/adapters/IntegrationAdapter.ts
@@ -92,7 +92,8 @@ export const toIntegration = (serverIntegration: ServerIntegrationResponse): Int
         name: serverIntegration.name || '',
         isEnabled: !!serverIntegration.enabled,
         type: getIntegrationType(serverIntegration),
-        status: serverIntegration.status ?? 'UNKNOWN'
+        status: serverIntegration.status ?? 'UNKNOWN',
+        serverErrors: serverIntegration.server_errors ?? 0
     };
 
     if (isCamelType(integrationBase.type)) {

--- a/src/types/adapters/IntegrationAdapter.ts
+++ b/src/types/adapters/IntegrationAdapter.ts
@@ -91,7 +91,8 @@ export const toIntegration = (serverIntegration: ServerIntegrationResponse): Int
         id: serverIntegration.id || '',
         name: serverIntegration.name || '',
         isEnabled: !!serverIntegration.enabled,
-        type: getIntegrationType(serverIntegration)
+        type: getIntegrationType(serverIntegration),
+        status: serverIntegration.status ?? 'UNKNOWN'
     };
 
     if (isCamelType(integrationBase.type)) {

--- a/src/types/adapters/__tests__/IntegrationAdapter.test.ts
+++ b/src/types/adapters/__tests__/IntegrationAdapter.test.ts
@@ -24,7 +24,9 @@ describe('src/types/adapters/IntegrationAdapter', () => {
                     disable_ssl_verification: false,
                     method: Schemas.HttpType.Enum.GET,
                     secret_token: undefined
-                }
+                },
+                server_errors: 5,
+                status: 'READY'
             };
             const integration = toIntegration(serverIntegration);
             expect(integration).toEqual({
@@ -35,7 +37,9 @@ describe('src/types/adapters/IntegrationAdapter', () => {
                 url: 'https://my-cool-webhook.com',
                 sslVerificationEnabled: true,
                 method: 'GET',
-                secretToken: undefined
+                secretToken: undefined,
+                serverErrors: 5,
+                status: 'READY'
             });
         });
 
@@ -51,7 +55,9 @@ describe('src/types/adapters/IntegrationAdapter', () => {
                     disable_ssl_verification: false,
                     method: Schemas.HttpType.Enum.GET,
                     secret_token: ''
-                }
+                },
+                server_errors: 5,
+                status: 'READY'
             };
             const integration = toIntegration(serverIntegration);
             expect(integration).toEqual({
@@ -62,7 +68,9 @@ describe('src/types/adapters/IntegrationAdapter', () => {
                 url: 'https://foobarbaz.com',
                 sslVerificationEnabled: true,
                 method: 'GET',
-                secretToken: undefined
+                secretToken: undefined,
+                serverErrors: 5,
+                status: 'READY'
             });
         });
 
@@ -115,7 +123,9 @@ describe('src/types/adapters/IntegrationAdapter', () => {
                         disable_ssl_verification: false,
                         method: Schemas.HttpType.Enum.GET,
                         secret_token: 'my-token'
-                    }
+                    },
+                    server_errors: 3,
+                    status: 'PROVISIONING'
                 },
                 {
                     id: 'meep',
@@ -128,7 +138,9 @@ describe('src/types/adapters/IntegrationAdapter', () => {
                         disable_ssl_verification: false,
                         method: Schemas.HttpType.Enum.GET,
                         secret_token: ''
-                    }
+                    },
+                    server_errors: 7,
+                    status: 'FAILED'
                 }
             ] as Array<ServerIntegrationResponse>;
             expect(toIntegrations(integrations)).toEqual([
@@ -140,7 +152,9 @@ describe('src/types/adapters/IntegrationAdapter', () => {
                     url: 'https://my-cool-webhook.com',
                     sslVerificationEnabled: true,
                     method: 'GET',
-                    secretToken: 'my-token'
+                    secretToken: 'my-token',
+                    serverErrors: 3,
+                    status: 'PROVISIONING'
                 },
                 {
                     id: 'meep',
@@ -150,7 +164,9 @@ describe('src/types/adapters/IntegrationAdapter', () => {
                     url: 'https://foobarbaz.com',
                     sslVerificationEnabled: true,
                     method: 'GET',
-                    secretToken: undefined
+                    secretToken: undefined,
+                    serverErrors: 7,
+                    status: 'FAILED'
                 }
             ]);
         });
@@ -202,7 +218,9 @@ describe('src/types/adapters/IntegrationAdapter', () => {
                 type: IntegrationType.WEBHOOK,
                 method: Schemas.HttpType.Enum.POST,
                 secretToken: undefined,
-                sslVerificationEnabled: true
+                sslVerificationEnabled: true,
+                serverErrors: 5,
+                status: 'READY'
             };
 
             expect(toServerIntegrationRequest(integration)).toEqual({
@@ -216,7 +234,8 @@ describe('src/types/adapters/IntegrationAdapter', () => {
                     method: 'POST',
                     disable_ssl_verification: false,
                     secret_token: undefined
-                }
+                },
+                sub_type: undefined
             });
         });
 

--- a/src/utils/ConnectionAttemptStatus.ts
+++ b/src/utils/ConnectionAttemptStatus.ts
@@ -1,0 +1,24 @@
+import { IntegrationConnectionAttempt } from '../types/Integration';
+
+export enum AggregatedConnectionAttemptStatus {
+    UNKNOWN,
+    SUCCESS,
+    WARNING,
+    ERROR
+}
+
+export const aggregateConnectionAttemptStatus = (attempts: Array<IntegrationConnectionAttempt> | undefined): AggregatedConnectionAttemptStatus => {
+    if (!attempts || attempts.length === 0) {
+        return AggregatedConnectionAttemptStatus.UNKNOWN;
+    }
+
+    const failures = attempts.filter(a => !a.isSuccess).length;
+
+    if (failures === attempts.length) {
+        return AggregatedConnectionAttemptStatus.ERROR;
+    } else if (failures > 0) {
+        return AggregatedConnectionAttemptStatus.WARNING;
+    }
+
+    return AggregatedConnectionAttemptStatus.SUCCESS;
+};

--- a/src/utils/exporters/Integration/Csv.ts
+++ b/src/utils/exporters/Integration/Csv.ts
@@ -17,7 +17,9 @@ export class IntegrationExporterCsv extends ExporterCsv<UserIntegration> {
             [ 'isEnabled', 'isEnabled' ],
             [ 'type', 'type' ],
             // This works now, but what will happen when there are multiple types (slack, webhook, etc)
-            [ 'url', 'url' ]
+            [ 'url', 'url' ],
+            [ 'status', 'status' ],
+            [ 'serverErrors', 'serverErrors' ]
         ];
     }
 }

--- a/src/utils/exporters/Integration/__tests__/Csv.test.ts
+++ b/src/utils/exporters/Integration/__tests__/Csv.test.ts
@@ -15,7 +15,7 @@ describe('src/utils/exporters/Policy/Csv', () => {
         expect(result.type).toEqual('text/csv');
     });
 
-    it('has 5 columns', () => {
+    it('has 7 columns', () => {
         const result = new IntegrationExporterCsv().export([
             {
                 id: '12345',
@@ -25,7 +25,9 @@ describe('src/utils/exporters/Policy/Csv', () => {
                 url: 'http://foo.bar',
                 secretToken: 'foo',
                 method: Schemas.HttpType.Enum.GET,
-                sslVerificationEnabled: false
+                sslVerificationEnabled: false,
+                status: 'READY',
+                serverErrors: 5
             }
         ]);
 
@@ -34,7 +36,7 @@ describe('src/utils/exporters/Policy/Csv', () => {
             reader.addEventListener('loadend', () => {
                 try {
                     const text = (reader.result as string).split('\r');
-                    expect(text[0]).toEqual('id,name,isEnabled,type,url');
+                    expect(text[0]).toEqual('id,name,isEnabled,type,url,status,serverErrors');
                     done();
                 } catch (ex) {
                     fail(ex);


### PR DESCRIPTION
Adding integrations status

The integration status is used for camel integrations that require a setup phase - so the flow will be:

![Screenshot_2022-10-03_12-32-11](https://user-images.githubusercontent.com/3845764/193652257-b889f55a-a964-4841-8b47-e489ada568d9.png)

The status is aggregated with the result of the last notification histories if the status is READY - otherwise it will display the status

The header contains a `?` button with the description of the status

![Screenshot_2022-10-18_09-11-13](https://user-images.githubusercontent.com/3845764/196470540-f9315f66-1f85-4c67-94d0-f010d5492aaa.png)


### Ready

####  No history - shows as Ready

![Screenshot_2022-10-17_17-39-25](https://user-images.githubusercontent.com/3845764/196469216-3d0aefb7-fcde-430f-9577-7d9f263bf74d.png)

#### With history - last history is success but has errors
![Screenshot_2022-10-17_17-38-58](https://user-images.githubusercontent.com/3845764/196469219-cd105b48-a534-4cac-914f-b41a8d11053d.png)

Note: When there are only success calls, it does not show the "Degraded connection"

#### With history - last history is error
![Screenshot_2022-10-17_17-37-38](https://user-images.githubusercontent.com/3845764/196469220-5f35bba9-ccc9-43b5-8a85-3186a4b5eb05.png)

### Provisioning or Deleting
![Screenshot_2022-10-17_17-40-36](https://user-images.githubusercontent.com/3845764/196469213-4ba8d9fb-9765-4801-93b6-539f6e78c161.png)

### Failed to create
![Screenshot_2022-10-17_17-39-54](https://user-images.githubusercontent.com/3845764/196469214-493cbeec-51cf-4c0b-882f-c0507b05d981.png)


Notes: 
 - This PR does not move the last errors out of the expanded content
 -  Some screenshots don't have the `?` in the header of the table - these were taken before adding it.