### PR TITLE
Clean the test integration modal

### DIFF
--- a/src/components/Integrations/Table/IntegrationTest.tsx
+++ b/src/components/Integrations/Table/IntegrationTest.tsx
@@ -55,7 +55,6 @@ const IntegrationTestModal = ({
               `Status: ${response.status} - ${response.statusText}`
           );
     } catch (error) {
-      console.error(testFailedMessage, error);
       addWarningNotification(testFailedMessage, error?.toString());
     } finally {
       onClose();

--- a/src/components/Integrations/Table/IntegrationTest.tsx
+++ b/src/components/Integrations/Table/IntegrationTest.tsx
@@ -50,8 +50,9 @@ const IntegrationTestModal = ({
             </>
           )
         : addWarningNotification(
-            `${testFailedMessage} - ${response.status} ${response.statusText}`,
-            response.data
+            testFailedMessage,
+            response.data ||
+              `Status: ${response.status} - ${response.statusText}`
           );
     } catch (error) {
       console.error(testFailedMessage, error);

--- a/src/components/Integrations/Table/IntegrationTest.tsx
+++ b/src/components/Integrations/Table/IntegrationTest.tsx
@@ -41,7 +41,7 @@ const IntegrationTestModal = ({
         ? addSuccessNotification(
             notificationMessage,
             <>
-              Your test to integration {type} was successful, to view payload
+              Your test to integration {type} was successful. To view payload
               response check{' '}
               <Link to={`/settings/notifications${linkTo.eventLog()}`}>
                 event log

--- a/src/components/Integrations/Table/IntegrationTestProvider.tsx
+++ b/src/components/Integrations/Table/IntegrationTestProvider.tsx
@@ -5,11 +5,17 @@ import IntegrationTestModal from './IntegrationTest';
 
 const registry = getNotificationsRegistry();
 
-const IntegrationTestProvider = ({ integrationUUID, onClose, isModalOpen }) => {
+const IntegrationTestProvider = ({
+  integrationId,
+  integrationType,
+  onClose,
+  isModalOpen,
+}) => {
   return (
     <Provider store={registry.getStore()}>
       <IntegrationTestModal
-        integrationUUID={integrationUUID}
+        integrationId={integrationId}
+        integrationType={integrationType}
         onClose={onClose}
         isModalOpen={isModalOpen}
       />

--- a/src/config/Config.ts
+++ b/src/config/Config.ts
@@ -33,7 +33,10 @@ interface NotificationTypeConfig {
   name: string;
 }
 
-const integrationTypes: Record<IntegrationType, IntegrationTypeConfigBase> = {
+export const integrationTypes: Record<
+  IntegrationType,
+  IntegrationTypeConfigBase
+> = {
   [IntegrationType.SPLUNK]: {
     name: 'Splunk',
   },

--- a/src/pages/Integrations/List/List.tsx
+++ b/src/pages/Integrations/List/List.tsx
@@ -61,7 +61,8 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
   const dispatch = useDispatch();
   const wizardEnabled = useFlag('insights.integrations.wizard');
   const { savedNotificationScope } = useSelector(selector);
-  const [selectedIntegrationID, setSelectedIntegrationID] = useState('');
+  const [selectedIntegration, setSelectedIntegration] =
+    useState<UserIntegration>();
   const [isTestModalOpen, setIsTestModalOpen] = useState(true);
   const {
     rbac: { canWriteIntegrationsEndpoints },
@@ -139,7 +140,7 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
 
   const onTest = React.useCallback(
     (integration: UserIntegration) => {
-      setSelectedIntegrationID(integration.id);
+      setSelectedIntegration(integration);
       modalIsOpenActions.test(integration);
     },
     [modalIsOpenActions]
@@ -208,7 +209,6 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
     onEnable: integrationRows.onEnable,
   });
 
-  // eslint-disable-next-line
   const closeFormModal = React.useCallback(
     (saved: boolean) => {
       const query = integrationsQuery.query;
@@ -304,17 +304,18 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
       )}
       {modalIsOpenState.isTest && (
         <IntegrationTestProvider
-          integrationUUID={selectedIntegrationID}
+          integrationId={selectedIntegration?.id}
+          integrationType={selectedIntegration?.type}
           onClose={() => setIsTestModalOpen(false)}
           isModalOpen={isTestModalOpen}
         />
       )}
-      {wizardEnabled && category && !modalIsOpenState.isTest && (
+      {wizardEnabled && category && (
         <IntegrationWizard
           isOpen={modalIsOpenState.isOpen}
           isEdit={modalIsOpenState.isEdit}
           template={modalIsOpenState.template}
-          closeModal={() => modalIsOpenActions.reset()}
+          closeModal={modalIsOpenActions.reset}
           category={category}
         />
       )}


### PR DESCRIPTION
[RHCLOUD-29966](https://issues.redhat.com/browse/RHCLOUD-29966)

Made some visual cleanup of the test integration modal and notifications displayed after a discussion with UX.

## Before:
![image](https://github.com/RedHatInsights/notifications-frontend/assets/50696716/2ca04831-98f5-4455-b237-29784d83bb23)

![image](https://github.com/RedHatInsights/notifications-frontend/assets/50696716/96e6a69a-34c5-4b59-9762-2153ea0511de)

![image](https://github.com/RedHatInsights/notifications-frontend/assets/50696716/f591cf18-5ddf-42d4-8e1b-1e6e2d25a66d)

---

## Now:
![image](https://github.com/RedHatInsights/notifications-frontend/assets/50696716/4bc35d15-7a3f-4fbc-a247-bc1d2c04a925)

![image](https://github.com/RedHatInsights/notifications-frontend/assets/50696716/2a550ee6-f295-4f2e-932a-408d6717747f)

![image](https://github.com/RedHatInsights/notifications-frontend/assets/50696716/b94d01dd-2d8a-45d7-8153-57784a691fbe)