### PR TITLE
Make openshift tab/bundle configurable in notifications UI

### DIFF
--- a/src/pages/Notifications/List/BundlePage.tsx
+++ b/src/pages/Notifications/List/BundlePage.tsx
@@ -40,7 +40,7 @@ const bundleMapping = {
 export const NotificationListBundlePage: React.FunctionComponent<
   React.PropsWithChildren<NotificationListBundlePageProps>
 > = (props) => {
-  const { updateDocumentTitle } = useChrome();
+  const { updateDocumentTitle, isFedramp } = useChrome();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -155,14 +155,19 @@ export const NotificationListBundlePage: React.FunctionComponent<
               }}
               className={paddingLeftClassName}
             >
-              <Tab eventKey={2} title={<TabTitleText>OpenShift</TabTitleText>}>
-                <Main>
-                  <BundlePageBehaviorGroupContent
-                    applications={getInitialApplications}
-                    bundle={props.bundleTabs[2]}
-                  />
-                </Main>
-              </Tab>
+              {isFedramp ? null : (
+                <Tab
+                  eventKey={2}
+                  title={<TabTitleText>OpenShift</TabTitleText>}
+                >
+                  <Main>
+                    <BundlePageBehaviorGroupContent
+                      applications={getInitialApplications}
+                      bundle={props.bundleTabs[2]}
+                    />
+                  </Main>
+                </Tab>
+              )}
               <Tab
                 eventKey={0}
                 title={<TabTitleText>Red Hat Enterprise Linux</TabTitleText>}

--- a/src/pages/Notifications/List/Page.tsx
+++ b/src/pages/Notifications/List/Page.tsx
@@ -8,6 +8,7 @@ import { useGetApplicationsLazy } from '../../../services/Notifications/GetAppli
 import { useGetBundles } from '../../../services/Notifications/GetBundles';
 import { Facet } from '../../../types/Notification';
 import { NotificationListBundlePage } from './BundlePage';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 enum BundleStatus {
   LOADING,
@@ -20,9 +21,14 @@ const isBundleStatus = (bundle: Facet | BundleStatus): bundle is BundleStatus =>
 
 export const NotificationsListPage: React.FunctionComponent = () => {
   const navigate = useNavigate();
+  const { isFedramp } = useChrome();
   const params = useParams<Record<string, string | undefined>>();
   const notificationsOverhaul = useFlag('platform.notifications.overhaul');
-  const bundleList = ['rhel', 'console', 'openshift'];
+  const bundleList = ['rhel', 'console'];
+
+  if (!isFedramp) {
+    bundleList.push('openshift');
+  }
 
   const bundleName = useMemo(
     () => (notificationsOverhaul ? 'rhel' : params.bundleName),


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

After enabling the notifications overhaul inboundary - some of the notifications frontend logic is breaking. Since configuring openshift notifications is not permitted, we need this logic to handle if the openshift bundle is not present.

---

### Screenshots
N/A (inboundary)

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
