### PR TITLE
Expose dashboard widget

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -26,7 +26,8 @@ module.exports = {
             './RootApp': path.resolve(__dirname, './src/AppEntry.tsx'),
             './IntegrationsTable': path.resolve(__dirname, './src/IntegrationsEntry.tsx'),
             './TimeConfig': path.resolve(__dirname, './src/components/Notifications/TimeConfig.tsx'),
-            './ConnectedTimeConfig': path.resolve(__dirname, './src/components/Notifications/ConnectedTimeConfig.tsx')
+            './ConnectedTimeConfig': path.resolve(__dirname, './src/components/Notifications/ConnectedTimeConfig.tsx'),
+            './DashboardWidget': path.resolve(__dirname, './src/components/Widgets/EventsWidget')
         },
         shared: [
             {

--- a/src/components/Widgets/EventsWidget.tsx
+++ b/src/components/Widgets/EventsWidget.tsx
@@ -19,15 +19,17 @@ import {
   StackItem,
   Title,
 } from '@patternfly/react-core';
+import { DateFormat } from '@redhat-cloud-services/frontend-components/DateFormat';
 import { useIntl } from 'react-intl';
 import messages from '../../properties/DefinedMessages';
 
 export type Notification = {
   id: string;
-  title: string;
+  event_type: string;
   description: string;
   read: boolean;
-  source: string;
+  application: string;
+  bundle: string;
   created: string;
 };
 
@@ -51,7 +53,7 @@ const EventsWidget: React.FunctionComponent = () => {
   const fetchNotifications = async () => {
     try {
       const response = await fetch(
-        '/api/notifications/v1/notifications/drawer'
+        '/api/notifications/v1.0/notifications/events?limit=5'
       );
       const { data } = await response.json();
       setNotifications(data);
@@ -101,13 +103,13 @@ const EventsWidget: React.FunctionComponent = () => {
             {notifications?.slice(0, MAX_ROWS).map((event) => (
               <Tr key={event.id}>
                 <Td dataLabel={intl.formatMessage(messages.event)}>
-                  {event.title}
+                  {event.event_type}
                 </Td>
                 <Td dataLabel={intl.formatMessage(messages.service)}>
-                  {event.source}
+                  {event.application} - {event.bundle}
                 </Td>
                 <Td dataLabel={intl.formatMessage(messages.date)}>
-                  {event.created}
+                  <DateFormat date={event.created} />
                 </Td>
               </Tr>
             ))}


### PR DESCRIPTION
### Description
Let's expose event log widget from notifications application. I had to adjust the widget source data to be event log instead of notifications as well.

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##