### PR TITLE
RHCLOUD-29992 various fixes on Integrations page

### DIFF
--- a/src/components/Integrations/DopeBox.tsx
+++ b/src/components/Integrations/DopeBox.tsx
@@ -65,7 +65,7 @@ const DopeBox: React.FC<DopeBoxProps> = ({ category }) => {
                     <Icon className="pf-v5-u-pl-sm pf-v5-u-pr-md">
                       <CogIcon />
                     </Icon>
-                    Configure Applications
+                    Configure applications
                   </Text>
                   <Text component="p" className="pf-u-flex-grow-1">
                     To prepare for integration with the Hybrid Cloud Console,
@@ -161,7 +161,7 @@ const DopeBox: React.FC<DopeBoxProps> = ({ category }) => {
                   <Text component="p" className="pf-u-flex-grow-1">
                     To configure notifications and integration settings, you
                     must be a member of a group with the Notifications
-                    adminstrator role. This group must be configured in User
+                    administrator role. This group must be configured in User
                     Access by an Organization Administrator.
                   </Text>
                   <Text component="p">
@@ -195,12 +195,12 @@ const DopeBox: React.FC<DopeBoxProps> = ({ category }) => {
                     <Icon className="pf-v5-u-pl-sm pf-v5-u-pr-md">
                       <BellIcon />
                     </Icon>
-                    Configure Notifications Portal
+                    Configure notifications portal
                   </Text>
                   <Text component="p" className="pf-u-flex-grow-1">
-                    You can configure the Red Hat Cloud Console to send event
+                    You can configure the Hybrid Cloud Console to send event
                     notifications to all users on a new or existing channel in
-                    Google Chat, Microsoft Teams, or Slack.
+                    Slack, Google Chat, or Microsoft Teams.
                   </Text>
                   <Text component="p">
                     <Link

--- a/src/components/Integrations/EmptyState.tsx
+++ b/src/components/Integrations/EmptyState.tsx
@@ -106,7 +106,7 @@ export const IntegrationsEmptyState: React.FunctionComponent<{
                 isOrgAdmin={isOrgAdmin}
                 TitleIcon={InfrastructureIcon}
                 title="Create behavior groups"
-                body="A behavior group defines which notifications will be sent to external services when a specific event is received by the notifications service. You can link events from any Red Hat Hybrid Cloud Console service to your behavior group."
+                body="A behavior group defines which notifications will be sent to external services when a specific event is received by the notifications service. You can link events from any Hybrid Cloud Console service to your behavior group."
                 link="https://access.redhat.com/documentation/en-us/red_hat_hybrid_cloud_console/2023/html/configuring_notifications_on_the_red_hat_hybrid_cloud_console/assembly-config-behavior-groups_notifications"
               />
             )}

--- a/src/components/Integrations/Table/IntegrationStatus.tsx
+++ b/src/components/Integrations/Table/IntegrationStatus.tsx
@@ -80,7 +80,7 @@ export const StatusSuccess: React.FunctionComponent<DegradedProps> = (
       <CheckCircleIcon
         data-testid="success-icon"
         color={global_success_color_100.value}
-      />
+      />{' '}
     </Status>
   </Degraded>
 );
@@ -93,7 +93,7 @@ export const StatusEventFailure: React.FunctionComponent<DegradedProps> = (
       <ExclamationCircleIcon
         data-testid="fail-icon"
         color={global_danger_color_100.value}
-      />
+      />{' '}
     </Status>
   </Degraded>
 );
@@ -103,7 +103,7 @@ export const StatusReady: React.FunctionComponent<unknown> = () => (
     <CheckCircleIcon
       data-testid="success-icon"
       color={global_success_color_100.value}
-    />
+    />{' '}
   </Status>
 );
 
@@ -112,18 +112,18 @@ export const StatusCreationFailure: React.FunctionComponent<unknown> = () => (
     <ExclamationCircleIcon
       data-testid="fail-icon"
       color={global_danger_color_100.value}
-    />
+    />{' '}
   </Status>
 );
 
 export const StatusProcessing: React.FunctionComponent<unknown> = () => (
   <Status text="Processing">
-    <InProgressIcon data-testid="in-progress-icon" />
+    <InProgressIcon data-testid="in-progress-icon" />{' '}
   </Status>
 );
 
 export const StatusUnknown: React.FunctionComponent<unknown> = () => (
   <Status text="Error loading status">
-    <UnknownIcon data-testid="unknown-icon" />
+    <UnknownIcon data-testid="unknown-icon" />{' '}
   </Status>
 );


### PR DESCRIPTION
Jira [RHCLOUD-29992](https://issues.redhat.com/browse/RHCLOUD-29992)

Fixes:

The first two items are being taken care of separately in sourcesUI
> 
> Cloud tab - button says Add source (should it be Add integration?). Same with 'Add a cloud source' wizard - "Add a cloud integration'?
> Red Hat tab - wizard should be 'Add Red Hat integration'

Communications
- under "Configure User Access' - typo in the copy "Notifications adminstrator role"
- under Next Steps - edit "Red Hat Cloud Console" to "Hybrid Cloud Console", and "to send even notifications" --> change to 'event notifications'
- under Next Steps - should the order be changed to 'Slack, Google Chat, or  Microsoft Teams' to align with the order under Getting Started
- General comment about the headings - Configure Applications - 'applications' can be lower case, same with 'Configure notifications portal'. Is 'portal the correct word? (Not sure, disregard if yes!)

Reporting & Automation - No integrations yet
Under 'Create behavior groups', you could remove 'Red Hat' and just call it 'Hybrid Cloud Console' like in the other descriptions.

Nit - Under 'Last connection attempt', the green check icon seems to need a space before the word Ready.