### PR TITLE
Save time preference fix

### DIFF
--- a/src/components/Notifications/TimeConfig.tsx
+++ b/src/components/Notifications/TimeConfig.tsx
@@ -28,6 +28,7 @@ import { style } from 'typestyle';
 import { useGetTimePreference } from '../../services/Notifications/GetTimePreference';
 import { useUpdateTimePreference } from '../../services/Notifications/SaveTimePreference';
 import { useNotification } from '../../utils/AlertUtils';
+import axios from 'axios';
 
 const dropDownClassName = style({
   width: '280px',
@@ -144,25 +145,27 @@ export const TimeConfigComponent: React.FunctionComponent = () => {
 
   const handleButtonSave = React.useCallback(() => {
     if (timeSelect) {
-      const mutate = saveTimePreference.mutate;
-      mutate({
-        body: timeSelect.utcTime,
-      }).then((response) => {
-        if (response.status === 204) {
+      const body = timeSelect.utcTime;
+      axios
+        .put(
+          '/api/notifications/v1.0/org-config/daily-digest/time-preference',
+          body,
+          {
+            headers: {
+              'Content-Type': 'application/json',
+            },
+          }
+        )
+        .then(() => {
           addSuccessNotification('Action settings saved', '');
-        } else {
+        })
+        .catch(() => {
           addDangerNotification('Failed to save action settings', '');
-        }
-      });
+        });
     }
 
     setIsModalOpen(false);
-  }, [
-    addDangerNotification,
-    addSuccessNotification,
-    saveTimePreference.mutate,
-    timeSelect,
-  ]);
+  }, [addDangerNotification, addSuccessNotification, timeSelect]);
 
   const isLoading = saveTimePreference.loading || getTimePreference.loading;
 


### PR DESCRIPTION
### Description

API call changed from react-fetching-library to Axios. Specified header type (JSON) as requested by API specs.

[RHCLOUD-29607](https://issues.redhat.com/browse/RHCLOUD-29607)

---

### Screenshots

#### Before:
![image](https://github.com/RedHatInsights/notifications-frontend/assets/51480040/a1fa308c-2062-4342-9b0f-f0d660d4fb05)


#### After:
![image](https://github.com/RedHatInsights/notifications-frontend/assets/51480040/de518006-4b29-4744-8674-45a0868f4fa7)


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
