### PR TITLE
Enable overhaul navigation via feature flags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@redhat-cloud-services/frontend-components-utilities": "3.3.5",
         "@redhat-cloud-services/insights-common-typescript": "4.13.0",
         "@redhat-cloud-services/rbac-client": "1.2.2",
+        "@unleash/proxy-client-react": "3.6.0",
         "axios": "0.21.3",
         "camelcase": "5.3.1",
         "classnames": "2.2.6",
@@ -5338,6 +5339,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@unleash/proxy-client-react": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@unleash/proxy-client-react/-/proxy-client-react-3.6.0.tgz",
+      "integrity": "sha512-maQ3PYdBWUpIraD9z/2C8oVoCAS/EryV0WT4HiZQWxzrwvrZ+XHQJw1sImzRdWlGMvl1qJcgdEoxXhNSuYIrEQ==",
+      "peerDependencies": {
+        "unleash-proxy-client": "^2.5.0"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -21694,6 +21703,12 @@
       "resolved": "https://registry.npmjs.org/timezones.json/-/timezones.json-1.7.0.tgz",
       "integrity": "sha512-qzreOP+2sNmx6S3Cys0pEyI6t4qX0VPb4oFYMePUrYvQeBszGazzNpvWuAAGENGmpw7GoAND255NTkEQeXryvg=="
     },
+    "node_modules/tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
+      "peer": true
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
@@ -22433,6 +22448,16 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unleash-proxy-client": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-2.5.0.tgz",
+      "integrity": "sha512-GWYLcQDW2UVhqAVwZX7jNzD6Lp96UJXEi66r9MiDd/C3Xw7rbTdFziNJAhEZpLNqR7j75+TfZaEYMCMy/k778g==",
+      "peer": true,
+      "dependencies": {
+        "tiny-emitter": "^2.1.0",
+        "uuid": "^8.3.2"
       }
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@redhat-cloud-services/frontend-components-utilities": "3.3.5",
     "@redhat-cloud-services/insights-common-typescript": "4.13.0",
     "@redhat-cloud-services/rbac-client": "1.2.2",
+    "@unleash/proxy-client-react": "3.6.0",
     "axios": "0.21.3",
     "camelcase": "5.3.1",
     "classnames": "2.2.6",

--- a/src/__mocks__/@unleash/proxy-client-react/index.js
+++ b/src/__mocks__/@unleash/proxy-client-react/index.js
@@ -1,0 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const React = require('react');
+
+module.exports.useFlag = () => false;
+module.exports.FlagProvider = React.Fragment;
+module.exports.UnleashClient = class {};

--- a/src/__tests__/Routes.test.tsx
+++ b/src/__tests__/Routes.test.tsx
@@ -1,5 +1,6 @@
 import { IntlProvider } from '@redhat-cloud-services/frontend-components-translations';
 import { render, screen } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
 import * as React from 'react';
 
 import messages from '../../locales/data.json';
@@ -21,6 +22,11 @@ describe('src/Routes', () => {
 
         beforeEach(() => {
             appWrapperSetup();
+            fetchMock.get(`/api/featureflags/v0`, {
+                body: {
+                    toggles: []
+                }
+            });
         });
 
         afterEach(() => {

--- a/src/app/__tests__/App.test.tsx
+++ b/src/app/__tests__/App.test.tsx
@@ -51,6 +51,11 @@ describe('src/app/App', () => {
 
     beforeEach(() => {
         appWrapperSetup();
+        fetchMock.get(`/api/featureflags/v0`, {
+            body: {
+                toggles: []
+            }
+        });
     });
 
     afterEach(() => {

--- a/src/pages/Notifications/List/__tests__/Page.test.tsx
+++ b/src/pages/Notifications/List/__tests__/Page.test.tsx
@@ -303,6 +303,11 @@ const mockBehaviorGroupsOfEventTypes = (eventTypeId: string = defaultEventTypeId
 describe('src/pages/Notifications/List/Page', () => {
     beforeEach(() => {
         appWrapperSetup();
+        fetchMock.get(`/api/featureflags/v0`, {
+            body: {
+                toggles: []
+            }
+        });
     });
 
     afterEach(() => {


### PR DESCRIPTION
### Desctiption

Change navigation based on active flag and react to it by selecting correct route.

I've also removed legacy `chrome.on` function which shouldn't be used anymore (once we migrate over to react router v6 it can actually break a lot of interactions)