### PR TITLE
RHCLOUD-26700 | feature: move Event Driven Ansible to "stable"

### DIFF
--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -101,6 +101,7 @@ const Config = {
         types: computeIntegrationConfig(integrationTypes),
         actions: {
             stable: sortedIntegrationList([
+                UserIntegrationType.ANSIBLE,
                 UserIntegrationType.GOOGLE_CHAT,
                 UserIntegrationType.TEAMS,
                 UserIntegrationType.SERVICE_NOW,


### PR DESCRIPTION
Since Red Hat Insights EDA v1.0.0 is available on the Automation Hub, we can consider this integration as "stable" now.

## Links

[[RHCLOUD-26700]](https://issues.redhat.com/browse/RHCLOUD-26700)