### PR TITLE
Enable drawer notification type

### DIFF
--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -46,6 +46,9 @@ const integrationTypes: Record<IntegrationType, IntegrationTypeConfigBase> = {
     },
     [IntegrationType.GOOGLE_CHAT]: {
         name: 'Google Chat'
+    },
+    [IntegrationType.DRAWER]: {
+        name: 'Drawer'
     }
 };
 
@@ -66,7 +69,7 @@ const computeIntegrationConfig = (base: Record<IntegrationType, IntegrationTypeC
 
     const transform = (type: IntegrationType, element: IntegrationTypeConfigBase): IntegrationTypeConfig => ({
         ...element,
-        action: type === IntegrationType.EMAIL_SUBSCRIPTION ? element.name : `Integration: ${element.name}`
+        action: [ IntegrationType.EMAIL_SUBSCRIPTION, IntegrationType.DRAWER ].includes(type) ? element.name : `Integration: ${element.name}`
     });
 
     Object.keys(base).forEach((key) => {

--- a/src/generated/OpenapiNotifications.ts
+++ b/src/generated/OpenapiNotifications.ts
@@ -168,6 +168,13 @@ export namespace Schemas {
     updatedIntegrations?: number | undefined | null;
   };
 
+  export const DrawerSubscriptionProperties = zodSchemaDrawerSubscriptionProperties();
+  export type DrawerSubscriptionProperties = {
+    group_id?: UUID | undefined | null;
+    only_admins: boolean;
+    ignore_preferences: boolean;
+  }
+
   export const EmailSubscriptionProperties =
     zodSchemaEmailSubscriptionProperties();
   export type EmailSubscriptionProperties = {
@@ -187,7 +194,7 @@ export namespace Schemas {
     id?: UUID | undefined | null;
     name: string;
     properties?:
-      | (WebhookProperties | EmailSubscriptionProperties | CamelProperties)
+      | (WebhookProperties | EmailSubscriptionProperties | CamelProperties | DrawerSubscriptionProperties)
       | undefined
       | null;
     server_errors?: number | undefined | null;
@@ -223,7 +230,8 @@ export namespace Schemas {
     | 'webhook'
     | 'email_subscription'
     | 'camel'
-    | 'ansible';
+    | 'ansible'
+    | 'drawer';
 
   export const Environment = zodSchemaEnvironment();
   export type Environment = 'PROD' | 'STAGE' | 'EPHEMERAL' | 'LOCAL_SERVER';
@@ -678,6 +686,15 @@ export namespace Schemas {
       .nonstrict();
   }
 
+  function zodSchemaDrawerSubscriptionProperties() {
+    return z
+      .object({
+          group_id: zodSchemaUUID().optional().nullable(),
+          only_admins: z.boolean()
+      })
+      .nonstrict();
+  }
+
   function zodSchemaEmailSubscriptionProperties() {
       return z
       .object({
@@ -743,7 +760,7 @@ export namespace Schemas {
   }
 
   function zodSchemaEndpointType() {
-      return z.enum([ 'webhook', 'email_subscription', 'camel', 'ansible' ]);
+      return z.enum([ 'webhook', 'email_subscription', 'camel', 'ansible', 'drawer' ]);
   }
 
   function zodSchemaEnvironment() {

--- a/src/pages/Notifications/BehaviorGroupWizard/useSaveBehaviorGroup.tsx
+++ b/src/pages/Notifications/BehaviorGroupWizard/useSaveBehaviorGroup.tsx
@@ -101,8 +101,8 @@ export const useSaveBehaviorGroup = (originalBehaviorGroup?: Partial<BehaviorGro
             isEqual
         );
 
-        if (toFetch.find(props => props.type !== NotificationType.EMAIL_SUBSCRIPTION)) {
-            throw new Error('Only email subscriptions are created when assigning behavior groups');
+        if (toFetch.find(props => ![ NotificationType.EMAIL_SUBSCRIPTION, NotificationType.DRAWER ].includes(props.type))) {
+            throw new Error('Only email and drawer subscriptions are created when assigning behavior groups');
         }
 
         if (toFetch.length > 0) {

--- a/src/pages/Notifications/EventLog/EventLogPage.tsx
+++ b/src/pages/Notifications/EventLog/EventLogPage.tsx
@@ -110,6 +110,7 @@ export const EventLogPage: React.FunctionComponent = () => {
                 case 'ansible':
                     return endpoint.payload.value.name;
                 case 'email_subscription':
+                case 'drawer':
                     const properties = endpoint.payload.value.properties as Schemas.EmailSubscriptionProperties;
                     if (properties.only_admins) {
                         return 'Users: Admin';

--- a/src/schemas/Integrations/Notifications.ts
+++ b/src/schemas/Integrations/Notifications.ts
@@ -11,7 +11,7 @@ const ActionIntegration = Yup.object({
 });
 
 const ActionNotify = Yup.object({
-    type: Yup.mixed().oneOf([ NotificationType.EMAIL_SUBSCRIPTION /*, NotificationType.DRAWER */ ]).required(),
+    type: Yup.mixed().oneOf([ NotificationType.EMAIL_SUBSCRIPTION, NotificationType.DRAWER ]).required(),
     recipient: Yup.array(Yup.object()).min(1),
     integrationId: Yup.string().min(0)
 });

--- a/src/services/Integrations/GetDefaultSystemEndpoint.ts
+++ b/src/services/Integrations/GetDefaultSystemEndpoint.ts
@@ -1,11 +1,18 @@
 import assertNever from 'assert-never';
 
 import { Operations } from '../../generated/OpenapiIntegrations';
-import { NotificationType, SystemProperties } from '../../types/Notification';
+import { isDrawerSystemProperties, isEmailSystemProperties, SystemProperties } from '../../types/Notification';
 
 export const getDefaultSystemEndpointAction = (systemProperties: SystemProperties) => {
-    if (systemProperties.type === NotificationType.EMAIL_SUBSCRIPTION) {
+    if (isEmailSystemProperties(systemProperties)) {
         return Operations.EndpointResourceGetOrCreateEmailSubscriptionEndpoint.actionCreator({
+            body: {
+                only_admins: systemProperties.props.onlyAdmins,
+                group_id: systemProperties.props.groupId
+            }
+        });
+    } else if (isDrawerSystemProperties(systemProperties)) {
+        return Operations.EndpointResourceGetOrCreateDrawerSubscriptionEndpoint.actionCreator({
             body: {
                 only_admins: systemProperties.props.onlyAdmins,
                 group_id: systemProperties.props.groupId
@@ -13,5 +20,5 @@ export const getDefaultSystemEndpointAction = (systemProperties: SystemPropertie
         });
     }
 
-    assertNever(systemProperties.type);
+    assertNever(systemProperties);
 };

--- a/src/types/Integration.ts
+++ b/src/types/Integration.ts
@@ -11,7 +11,8 @@ export enum IntegrationType {
     SERVICE_NOW = 'camel:servicenow',
     TEAMS = 'camel:teams',
     GOOGLE_CHAT = 'camel:google_chat',
-    ANSIBLE = 'ansible' // Event-Driven Ansible
+    ANSIBLE = 'ansible', // Event-Driven Ansible
+    DRAWER = 'drawer'
 }
 
 export const UserIntegrationType = {
@@ -60,6 +61,13 @@ export interface IntegrationAnsible extends IntegrationBase<IntegrationType.ANSI
     method: Schemas.HttpType;
 }
 
+export interface IntegrationDrawer extends IntegrationBase<IntegrationType.DRAWER> {
+  type: IntegrationType.DRAWER;
+  ignorePreferences: boolean;
+  onlyAdmin: boolean;
+  groupId?: UUID
+}
+
 export interface IntegrationCamel extends IntegrationBase<CamelIntegrationType> {
     type: CamelIntegrationType;
     url: string;
@@ -79,7 +87,7 @@ export interface IntegrationEmailSubscription extends IntegrationBase<Integratio
     groupId?: UUID
 }
 
-export type Integration = IntegrationHttp | IntegrationAnsible | IntegrationEmailSubscription | IntegrationCamel;
+export type Integration = IntegrationHttp | IntegrationAnsible | IntegrationEmailSubscription | IntegrationCamel | IntegrationDrawer;
 export type TypedIntegration<T extends IntegrationType> = Extract<Integration, {
     type: T
 }>;

--- a/src/types/Notification.ts
+++ b/src/types/Notification.ts
@@ -80,7 +80,24 @@ export type EmailSystemProperties = {
         groupId: undefined | UUID;
     }
 }
-export type SystemProperties = EmailSystemProperties;
+export type DrawerSystemProperties = {
+  type: NotificationType.DRAWER;
+    props: {
+        onlyAdmins: boolean;
+        groupId: undefined | UUID;
+        ignorePreferences: false;
+    }
+}
+
+export type SystemProperties = EmailSystemProperties | DrawerSystemProperties;
+
+export function isEmailSystemProperties(properties: SystemProperties): properties is EmailSystemProperties {
+    return properties.type === NotificationType.EMAIL_SUBSCRIPTION;
+}
+
+export function isDrawerSystemProperties(properties: SystemProperties): properties is DrawerSystemProperties {
+    return properties.type === NotificationType.DRAWER;
+}
 
 const getIntegrationIds = (actions: ReadonlyArray<Action | undefined>): Array<UUID | undefined> => {
     return actions.map(action => {

--- a/src/types/adapters/IntegrationAdapter.ts
+++ b/src/types/adapters/IntegrationAdapter.ts
@@ -7,6 +7,7 @@ import {
     IntegrationAnsible,
     IntegrationBase,
     IntegrationCamel,
+    IntegrationDrawer,
     IntegrationEmailSubscription,
     IntegrationHttp,
     IntegrationType, isCamelType,
@@ -96,6 +97,14 @@ const toIntegrationEmail = (
     onlyAdmin: properties.only_admins
 });
 
+const toIntegrationDrawer = (
+    integrationBase: IntegrationBase<IntegrationType.DRAWER>, properties: Schemas.DrawerProperties): IntegrationDrawer => ({
+    ...integrationBase,
+    ignorePreferences: properties.ignore_preferences,
+    groupId: properties.group_id === null ? undefined : properties.group_id,
+    onlyAdmin: properties.only_admins
+});
+
 export const toIntegration = (serverIntegration: ServerIntegrationResponse): Integration => {
 
     const integrationBase: IntegrationBase<IntegrationType> = {
@@ -130,6 +139,11 @@ export const toIntegration = (serverIntegration: ServerIntegrationResponse): Int
                 integrationBase as IntegrationBase<IntegrationType.EMAIL_SUBSCRIPTION>,
                 serverIntegration.properties as Schemas.EmailSubscriptionProperties
             );
+        case IntegrationType.DRAWER:
+            return toIntegrationDrawer(
+                  integrationBase as IntegrationBase<IntegrationType.DRAWER>,
+                  serverIntegration.properties as Schemas.DrawerProperties
+            );
         default:
             assertNever(integrationBase.type);
     }
@@ -140,7 +154,11 @@ export const toIntegrations = (serverIntegrations: Array<ServerIntegrationRespon
     .map(toIntegration);
 };
 
-type ServerIntegrationProperties = Schemas.EmailSubscriptionProperties | Schemas.WebhookProperties | Schemas.CamelProperties
+type ServerIntegrationProperties =
+  Schemas.EmailSubscriptionProperties |
+  Schemas.WebhookProperties |
+  Schemas.CamelProperties |
+  Schemas.DrawerProperties;
 
 export const toIntegrationProperties = (integration: Integration | NewIntegration): ServerIntegrationProperties => {
 
@@ -183,6 +201,13 @@ export const toIntegrationProperties = (integration: Integration | NewIntegratio
                 only_admins: integrationEmail.onlyAdmin,
                 group_id: integrationEmail.groupId,
                 ignore_preferences: integrationEmail.ignorePreferences
+            };
+        case IntegrationType.DRAWER:
+            const integrationDrawer: IntegrationDrawer = integration as IntegrationDrawer;
+            return {
+                only_admins: integrationDrawer.onlyAdmin,
+                group_id: integrationDrawer.groupId,
+                ignore_preferences: integrationDrawer.ignorePreferences
             };
         default:
             assertNever(type);


### PR DESCRIPTION
### Description

To fully enable notification drawer we need another notification type DRAWER. This will be enabled in notification group with option to choose which RBAC group is targeted and which events should be sent to user.

### Screenshots
![Screenshot from 2023-06-23 14-40-17](https://github.com/RedHatInsights/notifications-frontend/assets/3439771/ad8ff3e1-bd3e-4ffb-b24d-cf902b0c622a)
![Screenshot from 2023-06-23 14-40-23](https://github.com/RedHatInsights/notifications-frontend/assets/3439771/c503fdb9-335a-4e1e-aea9-f7d1e66dfdc2)
![Screenshot from 2023-06-23 14-40-35](https://github.com/RedHatInsights/notifications-frontend/assets/3439771/f63da76b-3a8a-4e0f-912e-97e53b4b374b)



### JIRA

[RHCLOUD-26545](https://issues.redhat.com/browse/RHCLOUD-26545)