### PR TITLE
RHCLOUD-29462: overview top accordion item should be open by default

### DIFF
--- a/src/pages/Notifications/Overview/CustomDataListItem.tsx
+++ b/src/pages/Notifications/Overview/CustomDataListItem.tsx
@@ -38,6 +38,7 @@ interface CustomDataListItemProps {
   linkTarget?: string;
   expandableContent: string;
   isRedirect?: boolean;
+  isExpanded?: boolean;
 }
 
 const CustomDataListItem: React.FC<CustomDataListItemProps> = ({
@@ -47,10 +48,11 @@ const CustomDataListItem: React.FC<CustomDataListItemProps> = ({
   linkTarget,
   expandableContent,
   isRedirect,
+  isExpanded,
 }) => {
   const navigate = useNavigate();
   let iconElement: React.ReactNode = null;
-  const [expanded, setExpanded] = React.useState(false);
+  const [expanded, setExpanded] = React.useState(isExpanded || false);
 
   switch (icon) {
     case IconName.USER:

--- a/src/pages/Notifications/Overview/Page.tsx
+++ b/src/pages/Notifications/Overview/Page.tsx
@@ -255,6 +255,7 @@ export const NotificationsOverviewPage: React.FunctionComponent = () => {
             >
               <CustomDataListItem
                 icon={IconName.USER}
+                isExpanded
                 heading="Manage your own notifications with My User Preferences"
                 linkTitle="Go to My User Preferences"
                 linkTarget={`${


### PR DESCRIPTION

![Screenshot 2023-11-28 at 3 16 09 PM](https://github.com/RedHatInsights/notifications-frontend/assets/21317056/34f8e81e-df3c-4c65-a96d-047bc54d14ec)


Resolves https://issues.redhat.com/browse/RHCLOUD-29462