### PR TITLE
Fix integrations empty state

### DIFF
--- a/src/components/Integrations/Table.tsx
+++ b/src/components/Integrations/Table.tsx
@@ -5,7 +5,7 @@ import {
   Spinner,
   Switch,
 } from '@patternfly/react-core';
-import { CubesIcon, HelpIcon } from '@patternfly/react-icons';
+import { HelpIcon, SearchIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import styles from '@patternfly/react-styles/css/components/Table/table';
 import {
@@ -390,7 +390,7 @@ export const IntegrationsTable: React.FunctionComponent<IntegrationsTableProps> 
       return (
         <EmptyStateSearch
           variant={EmptyStateVariant.full}
-          icon={CubesIcon}
+          icon={SearchIcon}
           title={intl.formatMessage(messages.integrationsEmptyStateTitle)}
           description={intl.formatMessage(
             messages.integrationsTableEmptyStateBody

--- a/src/pages/Integrations/List/List.tsx
+++ b/src/pages/Integrations/List/List.tsx
@@ -245,7 +245,9 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
     ) || 10;
 
   const integrationsEmpty =
-    integrations.count < 1 && !integrationsQuery.loading;
+    integrations.count < 1 &&
+    !integrationsQuery.loading &&
+    Object.values(integrationFilter.filters).every((filter) => !filter);
 
   return (
     <>
@@ -256,38 +258,42 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
           }
         />
       )}
-      {!integrationsEmpty && <IntegrationsDopeBox category={category} />}
       {!integrationsEmpty && (
-        <IntegrationsToolbar
-          onAddIntegration={
-            canWriteIntegrationsEndpoints ? onAddIntegrationClicked : undefined
-          }
-          onExport={onExport}
-          filters={integrationFilter.filters}
-          setFilters={integrationFilter.setFilters}
-          clearFilters={integrationFilter.clearFilter}
-          count={integrations.count || 0}
-          pageCount={integrations.data.length}
-          page={pageData.page.index}
-          perPage={pageData.page.size}
-          pageChanged={pageData.changePage}
-          perPageChanged={pageData.changeItemsPerPage}
-        >
-          <IntegrationsTable
-            isLoading={integrationsQuery.loading}
-            loadingCount={loadingCount}
-            integrations={integrationRows.rows}
-            onCollapse={integrationRows.onCollapse}
-            onEnable={
+        <>
+          <IntegrationsDopeBox category={category} />
+          <IntegrationsToolbar
+            onAddIntegration={
               canWriteIntegrationsEndpoints
-                ? integrationRows.onEnable
+                ? onAddIntegrationClicked
                 : undefined
             }
-            actionResolver={actionResolver}
-            onSort={sort.onSort}
-            sortBy={sort.sortBy}
-          />
-        </IntegrationsToolbar>
+            onExport={onExport}
+            filters={integrationFilter.filters}
+            setFilters={integrationFilter.setFilters}
+            clearFilters={integrationFilter.clearFilter}
+            count={integrations.count || 0}
+            pageCount={integrations.data.length}
+            page={pageData.page.index}
+            perPage={pageData.page.size}
+            pageChanged={pageData.changePage}
+            perPageChanged={pageData.changeItemsPerPage}
+          >
+            <IntegrationsTable
+              isLoading={integrationsQuery.loading}
+              loadingCount={loadingCount}
+              integrations={integrationRows.rows}
+              onCollapse={integrationRows.onCollapse}
+              onEnable={
+                canWriteIntegrationsEndpoints
+                  ? integrationRows.onEnable
+                  : undefined
+              }
+              actionResolver={actionResolver}
+              onSort={sort.onSort}
+              sortBy={sort.sortBy}
+            />
+          </IntegrationsToolbar>
+        </>
       )}
       {modalIsOpenState.isOpen && !wizardEnabled && (
         <CreatePage

--- a/src/properties/DefinedMessages.ts
+++ b/src/properties/DefinedMessages.ts
@@ -14,11 +14,12 @@ export default defineMessages({
   integrationsEmptyStateTitle: {
     id: 'integrationsEmptyStateTitle',
     description: 'Integrations Empty State title',
-    defaultMessage: 'No integrations',
+    defaultMessage: 'No integrations found',
   },
   integrationsTableEmptyStateBody: {
     id: 'integrationsTableEmptyStateBody',
     description: 'Integrations Empty State body',
-    defaultMessage: 'Connect to webhooks and external applications.',
+    defaultMessage:
+      'No integrations match the filter criteria. Remove all filters or clear all filters to show integrations.',
   },
 });


### PR DESCRIPTION
Fixes [RHCLOUD-30785](https://issues.redhat.com/browse/RHCLOUD-30785)

Before
[Video](https://github.com/RedHatInsights/notifications-frontend/assets/50696716/e9d1d24b-a987-4a63-9382-cfed9ec28e32)


Now
![image](https://github.com/RedHatInsights/notifications-frontend/assets/50696716/e460264a-e973-47f0-8900-6cad2d00a692)

- fixed the table empty state to appear on filtering instead of the global one
- made the empty state consistent with Sources UI (icon & wording)