### PR TITLE
expose TimeConfig modal

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -24,7 +24,8 @@ module.exports = {
     moduleFederation: {
         exposes: {
             './RootApp': path.resolve(__dirname, './src/AppEntry.tsx'),
-            './IntegrationsTable': path.resolve(__dirname, './src/IntegrationsEntry.tsx')
+            './IntegrationsTable': path.resolve(__dirname, './src/IntegrationsEntry.tsx'),
+            './TimeConfig': path.resolve(__dirname, './src/components/Notifications/TimeConfig.tsx')
         },
         shared: [
             {

--- a/src/components/Notifications/TimeConfig.tsx
+++ b/src/components/Notifications/TimeConfig.tsx
@@ -256,3 +256,4 @@ export const TimeConfigComponent: React.FunctionComponent = () => {
 
 };
 
+export default TimeConfigComponent;


### PR DESCRIPTION
part of [RHCLOUD-28511](https://issues.redhat.com/browse/RHCLOUD-28511)

need to expose the TimeConfig modal so it can be used in user-preferences-frontend