### PR TITLE
Order integration types alphabetically

### DIFF
--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -83,27 +83,27 @@ const Config = {
         types: computeIntegrationConfig(integrationTypes),
         actions: {
             stable: [
-                UserIntegrationType.WEBHOOK,
-                UserIntegrationType.SPLUNK,
+                UserIntegrationType.SERVICE_NOW,
                 UserIntegrationType.SLACK,
-                UserIntegrationType.SERVICE_NOW
+                UserIntegrationType.SPLUNK,
+                UserIntegrationType.WEBHOOK
             ],
             beta: [
-                UserIntegrationType.WEBHOOK,
-                UserIntegrationType.SPLUNK,
-                UserIntegrationType.SLACK,
-                UserIntegrationType.SERVICE_NOW,
+                UserIntegrationType.GOOGLE_CHAT,
                 UserIntegrationType.TEAMS,
-                UserIntegrationType.GOOGLE_CHAT
+                UserIntegrationType.SERVICE_NOW,
+                UserIntegrationType.SLACK,
+                UserIntegrationType.SPLUNK,
+                UserIntegrationType.WEBHOOK
             ],
             experimental: [
-                UserIntegrationType.WEBHOOK,
-                UserIntegrationType.SPLUNK,
-                UserIntegrationType.SLACK,
-                UserIntegrationType.SERVICE_NOW,
-                UserIntegrationType.TEAMS,
+                UserIntegrationType.ANSIBLE,
                 UserIntegrationType.GOOGLE_CHAT,
-                UserIntegrationType.ANSIBLE
+                UserIntegrationType.TEAMS,
+                UserIntegrationType.SERVICE_NOW,
+                UserIntegrationType.SLACK,
+                UserIntegrationType.SPLUNK,
+                UserIntegrationType.WEBHOOK
             ],
             fedramp: []
         }


### PR DESCRIPTION
This is a short term fix. On the longer term, we'll probably need to sort the array with some TypeScript function.