### PR TITLE
Add integration wizard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "notifications-frontend",
       "version": "1.1.0",
       "dependencies": {
+        "@data-driven-forms/pf4-component-mapper": "3.20.1",
+        "@data-driven-forms/react-form-renderer": "^3.21.10",
         "@patternfly/patternfly": "4.217.1",
         "@patternfly/react-core": "4.250.1",
         "@patternfly/react-icons": "4.92.6",
@@ -1821,6 +1823,56 @@
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@data-driven-forms/common": {
+      "version": "3.21.10",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/common/-/common-3.21.10.tgz",
+      "integrity": "sha512-Pys6dpMW0JOSiUISur3oZsLkg4gpPBtZY3WYb0C3Td/iPXufgI1Le2Vc8xsWeeLqwphafhMtPlOG3Kz045KvoQ==",
+      "dependencies": {
+        "clsx": "^1.0.4",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.2 || ^18.0.0",
+        "react-dom": "^16.13.1 || ^17.0.2 || ^18.0.0"
+      }
+    },
+    "node_modules/@data-driven-forms/pf4-component-mapper": {
+      "version": "3.20.1",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/pf4-component-mapper/-/pf4-component-mapper-3.20.1.tgz",
+      "integrity": "sha512-nY2VDuj6ljNh0Ayiunj9GdUkoafImFv6nXD+Ix6RgCYrFXgOKvnP8NBoRWPMQt3x5mFgPvbC58S2Lo+DM7msDQ==",
+      "dependencies": {
+        "@data-driven-forms/common": "^3.20.1",
+        "downshift": "^5.4.3",
+        "lodash": "^4.17.21",
+        "prop-types": "^15.7.2"
+      },
+      "peerDependencies": {
+        "@data-driven-forms/react-form-renderer": "^3.20.1",
+        "@patternfly/react-core": "^4.157.3",
+        "@patternfly/react-icons": "^4.11.7",
+        "react": "^16.13.1 || ^17.0.2 || ^18.0.0",
+        "react-dom": "^16.13.1 || ^17.0.2 || ^18.0.0"
+      }
+    },
+    "node_modules/@data-driven-forms/react-form-renderer": {
+      "version": "3.21.10",
+      "resolved": "https://registry.npmjs.org/@data-driven-forms/react-form-renderer/-/react-form-renderer-3.21.10.tgz",
+      "integrity": "sha512-/FUvxNDnQ8k3A1KVhW8HsjQXkvzyBmA01BCyPQJyWkRU9wNndaeFBvNgb7LHZ6jlpeSGXOpgwgdEpANFmU69zg==",
+      "dependencies": {
+        "final-form": "^4.20.4",
+        "final-form-arrays": "^3.0.2",
+        "final-form-focus": "^1.1.2",
+        "lodash": "^4.17.15",
+        "prop-types": "^15.7.2",
+        "react-final-form": "^6.5.0",
+        "react-final-form-arrays": "^3.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17.0.2 || ^18.0.0",
+        "react-dom": "^16.13.1 || ^17.0.2 || ^18.0.0"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -6881,6 +6933,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -7018,6 +7078,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
+    },
+    "node_modules/compute-scroll-into-view": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-1.0.20.tgz",
+      "integrity": "sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -8349,6 +8414,20 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/downshift": {
+      "version": "5.4.7",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-5.4.7.tgz",
+      "integrity": "sha512-xaH0RNqwJ5pAsyk9qBmR9XJWmg1OOWMfrhzYv0NH2NjJxn77S3zBcfClw341UfhGyKg5v+qVqg/CQzvAgBNCXQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.2",
+        "compute-scroll-into-view": "^1.0.14",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.13.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/duplexer": {
@@ -10098,6 +10177,37 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/final-form": {
+      "version": "4.20.10",
+      "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.20.10.tgz",
+      "integrity": "sha512-TL48Pi1oNHeMOHrKv1bCJUrWZDcD3DIG6AGYVNOnyZPr7Bd/pStN0pL+lfzF5BNoj/FclaoiaLenk4XUIFVYng==",
+      "dependencies": {
+        "@babel/runtime": "^7.10.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/final-form"
+      }
+    },
+    "node_modules/final-form-arrays": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/final-form-arrays/-/final-form-arrays-3.1.0.tgz",
+      "integrity": "sha512-TWBvun+AopgBLw9zfTFHBllnKMVNEwCEyDawphPuBGGqNsuhGzhT7yewHys64KFFwzIs6KEteGLpKOwvTQEscQ==",
+      "peerDependencies": {
+        "final-form": "^4.20.8"
+      }
+    },
+    "node_modules/final-form-focus": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/final-form-focus/-/final-form-focus-1.1.2.tgz",
+      "integrity": "sha512-Gd+Bd2Ll7ijo3/sd6kJ/bwLkhc2bUJPxTON6fIqee/008EJpACWhT+zoWCm9q6NcfMcWRS+Sp5ikRX8iqdXeGQ==",
+      "peerDependencies": {
+        "final-form": ">=1.3.0"
       }
     },
     "node_modules/finalhandler": {
@@ -19093,6 +19203,36 @@
       "peerDependencies": {
         "react": ">=16.8.4",
         "react-dom": ">=16.8.4"
+      }
+    },
+    "node_modules/react-final-form": {
+      "version": "6.5.9",
+      "resolved": "https://registry.npmjs.org/react-final-form/-/react-final-form-6.5.9.tgz",
+      "integrity": "sha512-x3XYvozolECp3nIjly+4QqxdjSSWfcnpGEL5K8OBT6xmGrq5kBqbA6+/tOqoom9NwqIPPbxPNsOViFlbKgowbA==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/final-form"
+      },
+      "peerDependencies": {
+        "final-form": "^4.20.4",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-final-form-arrays": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/react-final-form-arrays/-/react-final-form-arrays-3.1.4.tgz",
+      "integrity": "sha512-siVFAolUAe29rMR6u8VwepoysUcUdh6MLV2OWnCtKpsPRUdT9VUgECjAPaVMAH2GROZNiVB9On1H9MMrm9gdpg==",
+      "dependencies": {
+        "@babel/runtime": "^7.19.4"
+      },
+      "peerDependencies": {
+        "final-form": "^4.15.0",
+        "final-form-arrays": ">=1.0.4",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-final-form": "^6.2.1"
       }
     },
     "node_modules/react-intl": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "@redhat-cloud-services/frontend-components-utilities": "3.3.5",
     "@redhat-cloud-services/insights-common-typescript": "5.0.1",
     "@redhat-cloud-services/rbac-client": "1.2.2",
