### PR TITLE
feat: add new Ansible integration type

### DIFF
--- a/src/components/Integrations/Form/IntegrationTypeForm.tsx
+++ b/src/components/Integrations/Form/IntegrationTypeForm.tsx
@@ -41,6 +41,7 @@ export const IntegrationTypeForm: React.FunctionComponent<IntegrationTypeForm> =
 
     switch (props.type) {
         case IntegrationType.WEBHOOK:
+        case IntegrationType.ANSIBLE:
             return <IntegrationTypeHttpForm { ...props } />;
         default:
             assertNever(props.type);

--- a/src/components/Integrations/Form/IntegrationTypeHttpForm.tsx
+++ b/src/components/Integrations/Form/IntegrationTypeHttpForm.tsx
@@ -2,6 +2,7 @@ import { FormGroup } from '@patternfly/react-core';
 import { Checkbox, FormTextInput, ouiaIdConcat } from '@redhat-cloud-services/insights-common-typescript';
 import * as React from 'react';
 
+import { IntegrationType } from '../../../types/Integration';
 import { getOuiaProps } from '../../../utils/getOuiaProps';
 import { IntegrationTypeForm } from './IntegrationTypeForm';
 
@@ -22,16 +23,18 @@ export const IntegrationTypeHttpForm: React.FunctionComponent<IntegrationTypeFor
                 name="sslVerificationEnabled"
                 ouiaId={ ouiaIdConcat(props.ouiaId, 'is-ssl-verification-enabled') }
             />
-            <FormGroup fieldId='integration-type-http-secret-token'
-                helperText='The defined secret token is sent as a "X-Insight-Token" header on the request.'>
-                <FormTextInput
-                    isRequired={ false }
-                    label="Secret token"
-                    id="integration-type-http-secret-token"
-                    name="secretToken"
-                    ouiaId={ ouiaIdConcat(props.ouiaId, 'secret-token') }
-                />
-            </FormGroup>
+            { props.type !== IntegrationType.ANSIBLE &&
+                <FormGroup fieldId='integration-type-http-secret-token'
+                    helperText='The defined secret token is sent as a "X-Insight-Token" header on the request.'>
+                    <FormTextInput
+                        isRequired={ false }
+                        label="Secret token"
+                        id="integration-type-http-secret-token"
+                        name="secretToken"
+                        ouiaId={ ouiaIdConcat(props.ouiaId, 'secret-token') }
+                    />
+                </FormGroup>
+            }
         </div>
     );
 };

--- a/src/components/Integrations/Table/ExpandedContent/IntegrationExpandedContent.tsx
+++ b/src/components/Integrations/Table/ExpandedContent/IntegrationExpandedContent.tsx
@@ -24,9 +24,11 @@ export const IntegrationExpandedContent: React.FunctionComponent<ExpandedContent
                 <TextListItem className={ expandedContentTitleClass } component={ TextListItemVariants.dt }>
                     Authentication type
                 </TextListItem>
-                <TextListItem component={ TextListItemVariants.dd }>
-                    { props.integration.secretToken !== undefined ? 'Secret token' : 'None' }
-                </TextListItem>
+                { 'secretToken' in props.integration &&
+                    <TextListItem component={ TextListItemVariants.dd }>
+                        { props.integration.secretToken !== undefined ? 'Secret token' : 'None' }
+                    </TextListItem>
+                }
             </TextList>
         </TextContent>
     );

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -35,6 +35,9 @@ const integrationTypes: Record<IntegrationType, IntegrationTypeConfigBase> = {
     [IntegrationType.WEBHOOK]: {
         name: 'Webhook'
     },
+    [IntegrationType.ANSIBLE]: {
+        name: 'Event-Driven Ansible'
+    },
     [IntegrationType.EMAIL_SUBSCRIPTION]: {
         name: 'Email'
     },
@@ -97,7 +100,8 @@ const Config = {
                 UserIntegrationType.SLACK,
                 UserIntegrationType.SERVICE_NOW,
                 UserIntegrationType.TEAMS,
-                UserIntegrationType.GOOGLE_CHAT
+                UserIntegrationType.GOOGLE_CHAT,
+                UserIntegrationType.ANSIBLE
             ],
             fedramp: []
         }

