### PR TITLE
RHCLOUD-22647 update event-log filters to show correct status

### DIFF
--- a/src/components/Notifications/EventLog/EventLogToolbar.tsx
+++ b/src/components/Notifications/EventLog/EventLogToolbar.tsx
@@ -1,5 +1,6 @@
 import { PaginationProps, PaginationVariant } from '@patternfly/react-core';
 import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon, InProgressIcon } from '@patternfly/react-icons';
+import { global_warning_color_100 } from '@patternfly/react-tokens';
 import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components';
 import { ConditionalFilterProps } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 import { FilterChipsProps } from '@redhat-cloud-services/frontend-components/FilterChips';
@@ -10,6 +11,7 @@ import {
 import * as React from 'react';
 import { Dispatch } from 'react';
 import { SetStateAction } from 'react';
+import { style } from 'typestyle';
 
 import Config from '../../../config/Config';
 import { useIntegrations } from '../../../hooks/useIntegrations';
@@ -55,6 +57,10 @@ const notificationTypes: Record<NotificationType, { name: string }> = {
     }
 };
 
+const warningIconColorClassName = style({
+    color: global_warning_color_100.value
+});
+
 const actionStatusMetadata = [
     {
         value: 'true',
@@ -69,7 +75,7 @@ const actionStatusMetadata = [
     {
         value: 'false',
         chipValue: 'Warning',
-        label: <span><ExclamationTriangleIcon color='#F0AB00' /> Warning </span>
+        label: <span><ExclamationTriangleIcon className={ warningIconColorClassName } /> Warning </span>
     },
     {
         value: 'false',

--- a/src/components/Notifications/EventLog/EventLogToolbar.tsx
+++ b/src/components/Notifications/EventLog/EventLogToolbar.tsx
@@ -1,5 +1,5 @@
 import { PaginationProps, PaginationVariant } from '@patternfly/react-core';
-import { CheckCircleIcon, ExclamationCircleIcon } from '@patternfly/react-icons';
+import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon, InProgressIcon } from '@patternfly/react-icons';
 import { PrimaryToolbar } from '@redhat-cloud-services/frontend-components';
 import { ConditionalFilterProps } from '@redhat-cloud-services/frontend-components/ConditionalFilter';
 import { FilterChipsProps } from '@redhat-cloud-services/frontend-components/FilterChips';
@@ -60,6 +60,22 @@ const actionStatusMetadata = [
         value: 'true',
         chipValue: 'Success',
         label: <span><CheckCircleIcon color='green' /> Success</span>
+    },
+    {
+        value: 'false',
+        chipValue: 'Sent',
+        label: <span><CheckCircleIcon color='green' /> Sent</span>
+    },
+    {
+        value: 'false',
+        chipValue: 'Warning',
+        label: <span><ExclamationTriangleIcon color='#F0AB00' /> Warning </span>
+    },
+    {
+        value: 'false',
+        chipValue: 'Processing',
+        label: <span><InProgressIcon /> Processing </span>
+
     },
     {
         value: 'false',


### PR DESCRIPTION
Before - 
<img width="1419" alt="Screen Shot 2022-11-17 at 10 44 14 AM" src="https://github.com/RedHatInsights/notifications-frontend/assets/86322239/19000b69-9e66-4a7f-89b1-5d1bc5331293">

After - 
<img width="773" alt="Screen Shot 2023-08-24 at 1 54 07 PM" src="https://github.com/RedHatInsights/notifications-frontend/assets/86322239/4376828f-b2b3-4cb9-92f5-eabb6e91b4ad">
