### PR TITLE
Use proper document title

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,6 +2,7 @@ import './App.scss';
 
 import { Switch } from '@patternfly/react-core';
 import { Maintenance } from '@redhat-cloud-services/frontend-components';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import {
     getInsights,
     InsightsEnvDetector,
@@ -30,7 +31,9 @@ const switchClassname = style({
 });
 
 const App: React.ComponentType = () => {
+    const { updateDocumentTitle } = useChrome();
 
+    updateDocumentTitle?.('Notifications');
     const { rbac, server, isOrgAdmin } = useApp();
     const insights = getInsights();
     const [ usingExperimental, setUsingExperimental ] = React.useState<boolean>(false);

--- a/src/pages/Notifications/List/BundlePage.tsx
+++ b/src/pages/Notifications/List/BundlePage.tsx
@@ -1,5 +1,6 @@
 import { ButtonVariant, Tab, TabTitleText } from '@patternfly/react-core';
 import { Main } from '@redhat-cloud-services/frontend-components';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import {
     getInsights, getInsightsEnvironment,
     localUrl
@@ -23,6 +24,10 @@ interface NotificationListBundlePageProps {
 }
 
 export const NotificationListBundlePage: React.FunctionComponent<NotificationListBundlePageProps> = (props) => {
+
+    const { updateDocumentTitle } = useChrome();
+
+    updateDocumentTitle?.(`${props.bundle.displayName} - Notifications`);
 
     const { rbac } = useAppContext();
     const eventLogPageUrl = React.useMemo(() => linkTo.eventLog(props.bundle.name), [ props.bundle.name ]);


### PR DESCRIPTION
Description
We want to adjust all browser titles. This PR uses chrome's updateDocumentTitle and sets it to `Notifications`. Also whenever user switches between certain app notifications configs the current bundle title is used in the browser title.

JIRA
Application part of RHCLOUD-25356