### PR TITLE
Adjust integrations router

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    appUrl: '/settings/notifications',
+    appUrl: [ '/settings/notifications', 'settings/integrations' ],
     debug: true,
     useProxy: true,
     proxyVerbose: true,

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -58,6 +58,10 @@ const routesOverhaul: Path[] = [
         component: NotificationsOverviewPage
     },
     {
+        path: linkTo.integrations(),
+        component: ConnectedIntegrationsListPage
+    },
+    {
         path: linkTo.configureEvents(),
         component: NotificationsListPage
     },


### PR DESCRIPTION
### Description

When user navigates to integrations after the new UI overhaul they are greeted with blank page. This PR fixes such issue by adjusting the new router.