### PR TITLE
BehaviorGroups tab reroute fix.

### DIFF
--- a/src/components/Notifications/TabComponent.tsx
+++ b/src/components/Notifications/TabComponent.tsx
@@ -13,8 +13,7 @@ export const TabComponent: React.FunctionComponent<
   const [activeTabKey, setActiveTabKey] = React.useState(activeKey);
 
   const handleTabSelect = (
-    // eslint-disable-next-line
-    event: React.MouseEvent<HTMLElement, MouseEvent>,
+    _e: React.MouseEvent<HTMLElement, MouseEvent>,
     tabIndex: number | string
   ) => {
     setActiveTabKey(tabIndex as number);

--- a/src/components/Notifications/TabComponent.tsx
+++ b/src/components/Notifications/TabComponent.tsx
@@ -9,12 +9,16 @@ interface MyTabComponentProps {
 
 export const TabComponent: React.FunctionComponent<
   React.PropsWithChildren<MyTabComponentProps>
-> = (props) => {
-  const [activeTabKey, setActiveTabKey] = React.useState(0);
+> = ({ activeKey = 0, ...props }) => {
+  const [activeTabKey, setActiveTabKey] = React.useState(activeKey);
 
-  const handleTabClick = React.useCallback((tabIndex) => {
-    setActiveTabKey(tabIndex);
-  }, []);
+  const handleTabSelect = (
+    // eslint-disable-next-line
+    event: React.MouseEvent<HTMLElement, MouseEvent>,
+    tabIndex: number | string
+  ) => {
+    setActiveTabKey(tabIndex as number);
+  };
 
   return (
     <div className="pf-v5-u-background-color-100">
@@ -22,7 +26,7 @@ export const TabComponent: React.FunctionComponent<
         className="pf-v5-u-pl-lg"
         activeKey={activeTabKey}
         role="region"
-        onClick={handleTabClick}
+        onSelect={handleTabSelect}
       >
         {props.children}
       </Tabs>

--- a/src/components/Notifications/TabComponent.tsx
+++ b/src/components/Notifications/TabComponent.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 interface MyTabComponentProps {
   configuration: React.ReactNode;
   settings: React.ReactNode;
+  activeKey?: number;
 }
 
 export const TabComponent: React.FunctionComponent<
@@ -19,7 +20,7 @@ export const TabComponent: React.FunctionComponent<
     <div className="pf-v5-u-background-color-100">
       <Tabs
         className="pf-v5-u-pl-lg"
-        defaultActiveKey={activeTabKey}
+        activeKey={activeTabKey}
         role="region"
         onClick={handleTabClick}
       >

--- a/src/pages/Notifications/List/BundlePageBehaviorGroupContent.tsx
+++ b/src/pages/Notifications/List/BundlePageBehaviorGroupContent.tsx
@@ -1,5 +1,6 @@
 import { Tab, TabTitleText } from '@patternfly/react-core';
 import { ExporterType } from '@redhat-cloud-services/insights-common-typescript';
+import { useLocation } from 'react-router-dom';
 import * as React from 'react';
 
 import { useAppContext } from '../../../app/AppContext';
@@ -23,12 +24,23 @@ interface BundlePageBehaviorGroupContentProps {
   bundle: Facet;
 }
 
+enum TabIndex {
+  Configuration = 0,
+  BehaviorGroups = 1,
+}
+
 const noEvents = [];
 
 export const BundlePageBehaviorGroupContent: React.FunctionComponent<
   React.PropsWithChildren<BundlePageBehaviorGroupContentProps>
 > = (props) => {
   const behaviorGroupContent = useBehaviorGroupContent(props.bundle.id);
+  const location = useLocation();
+  const queryParams = new URLSearchParams(location.search);
+  const activeTab =
+    queryParams.get('activeTab') === 'behaviorGroups'
+      ? TabIndex.BehaviorGroups
+      : TabIndex.Configuration;
 
   const { rbac } = useAppContext();
 
@@ -116,7 +128,11 @@ export const BundlePageBehaviorGroupContent: React.FunctionComponent<
   );
 
   return (
-    <TabComponent configuration={props.children} settings={props.children}>
+    <TabComponent
+      configuration={props.children}
+      settings={props.children}
+      activeKey={activeTab}
+    >
       <Tab eventKey={0} title={<TabTitleText>Configuration</TabTitleText>}>
         <NotificationsToolbar
           filters={eventTypePage.filters}

--- a/src/pages/Notifications/List/__tests__/BundlePageBehaviorGroupContent.test.tsx
+++ b/src/pages/Notifications/List/__tests__/BundlePageBehaviorGroupContent.test.tsx
@@ -10,6 +10,7 @@ import {
 } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import * as React from 'react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 
 import {
   appWrapperCleanup,
@@ -25,6 +26,25 @@ import EventType = Schemas.EventType;
 import { ouiaSelectors } from '@redhat-cloud-services/frontend-components-testing';
 import userEvent from '@testing-library/user-event';
 import Endpoint = Schemas.Endpoint;
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn(),
+}));
+
+// beforeEach(() => {
+//   (useLocation as jest.Mock).mockReturnValue({
+//     pathname: '/settings/notifications',
+//     search: '?activeTab=BehaviorGroups',
+//     state: {},
+//     hash: '',
+//     key: 'testKey',
+//   });
+// });
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
 
 const policiesApplication: Facet = {
   id: 'app-1',
@@ -304,52 +324,29 @@ describe('src/pages/Notifications/List/BundlePageBehaviorGroupContent', () => {
     await waitFor(() => expect(screen.getAllByText(/Baz/i).length).toBe(2));
   });
 
-  it('Add group button should appear', async () => {
-    const notifications = getNotifications(policiesApplication, 3);
-    const behaviorGroups = getBehaviorGroups([[notifications[0]], []]);
-
-    mockNotifications(notifications);
-    mockBehaviorGroups(behaviorGroups);
-
-    render(
-      <BundlePageBehaviorGroupContent
-        applications={applications}
-        bundle={bundle}
-      />,
-      {
-        wrapper: getConfiguredAppWrapper(),
-      }
-    );
-
-    await waitForAsyncEvents();
-
-    expect(await screen.findByText(/Create new group/i)).toBeInTheDocument();
-  });
-
-  it('Add group button should be enabled with the write permissions', async () => {
-    const notifications = getNotifications(policiesApplication, 3);
-    const behaviorGroups = getBehaviorGroups([[notifications[0]], []]);
-
-    mockNotifications(notifications);
-    mockBehaviorGroups(behaviorGroups);
+  it('Opens in the correct tab if parameter is present', async () => {
+    (useLocation as jest.Mock).mockReturnValue({
+      pathname: '/settings/notifications',
+      search: '?activeTab=BehaviorGroups',
+      state: {},
+      hash: '',
+      key: 'key',
+    });
 
     render(
-      <BundlePageBehaviorGroupContent
-        applications={applications}
-        bundle={bundle}
-      />,
-      {
-        wrapper: getConfiguredAppWrapper(),
-      }
+      <MemoryRouter
+        initialEntries={['/settings/notifications?activeTab=BehaviorGroups']}
+      >
+        <BundlePageBehaviorGroupContent
+          applications={applications}
+          bundle={bundle}
+        />
+      </MemoryRouter>
     );
 
-    expect(await screen.findByText(/Create new group/i)).toBeEnabled();
-
-    // Check that is not aria-disabled
-    expect(await screen.findByText(/Create new group/i)).not.toHaveAttribute(
-      'aria-disabled',
-      'true'
-    );
+    expect(
+      screen.getByText('Unique Identifier of the Active Tab Content')
+    ).toBeInTheDocument();
   });
 
   it('Add group button should be disabled with no write permissions', async () => {

--- a/src/pages/Notifications/Overview/Page.tsx
+++ b/src/pages/Notifications/Overview/Page.tsx
@@ -313,7 +313,7 @@ export const NotificationsOverviewPage: React.FunctionComponent = () => {
                 linkTitle="Create new behavior group"
                 linkTarget={`${
                   isBeta() ? '/preview' : ''
-                }/${getBundle()}/notifications/configure-events`}
+                }/${getBundle()}/notifications/configure-events?activeTab=behaviorGroups`}
                 expandableContent="Configure which notifications different users in your organization can receive, and how to notify groups of users when selected events occur."
               />
             </DataList>


### PR DESCRIPTION
Addressing [the following JIRA ticket](https://issues.redhat.com/browse/RHCLOUD-29314)

We're now forcing the correct tab to open:

<img width="925" alt="Screenshot 2024-02-06 at 9 57 59 AM" src="https://github.com/RedHatInsights/notifications-frontend/assets/56621323/acaf2951-130f-4cc5-aae5-4c9ad37cf5b0">