--- a/src/generated/OpenapiIntegrations.ts
+++ b/src/generated/OpenapiIntegrations.ts
@@ -219,7 +219,11 @@ export namespace Schemas {
     | 'FAILED';
 
   export const EndpointType = zodSchemaEndpointType();
-  export type EndpointType = 'webhook' | 'email_subscription' | 'camel';
+  export type EndpointType =
+    | 'webhook'
+    | 'email_subscription'
+    | 'camel'
+    | 'ansible';
 
   export const Environment = zodSchemaEnvironment();
   export type Environment = 'PROD' | 'STAGE' | 'EPHEMERAL' | 'LOCAL_SERVER';
@@ -264,6 +268,7 @@ export namespace Schemas {
     application_id: UUID;
     description?: string | undefined | null;
     display_name: string;
+    fully_qualified_name?: string | undefined | null;
     id?: UUID | undefined | null;
     name: string;
   };
@@ -738,7 +743,7 @@ export namespace Schemas {
   }
 
   function zodSchemaEndpointType() {
-      return z.enum([ 'webhook', 'email_subscription', 'camel' ]);
+      return z.enum([ 'webhook', 'email_subscription', 'camel', 'ansible' ]);
   }
 
   function zodSchemaEnvironment() {
@@ -783,6 +788,7 @@ export namespace Schemas {
           application_id: zodSchemaUUID(),
           description: z.string().optional().nullable(),
           display_name: z.string(),
+          fully_qualified_name: z.string().optional().nullable(),
           id: zodSchemaUUID().optional().nullable(),
           name: z.string()
       })

--- a/src/generated/OpenapiNotifications.ts
+++ b/src/generated/OpenapiNotifications.ts
@@ -219,7 +219,11 @@ export namespace Schemas {
     | 'FAILED';
 
   export const EndpointType = zodSchemaEndpointType();
-  export type EndpointType = 'webhook' | 'email_subscription' | 'camel';
+  export type EndpointType =
+    | 'webhook'
+    | 'email_subscription'
+    | 'camel'
+    | 'ansible';
 
   export const Environment = zodSchemaEnvironment();
   export type Environment = 'PROD' | 'STAGE' | 'EPHEMERAL' | 'LOCAL_SERVER';
@@ -264,6 +268,7 @@ export namespace Schemas {
     application_id: UUID;
     description?: string | undefined | null;
     display_name: string;
+    fully_qualified_name?: string | undefined | null;
     id?: UUID | undefined | null;
     name: string;
   };
@@ -738,7 +743,7 @@ export namespace Schemas {
   }
 
   function zodSchemaEndpointType() {
-      return z.enum([ 'webhook', 'email_subscription', 'camel' ]);
+      return z.enum([ 'webhook', 'email_subscription', 'camel', 'ansible' ]);
   }
 
   function zodSchemaEnvironment() {
@@ -783,6 +788,7 @@ export namespace Schemas {
           application_id: zodSchemaUUID(),
           description: z.string().optional().nullable(),
           display_name: z.string(),
+          fully_qualified_name: z.string().optional().nullable(),
           id: zodSchemaUUID().optional().nullable(),
           name: z.string()
       })

--- a/src/pages/Notifications/EventLog/EventLogPage.tsx
+++ b/src/pages/Notifications/EventLog/EventLogPage.tsx
@@ -107,6 +107,7 @@ export const EventLogPage: React.FunctionComponent = () => {
             switch (type) {
                 case 'camel':
                 case 'webhook':
+                case 'ansible':
                     return endpoint.payload.value.name;
                 case 'email_subscription':
                     const properties = endpoint.payload.value.properties as Schemas.EmailSubscriptionProperties;

--- a/src/types/Integration.ts
+++ b/src/types/Integration.ts
@@ -10,11 +10,13 @@ export enum IntegrationType {
     SLACK = 'camel:slack',
     SERVICE_NOW = 'camel:servicenow',
     TEAMS = 'camel:teams',
-    GOOGLE_CHAT = 'camel:google_chat'
+    GOOGLE_CHAT = 'camel:google_chat',
+    ANSIBLE = 'ansible' // Event-Driven Ansible
 }
 
 export const UserIntegrationType = {
     WEBHOOK: IntegrationType.WEBHOOK,
+    ANSIBLE: IntegrationType.ANSIBLE,
     SPLUNK: IntegrationType.SPLUNK,
     SERVICE_NOW: IntegrationType.SERVICE_NOW,
     SLACK: IntegrationType.SLACK,
@@ -51,6 +53,11 @@ export interface IntegrationHttp extends IntegrationBase<IntegrationType.WEBHOOK
     method: Schemas.HttpType;
 }
 
+export interface IntegrationAnsible extends IntegrationBase<IntegrationType.ANSIBLE> {
+    url: string;
+    sslVerificationEnabled: boolean;
+}
+
 export interface IntegrationCamel extends IntegrationBase<CamelIntegrationType> {
     type: CamelIntegrationType;
     url: string;
@@ -70,7 +77,7 @@ export interface IntegrationEmailSubscription extends IntegrationBase<Integratio
     groupId?: UUID
 }
 
-export type Integration = IntegrationHttp | IntegrationEmailSubscription | IntegrationCamel;
+export type Integration = IntegrationHttp | IntegrationAnsible | IntegrationEmailSubscription | IntegrationCamel;
 export type TypedIntegration<T extends IntegrationType> = Extract<Integration, {
     type: T
 }>;

--- a/src/types/__tests__/Integration.test.ts
+++ b/src/types/__tests__/Integration.test.ts
@@ -3,6 +3,7 @@ import { IntegrationType, isCamelIntegrationType, isCamelType, isUserIntegration
 describe('src/types/Integration', () => {
     it('isCamelType returns true for camel subtypes', () => {
         expect(isCamelType(IntegrationType.WEBHOOK)).toBe(false);
+        expect(isCamelType(IntegrationType.ANSIBLE)).toBe(false);
         expect(isCamelType(IntegrationType.EMAIL_SUBSCRIPTION)).toBe(false);
         expect(isCamelType(IntegrationType.SPLUNK)).toBe(true);
         expect(isCamelType(IntegrationType.SLACK)).toBe(true);
@@ -19,6 +20,9 @@ describe('src/types/Integration', () => {
         expect(isCamelIntegrationType({})).toBe(false);
         expect(isCamelIntegrationType({
             type: IntegrationType.WEBHOOK
+        })).toBe(false);
+        expect(isCamelIntegrationType({
+            type: IntegrationType.ANSIBLE
         })).toBe(false);
         expect(isCamelIntegrationType({
             type: IntegrationType.SPLUNK
@@ -39,6 +43,7 @@ describe('src/types/Integration', () => {
 
     it('isUserIntegrationType returns true for UserIntegrationType', () => {
         expect(isUserIntegrationType(IntegrationType.WEBHOOK)).toBe(true);
+        expect(isUserIntegrationType(IntegrationType.ANSIBLE)).toBe(true);
         expect(isUserIntegrationType(IntegrationType.EMAIL_SUBSCRIPTION)).toBe(false);
         expect(isUserIntegrationType(IntegrationType.SPLUNK)).toBe(true);
         expect(isUserIntegrationType(IntegrationType.SLACK)).toBe(true);

--- a/src/types/adapters/IntegrationAdapter.ts
+++ b/src/types/adapters/IntegrationAdapter.ts
@@ -4,6 +4,7 @@ import { Schemas } from '../../generated/OpenapiIntegrations';
 import {
     CamelIntegrationType,
     Integration,
+    IntegrationAnsible,
     IntegrationBase,
     IntegrationCamel,
     IntegrationEmailSubscription,
@@ -59,6 +60,14 @@ const toIntegrationWebhook = (
     method: properties?.method ?? Schemas.HttpType.Enum.GET
 });
 
+const toIntegrationAnsible = (
+    integrationBase: IntegrationBase<IntegrationType.ANSIBLE>,
+    properties?: Schemas.WebhookProperties): IntegrationAnsible => ({
+    ...integrationBase,
+    url: properties?.url ?? '',
+    sslVerificationEnabled: !properties?.disable_ssl_verification ?? false
+});
+
 const toIntegrationCamel = (
     integrationBase: IntegrationBase<CamelIntegrationType>,
     properties?: Schemas.CamelProperties): IntegrationCamel => ({
@@ -109,6 +118,11 @@ export const toIntegration = (serverIntegration: ServerIntegrationResponse): Int
                 integrationBase as IntegrationBase<IntegrationType.WEBHOOK>,
                 serverIntegration.properties as Schemas.WebhookProperties
             );
+        case IntegrationType.ANSIBLE:
+            return toIntegrationAnsible(
+                integrationBase as IntegrationBase<IntegrationType.ANSIBLE>,
+                serverIntegration.properties as Schemas.WebhookProperties
+            );
         case IntegrationType.EMAIL_SUBSCRIPTION:
             return toIntegrationEmail(
                 integrationBase as IntegrationBase<IntegrationType.EMAIL_SUBSCRIPTION>,
@@ -152,6 +166,12 @@ export const toIntegrationProperties = (integration: Integration | NewIntegratio
                 method: integrationHttp.method,
                 disable_ssl_verification: !integrationHttp.sslVerificationEnabled,
                 secret_token: toSecretToken(integrationHttp.secretToken)
+            };
+        case IntegrationType.ANSIBLE:
+            const integrationAnsible = integration as IntegrationAnsible;
+            return {
+                url: integrationAnsible.url,
+                disable_ssl_verification: !integrationAnsible.sslVerificationEnabled
             };
         case IntegrationType.EMAIL_SUBSCRIPTION:
             const integrationEmail: IntegrationEmailSubscription = integration as IntegrationEmailSubscription;

--- a/src/types/adapters/NotificationAdapter.ts
+++ b/src/types/adapters/NotificationAdapter.ts
@@ -53,7 +53,7 @@ export const toNotification = (serverNotification: ServerNotificationResponse): 
 export const toAction = (serverAction: ServerIntegrationResponse): Action => {
     switch (serverAction.type) {
         case Schemas.EndpointType.enum.webhook:
-            return _toAction(NotificationType.INTEGRATION, serverAction);
+        case Schemas.EndpointType.enum.ansible:
         case Schemas.EndpointType.enum.camel:
             return _toAction(NotificationType.INTEGRATION, serverAction);
         case Schemas.EndpointType.enum.email_subscription:


### PR DESCRIPTION
The Ansible integration type is derived from the WebHook type. This will add support for Event-Driven Ansible.

RHCLOUD-25405