### PR TITLE
SPUR reordering + coloring of UI elements

### DIFF
--- a/src/components/Notifications/NotificationsBehaviorGroupTable.tsx
+++ b/src/components/Notifications/NotificationsBehaviorGroupTable.tsx
@@ -257,15 +257,17 @@ export const NotificationsBehaviorGroupTable =
       >
         <Thead>
           <Tr>
-            <Th sort={sortOptions[NotificationsTableColumns.EVENT]}>Event</Th>
+            <Th sort={sortOptions[NotificationsTableColumns.EVENT]}>
+              Event Type
+            </Th>
             <Th sort={sortOptions[NotificationsTableColumns.APPLICATION]}>
-              Application
+              Service
             </Th>
             <Th
               sort={sortOptions[NotificationsTableColumns.BEHAVIOR]}
               width={35}
             >
-              Behavior
+              Configuration
             </Th>
             <Th />
           </Tr>

--- a/src/components/Notifications/Toolbar.tsx
+++ b/src/components/Notifications/Toolbar.tsx
@@ -81,8 +81,8 @@ export const NotificationsToolbar: React.FunctionComponent<NotificationsToolbarP
           NotificationFilterColumn.APPLICATION
         )
           ? {
-              label: 'Application',
-              placeholder: 'Filter by application',
+              label: 'Service',
+              placeholder: 'Filter by service',
               options: {
                 exclusive: false,
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/pages/Notifications/List/BundlePage.tsx
+++ b/src/pages/Notifications/List/BundlePage.tsx
@@ -145,6 +145,17 @@ export const NotificationListBundlePage: React.FunctionComponent<NotificationLis
                 className={paddingLeftClassName}
               >
                 <Tab
+                  eventKey={2}
+                  title={<TabTitleText>Openshift</TabTitleText>}
+                >
+                  <Main>
+                    <BundlePageBehaviorGroupContent
+                      applications={getInitialApplications}
+                      bundle={props.bundleTabs[2]}
+                    />
+                  </Main>
+                </Tab>
+                <Tab
                   eventKey={0}
                   title={<TabTitleText>Red Hat Enterprise Linux</TabTitleText>}
                 >
@@ -160,17 +171,6 @@ export const NotificationListBundlePage: React.FunctionComponent<NotificationLis
                     <BundlePageBehaviorGroupContent
                       applications={getInitialApplications}
                       bundle={props.bundleTabs[1]}
-                    />
-                  </Main>
-                </Tab>
-                <Tab
-                  eventKey={2}
-                  title={<TabTitleText>Openshift</TabTitleText>}
-                >
-                  <Main>
-                    <BundlePageBehaviorGroupContent
-                      applications={getInitialApplications}
-                      bundle={props.bundleTabs[2]}
                     />
                   </Main>
                 </Tab>


### PR DESCRIPTION
[RHCLOUD-29455](https://issues.redhat.com/browse/RHCLOUD-29455)

Fixes for the following SPUR issues:
- (SPUR 1) Update order of tabs on the notifications config page
- (SPUR 2) _No work needed_
- (SPUR 3) Update column headers in configuration page
- (SPUR 6) Update "application" to "service" in the toolbar

_SPUR 4 will be covered by another PR*_