### PR TITLE
RHCLOUD-23554 Add text in UI to inform user that an email notif is being forced

### DIFF
--- a/src/components/Notifications/Form/RecipientTypeahead.tsx
+++ b/src/components/Notifications/Form/RecipientTypeahead.tsx
@@ -65,8 +65,8 @@ const loadingMapper = () => {
 
 const userOptions = [
     renderSelectGroup('users', 'Users', [
-        new NotificationUserRecipient(undefined, false),
-        new NotificationUserRecipient(undefined, true)
+        new NotificationUserRecipient(undefined, false, false),
+        new NotificationUserRecipient(undefined, true, false)
     ])
 ];
 

--- a/src/components/Notifications/Form/__tests__/ActionTypeahead.test.tsx
+++ b/src/components/Notifications/Form/__tests__/ActionTypeahead.test.tsx
@@ -12,8 +12,8 @@ import { RecipientContext, RecipientContextProvider } from '../../RecipientConte
 import { ActionTypeahead } from '../ActionTypeahead';
 
 const ALL_RECIPIENTS = [
-    new NotificationUserRecipient(undefined, false),
-    new NotificationUserRecipient(undefined, true)
+    new NotificationUserRecipient(undefined, false, false),
+    new NotificationUserRecipient(undefined, true, false)
 ] as ReadonlyArray<NotificationUserRecipient>;
 
 const defaultRecipientContext = (): RecipientContext => ({

--- a/src/components/Notifications/Form/__tests__/RecipientOption.test.ts
+++ b/src/components/Notifications/Form/__tests__/RecipientOption.test.ts
@@ -4,7 +4,7 @@ import { RecipientOption } from '../RecipientOption';
 
 describe('src/components/Notifications/Form/RecipientOption', () => {
     it('CompareTo returns equal for the same object', () => {
-        const recipient1 = new NotificationUserRecipient(undefined, true);
+        const recipient1 = new NotificationUserRecipient(undefined, true, false);
         const recipient2 = new IntegrationRecipient({
             name: 'bar',
             isEnabled: false,
@@ -20,8 +20,8 @@ describe('src/components/Notifications/Form/RecipientOption', () => {
     });
 
     it('CompareTo returns true for objects with same values', () => {
-        const recipient1 = new NotificationUserRecipient(undefined, true);
-        const recipient2 = new NotificationUserRecipient(undefined, true);
+        const recipient1 = new NotificationUserRecipient(undefined, true, false);
+        const recipient2 = new NotificationUserRecipient(undefined, true, false);
         const a = new RecipientOption(recipient1);
         const b = new RecipientOption(recipient2);
 
@@ -48,8 +48,8 @@ describe('src/components/Notifications/Form/RecipientOption', () => {
     });
 
     it('CompareTo returns false for objects with different values', () => {
-        const recipient1 = new NotificationUserRecipient(undefined, true);
-        const recipient2 = new NotificationUserRecipient(undefined, false);
+        const recipient1 = new NotificationUserRecipient(undefined, true, false);
+        const recipient2 = new NotificationUserRecipient(undefined, false, false);
         const a = new RecipientOption(recipient1);
         const b = new RecipientOption(recipient2);
         expect(a.compareTo(b)).toBe(false);
@@ -75,7 +75,7 @@ describe('src/components/Notifications/Form/RecipientOption', () => {
     });
 
     it('CompareTo returns false when mixing notification and integration', () => {
-        const recipient1 = new NotificationUserRecipient(undefined, true);
+        const recipient1 = new NotificationUserRecipient(undefined, true, false);
         const recipient2 = new IntegrationRecipient({
             name: 'bar',
             isEnabled: false,
@@ -89,7 +89,7 @@ describe('src/components/Notifications/Form/RecipientOption', () => {
     });
 
     it('toString returns the description', () => {
-        const recipient1 = new NotificationUserRecipient(undefined, true);
+        const recipient1 = new NotificationUserRecipient(undefined, true, false);
         const a = new RecipientOption(recipient1);
 
         expect(a.toString()).toEqual('Admins');

--- a/src/components/Notifications/Form/__tests__/RecipientTypeAhead.test.tsx
+++ b/src/components/Notifications/Form/__tests__/RecipientTypeAhead.test.tsx
@@ -19,12 +19,12 @@ const getConfiguredWrapper = (getRecipients?: GetNotificationRecipients) => {
 };
 
 const SELECTED_ALL = [
-    new NotificationUserRecipient(undefined, false),
-    new NotificationUserRecipient(undefined, true)
+    new NotificationUserRecipient(undefined, false, false),
+    new NotificationUserRecipient(undefined, true, false)
 ] as ReadonlyArray<BaseNotificationRecipient>;
 
 const SELECTED_SEND_TO_ADMIN = [
-    new NotificationUserRecipient(undefined, true)
+    new NotificationUserRecipient(undefined, true, false)
 ] as ReadonlyArray<BaseNotificationRecipient>;
 
 const SELECTED_LOADED_GROUP = [
@@ -39,7 +39,7 @@ const SELECTED_NON_EXISTING_GROUP = [
     new NotificationRbacGroupRecipient(undefined, 'does-not-exists-group', false)
 ] as ReadonlyArray<BaseNotificationRecipient>;
 
-const createDefaultGetMock = () => fn(async () => [ new NotificationUserRecipient(undefined, true) ]);
+const createDefaultGetMock = () => fn(async () => [ new NotificationUserRecipient(undefined, true, false) ]);
 
 describe('src/components/Notifications/Form/RecipientTypeAhead', () => {
 

--- a/src/components/Notifications/Recipient.tsx
+++ b/src/components/Notifications/Recipient.tsx
@@ -5,7 +5,7 @@ import { join } from '@redhat-cloud-services/insights-common-typescript';
 import * as React from 'react';
 import { style } from 'typestyle';
 
-import { Action, EmailSystemProperties, NotificationType } from '../../types/Notification';
+import { Action, NotificationType } from '../../types/Notification';
 import { NotificationRbacGroupRecipient, NotificationUserRecipient } from '../../types/Recipient';
 import { GroupNotFound } from './Rbac/GroupNotFound';
 
@@ -27,8 +27,6 @@ const greyColorName = style({
 const CommaSeparator = () => <span>, </span>;
 
 export const Recipient: React.FunctionComponent<RecipientProps> = (props) => {
-
-    const [ ignorePref ] = React.useState<EmailSystemProperties>();
 
     if (props.action.type === NotificationType.INTEGRATION) {
         return (
@@ -53,15 +51,17 @@ export const Recipient: React.FunctionComponent<RecipientProps> = (props) => {
 
     return (
         <span>
-            { ignorePref ? users.length > 0 && <div>
-                Users: {join(users.map(u => u.displayName), CommaSeparator)}
-                <Tooltip content="You may still receive forced notifications for this service" position="bottom">
-                    <LockIcon className={ disabledLabelClassName } />
-                </Tooltip>
-            </div> :
-                <div>
-                Users: {join(users.map(u => u.displayName), CommaSeparator)}
-                </div>
+            { users.length > 0 && <div>
+                Users: {join(users.map(u =>
+                    <>
+                        {u.displayName}
+                        {u.ignorePreferences &&
+                    <span>
+                        <Tooltip content="You may still receive forced notifications for this service" position="bottom">
+                            <LockIcon className={ disabledLabelClassName } />
+                        </Tooltip>
+                    </span>} </>), CommaSeparator)}
+            </div>
             }
             { groups.length > 0 && <div>
                 User Access Groups: { join(groups.map(g => {

--- a/src/components/Notifications/Recipient.tsx
+++ b/src/components/Notifications/Recipient.tsx
@@ -1,11 +1,11 @@
 import { Skeleton, Tooltip } from '@patternfly/react-core';
-import { BanIcon } from '@patternfly/react-icons';
+import { BanIcon, LockIcon } from '@patternfly/react-icons';
 import { global_disabled_color_100, global_spacer_sm } from '@patternfly/react-tokens';
 import { join } from '@redhat-cloud-services/insights-common-typescript';
 import * as React from 'react';
 import { style } from 'typestyle';
 
-import { Action, NotificationType } from '../../types/Notification';
+import { Action, EmailSystemProperties, NotificationType } from '../../types/Notification';
 import { NotificationRbacGroupRecipient, NotificationUserRecipient } from '../../types/Recipient';
 import { GroupNotFound } from './Rbac/GroupNotFound';
 
@@ -27,6 +27,9 @@ const greyColorName = style({
 const CommaSeparator = () => <span>, </span>;
 
 export const Recipient: React.FunctionComponent<RecipientProps> = (props) => {
+
+    const [ ignorePref ] = React.useState<EmailSystemProperties>();
+
     if (props.action.type === NotificationType.INTEGRATION) {
         return (
             <>
@@ -50,9 +53,16 @@ export const Recipient: React.FunctionComponent<RecipientProps> = (props) => {
 
     return (
         <span>
-            { users.length > 0 && <div>
+            { ignorePref ? users.length > 0 && <div>
                 Users: {join(users.map(u => u.displayName), CommaSeparator)}
-            </div> }
+                <Tooltip content="You may still receive forced notifications for this service" position="bottom">
+                    <LockIcon className={ disabledLabelClassName } />
+                </Tooltip>
+            </div> :
+                <div>
+                Users: {join(users.map(u => u.displayName), CommaSeparator)}
+                </div>
+            }
             { groups.length > 0 && <div>
                 User Access Groups: { join(groups.map(g => {
                     if (g.hasError) {

--- a/src/pages/Notifications/BehaviorGroupWizard/__tests__/useSaveBehaviorGroup.test.tsx
+++ b/src/pages/Notifications/BehaviorGroupWizard/__tests__/useSaveBehaviorGroup.test.tsx
@@ -209,7 +209,7 @@ describe('src/pages/Notifications/Form/useSaveBehaviorGroup', () => {
                     },
                     {
                         type: NotificationType.EMAIL_SUBSCRIPTION,
-                        recipient: [ new NotificationUserRecipient('e1', true), new NotificationUserRecipient('e2', false) ]
+                        recipient: [ new NotificationUserRecipient('e1', true, false), new NotificationUserRecipient('e2', false, false) ]
                     },
                     {
                         type: NotificationType.INTEGRATION,
@@ -274,7 +274,7 @@ describe('src/pages/Notifications/Form/useSaveBehaviorGroup', () => {
                     },
                     {
                         type: NotificationType.EMAIL_SUBSCRIPTION,
-                        recipient: [ new NotificationUserRecipient(undefined, true), new NotificationUserRecipient('e2', false) ]
+                        recipient: [ new NotificationUserRecipient(undefined, true, false), new NotificationUserRecipient('e2', false, false) ]
                     },
                     {
                         type: NotificationType.INTEGRATION,

--- a/src/types/Recipient.ts
+++ b/src/types/Recipient.ts
@@ -52,10 +52,12 @@ export abstract class BaseNotificationRecipient extends Recipient {
 
 export class NotificationUserRecipient extends BaseNotificationRecipient {
     readonly sendToAdmin: boolean;
+    readonly ignorePreferences: boolean;
 
-    public constructor(integrationId: UUID | undefined, sendToAdmin: boolean) {
+    public constructor(integrationId: UUID | undefined, sendToAdmin: boolean, ignorePreferences: boolean) {
         let displayName;
         let description;
+
         if (sendToAdmin) {
             displayName = 'Admins';
             description = 'Organization administrators for your account';
@@ -72,6 +74,7 @@ export class NotificationUserRecipient extends BaseNotificationRecipient {
         );
 
         this.sendToAdmin = sendToAdmin;
+        this.ignorePreferences = ignorePreferences;
     }
 
     public equals(recipient: Recipient) {

--- a/src/types/Recipient.ts
+++ b/src/types/Recipient.ts
@@ -79,7 +79,8 @@ export class NotificationUserRecipient extends BaseNotificationRecipient {
 
     public equals(recipient: Recipient) {
         if (recipient instanceof NotificationUserRecipient) {
-            return recipient.sendToAdmin === this.sendToAdmin;
+            return recipient.sendToAdmin === this.sendToAdmin
+            && recipient.ignorePreferences === this.ignorePreferences;
         }
 
         return false;

--- a/src/types/adapters/NotificationAdapter.ts
+++ b/src/types/adapters/NotificationAdapter.ts
@@ -32,7 +32,7 @@ const _toAction = (type: NotificationType, serverAction: ServerIntegrationRespon
     if (integration.groupId) {
         action.recipient = [ new NotificationRbacGroupRecipient(integration.id, integration.groupId, true) ];
     } else {
-        action.recipient = [ new NotificationUserRecipient(integration.id, integration.onlyAdmin) ];
+        action.recipient = [ new NotificationUserRecipient(integration.id, integration.onlyAdmin, integration.ignorePreferences) ];
     }
 
     return action;


### PR DESCRIPTION
<img width="540" alt="Screen Shot 2023-04-06 at 1 23 35 PM" src="https://user-images.githubusercontent.com/86322239/230452093-2fc89d7d-a350-4ac3-b01b-3d03433e5d13.png">
this is what it would look like when there is a forced email. there is currently NO apps sending forced emails so you will not see this in the UI as of now.