### PR TITLE
Add integrations fallback to empty page

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -14,6 +14,13 @@ module.exports = {
      */
     plugins: [],
     _unstableHotReload: process.env.HOT === 'true',
+    routes: {
+        ...(process.env.CONFIG_PORT && {
+            '/api/chrome-service/v1/static': {
+                host: `http://localhost:${process.env.CONFIG_PORT}`
+            }
+        })
+    },
     moduleFederation: {
         exposes: {
             './RootApp': path.resolve(__dirname, './src/AppEntry.tsx'),

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,3 +1,4 @@
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import * as React from 'react';
 import { Navigate, Route, Routes as DomRoutes } from 'react-router-dom';
 
@@ -23,7 +24,14 @@ export const linkTo = {
     splunk: () => '/integrations/splunk-setup'
 };
 
-const EmptyPage: React.FunctionComponent = () => null;
+const EmptyPage: React.FunctionComponent = () => {
+    const { getApp } = useChrome();
+    if (getApp() === 'integrations') {
+        return <IntegrationsListPage />;
+    }
+
+    return null;
+};
 
 const legacyRoutes: Path[] = [
     {


### PR DESCRIPTION
### Description

Since react router v6 doesn't pass down information about active app if application spans across two pages we have to check if on empty page `integrations` app is active. And if so render it.