### PR TITLE
Add errata overview section

### DIFF
--- a/src/pages/Notifications/Overview/CustomDataListItem.tsx
+++ b/src/pages/Notifications/Overview/CustomDataListItem.tsx
@@ -15,6 +15,7 @@ import {
 } from '@patternfly/react-core';
 import {
   BellIcon,
+  BugIcon,
   IntegrationIcon,
   RunningIcon,
   UserIcon,
@@ -29,6 +30,7 @@ export enum IconName {
   INTEGRATION = 'integration',
   USERS = 'users',
   BELL = 'bell',
+  BUG = 'bug',
 }
 
 interface CustomDataListItemProps {
@@ -41,6 +43,17 @@ interface CustomDataListItemProps {
   isExpanded?: boolean;
 }
 
+const IconMapper = {
+  [IconName.USER]: <UserIcon className="pf-u-primary-color-100" />,
+  [IconName.RUNNING]: <RunningIcon className="pf-u-primary-color-100" />,
+  [IconName.INTEGRATION]: (
+    <IntegrationIcon className="pf-u-primary-color-100" />
+  ),
+  [IconName.USERS]: <UsersIcon className="pf-u-primary-color-100" />,
+  [IconName.BELL]: <BellIcon className="pf-u-primary-color-100" />,
+  [IconName.BUG]: <BugIcon className="pf-u-primary-color-100" />,
+};
+
 const CustomDataListItem: React.FC<CustomDataListItemProps> = ({
   icon,
   heading,
@@ -51,28 +64,8 @@ const CustomDataListItem: React.FC<CustomDataListItemProps> = ({
   isExpanded,
 }) => {
   const navigate = useNavigate();
-  let iconElement: React.ReactNode = null;
+  const iconElement: React.ReactNode | null = IconMapper[icon] || null;
   const [expanded, setExpanded] = React.useState(isExpanded || false);
-
-  switch (icon) {
-    case IconName.USER:
-      iconElement = <UserIcon className="pf-u-primary-color-100" />;
-      break;
-    case IconName.RUNNING:
-      iconElement = <RunningIcon className="pf-u-primary-color-100" />;
-      break;
-    case IconName.INTEGRATION:
-      iconElement = <IntegrationIcon className="pf-u-primary-color-100" />;
-      break;
-    case IconName.USERS:
-      iconElement = <UsersIcon className="pf-u-primary-color-100" />;
-      break;
-    case IconName.BELL:
-      iconElement = <BellIcon className="pf-u-primary-color-100" />;
-      break;
-    default:
-      break;
-  }
 
   return (
     <React.Fragment>

--- a/src/pages/Notifications/Overview/Page.tsx
+++ b/src/pages/Notifications/Overview/Page.tsx
@@ -48,6 +48,9 @@ export const NotificationsOverviewPage: React.FunctionComponent = () => {
   const [isOrgAdmin, setIsOrgAdmin] = React.useState(null);
   const { auth, isBeta, getBundle } = useChrome();
   const notificationsOverhaul = useFlag('platform.notifications.overhaul');
+  const errataNotifications = useFlag(
+    'platform.notifications.errata.userpreferences'
+  );
   React.useEffect(() => {
     const getUser = async () => {
       const {
@@ -312,6 +315,42 @@ export const NotificationsOverviewPage: React.FunctionComponent = () => {
                 }/${getBundle()}/notifications/configure-events?activeTab=behaviorGroups`}
                 expandableContent="Configure which notifications different users in your organization can receive, and how to notify groups of users when selected events occur."
               />
+              {errataNotifications && (
+                <CustomDataListItem
+                  icon={IconName.BUG}
+                  heading="Manage errata for your Subscriptions"
+                  linkTitle="Manage subscriptions errata"
+                  linkTarget={`${
+                    isBeta() ? '/preview' : ''
+                  }/${getBundle()}/notifications/user-preferences?bundle=subscription-services&app=errata-notifications`}
+                  expandableContent={
+                    <span>
+                      Configure notifications for product advisories that affect
+                      your purchased subscriptions. Managing these notifications
+                      can be done in your{' '}
+                      <Button
+                        component="a"
+                        href={`${
+                          isBeta() ? '/preview' : ''
+                        }/${getBundle()}/notifications/user-preferences`}
+                        className="pf-u-px-0"
+                        variant="link"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          navigate(
+                            `${
+                              isBeta() ? '/preview' : ''
+                            }/${getBundle()}/notifications/user-preferences`
+                          );
+                        }}
+                      >
+                        Notifications preferences
+                      </Button>
+                      .
+                    </span>
+                  }
+                />
+              )}
             </DataList>
           </React.Fragment>
         ) : (


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
We want to showcase to customers errata user preferences on overview page.

[RHCLOUD-33535](https://issues.redhat.com/browse/RHCLOUD-33535)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:

![Screenshot from 2024-08-07 08-40-18](https://github.com/user-attachments/assets/c504ab42-8667-4540-84bb-de6d8356473f)

#### After:

![Screenshot from 2024-08-07 08-56-25](https://github.com/user-attachments/assets/65d36b9f-0710-49a1-8c15-20f9def0456b)

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)


##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