+    "@data-driven-forms/react-form-renderer": "3.21.10",
+    "@data-driven-forms/pf4-component-mapper": "3.20.1",
     "@unleash/proxy-client-react": "3.6.0",
     "axios": "0.21.3",
     "camelcase": "5.3.1",

--- a/src/pages/Integrations/Create/CreateWizard.tsx
+++ b/src/pages/Integrations/Create/CreateWizard.tsx
@@ -1,0 +1,36 @@
+import componentMapper from '@data-driven-forms/pf4-component-mapper/component-mapper';
+import Pf4FormTemplate from '@data-driven-forms/pf4-component-mapper/form-template';
+import FormRenderer from '@data-driven-forms/react-form-renderer/form-renderer';
+import * as React from 'react';
+
+import Review from './Review';
+import { schema } from './schema';
+
+export interface CreateWizardProps {
+    category?: string;
+    isOpen: boolean;
+    closeModal: () => void;
+}
+
+export const CreateWizard: React.FunctionComponent<CreateWizardProps> = ({ isOpen, closeModal, category }: CreateWizardProps) => {
+
+    const mapperExtension = {
+        'summary-content': Review
+    };
+
+    React.useEffect(() => {
+        console.log(`Active category: ${category}`);
+    }, [ category ]);
+
+    return isOpen ? (
+        <FormRenderer
+            schema={ schema }
+            FormTemplate={ Pf4FormTemplate }
+            componentMapper={ { ...componentMapper, ...mapperExtension } }
+            onSubmit={ (props) => {
+                console.log(props);
+                closeModal();
+            } }
+            onCancel={ () => closeModal() }
+        />) : null;
+};

--- a/src/pages/Integrations/Create/Review.tsx
+++ b/src/pages/Integrations/Create/Review.tsx
@@ -1,0 +1,33 @@
+import useFormApi from '@data-driven-forms/react-form-renderer/use-form-api';
+import { Grid, GridItem, Stack, StackItem, Text, TextVariants } from '@patternfly/react-core';
+import React from 'react';
+
+const Review: React.FunctionComponent = () => {
+    const formOptions = useFormApi();
+    const {
+        'integration-name': name
+    } = formOptions.getState().values;
+
+    return (
+        <Stack hasGutter>
+            <StackItem>
+                <Stack hasGutter>
+                    <StackItem>
+                        <Grid>
+                            <GridItem md={ 3 }>
+                                <Text component={ TextVariants.h4 }>
+                                Integration name
+                                </Text>
+                            </GridItem>
+                            <GridItem md={ 9 }>
+                                <Text component={ TextVariants.p }>{name}</Text>
+                            </GridItem>
+                        </Grid>
+                    </StackItem>
+                </Stack>
+            </StackItem>
+        </Stack>
+    );
+};
+
+export default Review;

