### PR TITLE
Make IntegrationsList use categories

### DIFF
--- a/src/IntegrationsEntry.tsx
+++ b/src/IntegrationsEntry.tsx
@@ -31,7 +31,7 @@ const IntegrationsEntry: React.FunctionComponent<AppEntryProps> = (props) => {
         <IntlProvider locale={ navigator.language.slice(0, 2) } messages={ messages } onError={ console.log }>
             <Provider store={ store }>
                 <ClientContextProvider client={ client }>
-                    <IntegrationsApp />
+                    <IntegrationsApp { ...props } />
                 </ClientContextProvider>
             </Provider>
         </IntlProvider>

--- a/src/app/IntegrationsApp.tsx
+++ b/src/app/IntegrationsApp.tsx
@@ -6,13 +6,22 @@ import * as React from 'react';
 
 import { NotificationsPortal } from '../components/Store/NotificationsPortal';
 import IntegrationsList from '../pages/Integrations/List/List';
+import { IntegrationCategory } from '../types/Integration';
 import { AppContext } from './AppContext';
 import { RbacGroupContextProvider } from './rbac/RbacGroupContextProvider';
 import { useApp } from './useApp';
 
-const IntegrationsApp: React.ComponentType = () => {
+interface IntegrationsAppProps {
+    activeCategory?: string
+}
+
+const IntegrationsApp: React.ComponentType<IntegrationsAppProps> = ({ activeCategory, ...props }: IntegrationsAppProps) => {
 
     const { rbac, server, isOrgAdmin } = useApp();
+
+    const category = (activeCategory && Object.values(IntegrationCategory).includes(activeCategory as unknown as IntegrationCategory))
+        ? activeCategory as IntegrationCategory
+        : undefined;
 
     return (rbac && server) ?
         <AppContext.Provider value={ {
@@ -22,7 +31,7 @@ const IntegrationsApp: React.ComponentType = () => {
         } }>
             <RbacGroupContextProvider>
                 <NotificationsPortal />
-                <IntegrationsList />
+                <IntegrationsList category={ category } { ...props } />
             </RbacGroupContextProvider>
         </AppContext.Provider>
         :

--- a/src/hooks/useIntegrations.ts
+++ b/src/hooks/useIntegrations.ts
@@ -1,11 +1,11 @@
 import { getInsights, getInsightsEnvironment } from '@redhat-cloud-services/insights-common-typescript';
 
 import { getIntegrationActions } from '../config/Config';
-import { UserIntegrationType } from '../types/Integration';
+import { IntegrationCategory, UserIntegrationType } from '../types/Integration';
 
-export const useIntegrations = (): ReadonlyArray<UserIntegrationType> => {
+export const useIntegrations = (category?: IntegrationCategory): ReadonlyArray<UserIntegrationType> => {
     const insights = getInsights();
     const environment = getInsightsEnvironment(insights);
 
-    return getIntegrationActions(environment);
+    return getIntegrationActions(environment, category);
 };

--- a/src/pages/Integrations/List/List.tsx
+++ b/src/pages/Integrations/List/List.tsx
@@ -42,8 +42,6 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({ categ
 
     const { rbac: { canWriteIntegrationsEndpoints }} = useContext(AppContext);
 
-    console.log('category', category);
-
     const integrationFilter = useIntegrationFilter();
     const userIntegrations = useIntegrations(category);
     const integrationFilterBuilder = React.useCallback((filters?: IntegrationFilters) => {

--- a/src/pages/Integrations/List/List.tsx
+++ b/src/pages/Integrations/List/List.tsx
@@ -15,7 +15,7 @@ import { useIntegrations } from '../../../hooks/useIntegrations';
 import { usePage } from '../../../hooks/usePage';
 import { useListIntegrationPQuery, useListIntegrationsQuery } from '../../../services/useListIntegrations';
 import { NotificationAppState } from '../../../store/types/NotificationAppState';
-import { UserIntegration } from '../../../types/Integration';
+import { IntegrationCategory, UserIntegration } from '../../../types/Integration';
 import { integrationExporterFactory } from '../../../utils/exporters/Integration/Factory';
 import { CreatePage } from '../Create/CreatePage';
 import { IntegrationDeleteModalPage } from '../Delete/DeleteModal';
@@ -32,15 +32,20 @@ const selector = (state: NotificationAppState) => ({
     savedNotificationScope: state.savedNotificationScope
 });
 
-const IntegrationsList: React.FunctionComponent = () => {
+interface IntegrationListProps {
+    category?: IntegrationCategory
+}
 
+const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({ category }: IntegrationListProps) => {
     const dispatch = useDispatch();
     const { savedNotificationScope } = useSelector(selector);
 
     const { rbac: { canWriteIntegrationsEndpoints }} = useContext(AppContext);
 
+    console.log('category', category);
+
     const integrationFilter = useIntegrationFilter();
-    const userIntegrations = useIntegrations();
+    const userIntegrations = useIntegrations(category);
     const integrationFilterBuilder = React.useCallback((filters?: IntegrationFilters) => {
         const filter = new Filter();
         if (filters?.enabled?.length === 1) {

--- a/src/types/Integration.ts
+++ b/src/types/Integration.ts
@@ -25,6 +25,12 @@ export const UserIntegrationType = {
     GOOGLE_CHAT: IntegrationType.GOOGLE_CHAT
 } as const;
 
+export enum IntegrationCategory {
+    COMMUNICATIONS = 'Communications',
+    REPORTING = 'Reporting',
+    WEBHOOKS = 'Webhooks',
+}
+
 export type Subtypes<U, S extends string> = U extends `${S}:${string}` ? U : never;
 export type CamelIntegrationType = Subtypes<IntegrationType, 'camel'>;
 


### PR DESCRIPTION
Another part of [RHCLOUD-28950](https://issues.redhat.com/browse/RHCLOUD-28950)

Enhanced Integrations list to be able to display entries for given categories - Communications, Reporting, Webhooks