--- a/src/pages/Integrations/Create/schema.ts
+++ b/src/pages/Integrations/Create/schema.ts
@@ -1,0 +1,44 @@
+import { componentTypes } from '@data-driven-forms/react-form-renderer';
+
+export const schema = {
+    fields: [
+        {
+            component: componentTypes.WIZARD,
+            inModal: true,
+            title: 'Add integration',
+            description: 'Configure integrations between third-party tools and the Red Hat Hybrid Cloud Console.',
+            name: 'add-integration-wizard',
+            fields: [
+                {
+                    title: 'Enter details',
+                    name: 'details',
+                    nextStep: 'review',
+                    fields: [
+                        {
+                            component: componentTypes.TEXT_FIELD,
+                            name: 'integration-name',
+                            type: 'text',
+                            label: 'Integration name',
+                            isRequired: true,
+                            validate: [
+                                {
+                                    type: 'required'
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    title: 'Review',
+                    name: 'review',
+                    fields: [
+                        {
+                            component: 'summary-content',
+                            name: 'summary-content'
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+};

--- a/src/pages/Integrations/List/List.tsx
+++ b/src/pages/Integrations/List/List.tsx
@@ -17,7 +17,9 @@ import { useListIntegrationPQuery, useListIntegrationsQuery } from '../../../ser
 import { NotificationAppState } from '../../../store/types/NotificationAppState';
 import { IntegrationCategory, UserIntegration } from '../../../types/Integration';
 import { integrationExporterFactory } from '../../../utils/exporters/Integration/Factory';
+import { usePreviewFlag } from '../../../utils/usePreviewFlag';
 import { CreatePage } from '../Create/CreatePage';
+import { CreateWizard } from '../Create/CreateWizard';
 import { IntegrationDeleteModalPage } from '../Delete/DeleteModal';
 import { useActionResolver } from './useActionResolver';
 import { useIntegrationFilter } from './useIntegrationFilter';
@@ -38,6 +40,7 @@ interface IntegrationListProps {
 
 const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({ category }: IntegrationListProps) => {
     const dispatch = useDispatch();
+    const wizardEnabled = usePreviewFlag('insights.integrations.wizard');
     const { savedNotificationScope } = useSelector(selector);
 
     const { rbac: { canWriteIntegrationsEndpoints }} = useContext(AppContext);
@@ -190,13 +193,19 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({ categ
                     sortBy={ sort.sortBy }
                 />
             </IntegrationsToolbar>
-            { modalIsOpenState.isOpen && (
+            { modalIsOpenState.isOpen && !wizardEnabled && (
                 <CreatePage
                     isEdit={ modalIsOpenState.isEdit }
                     initialIntegration={ modalIsOpenState.template || {} }
                     onClose={ closeFormModal }
                 />
             ) }
+            {wizardEnabled && (
+                <CreateWizard
+                    isOpen={ modalIsOpenState.isOpen }
+                    closeModal={ () => modalIsOpenActions.reset() }
+                    category={ category } />
+            )}
             { deleteModalState.data && (
                 <IntegrationDeleteModalPage
                     onClose={ closeDeleteModal }

--- a/src/utils/usePreviewFlag.ts
+++ b/src/utils/usePreviewFlag.ts
@@ -1,0 +1,13 @@
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useFlag } from '@unleash/proxy-client-react';
+
+export const usePreviewFlag = (flag) => {
+    const { isBeta, getEnvironment } = useChrome();
+    const flagValue = useFlag(flag);
+
+    if (getEnvironment() === 'prod' && isBeta() === false) {
+        return false;
+    }
+
+    return flagValue;
+};


### PR DESCRIPTION
Initialized DDF for "Add integration wizard" which should be a base for 
[RHCLOUD-28957](https://issues.redhat.com/browse/RHCLOUD-28957)
[RHCLOUD-28959](https://issues.redhat.com/browse/RHCLOUD-28959)
[RHCLOUD-28960](https://issues.redhat.com/browse/RHCLOUD-28960)

- added first and review step + passing of active integrations tab
- wizard opens and closes
- hidden the wizard behind `insights.integrations.wizard` flag

![chrome-capture-2023-10-7](https://github.com/RedHatInsights/notifications-frontend/assets/50696716/bde053ae-abed-48e1-a273-86373c6475f4)
