### PR TITLE
RHCLOUD-34529 fix behavior group redirect to correct tab

### DIFF
--- a/src/pages/Integrations/Create/CustomComponents/CreatedStep.tsx
+++ b/src/pages/Integrations/Create/CustomComponents/CreatedStep.tsx
@@ -62,6 +62,9 @@ export const CreatedStep: React.FunctionComponent<ProgressProps> = (props) => {
             <Button
               variant="link"
               component="a"
+              href={`/${getBundle()}/notifications/configure-events?bundle=${
+                props.data.bundle_name
+              }&tab=behaviorGroups`}
               onClick={() => {
                 navigate(
                   `/${getBundle()}/notifications/configure-events?bundle=${

--- a/src/pages/Integrations/Create/CustomComponents/CreatedStep.tsx
+++ b/src/pages/Integrations/Create/CustomComponents/CreatedStep.tsx
@@ -62,19 +62,10 @@ export const CreatedStep: React.FunctionComponent<ProgressProps> = (props) => {
             <Button
               variant="link"
               component="a"
-              href={`${
-                isBeta() ? '/preview' : ''
-              }/${getBundle()}/notifications/configure-events?bundle=${
+              href={`/${getBundle()}/notifications/configure-events?bundle=${
                 props.data.bundle_name
               }&tab=behaviorGroups`}
               size="lg"
-              onClick={(e) => {
-                props.onClose();
-                e.preventDefault();
-                navigate(
-                  `/${getBundle()}/notifications/configure-events?tab=behaviorGroups`
-                );
-              }}
             >
               View behavior group
             </Button>

--- a/src/pages/Integrations/Create/CustomComponents/CreatedStep.tsx
+++ b/src/pages/Integrations/Create/CustomComponents/CreatedStep.tsx
@@ -71,23 +71,27 @@ export const CreatedStep: React.FunctionComponent<ProgressProps> = (props) => {
             </Button>
           </StackItem>
           <StackItem>
-            <Button
-              variant="link"
-              component="a"
-              href={`/${getBundle()}/notifications/configure-events?bundle=${
-                props.data.bundle_name
-              }&tab=behaviorGroups`}
-              onClick={() => {
-                navigate(
-                  `/${getBundle()}/notifications/configure-events?bundle=${
-                    props.data.bundle_name
-                  }&tab=behaviorGroups`
-                );
-              }}
-              size="lg"
-            >
-              View behavior group
-            </Button>
+            {props.hasBehaviorGroup ? (
+              <Button
+                variant="link"
+                component="a"
+                href={`/${getBundle()}/notifications/configure-events?bundle=${
+                  props.data.bundle_name
+                }&tab=behaviorGroups`}
+                onClick={() => {
+                  navigate(
+                    `/${getBundle()}/notifications/configure-events?bundle=${
+                      props.data.bundle_name
+                    }&tab=behaviorGroups`
+                  );
+                }}
+                size="lg"
+              >
+                View behavior group
+              </Button>
+            ) : (
+              ' '
+            )}
           </StackItem>
         </Stack>
       </EmptyStateFooter>

--- a/src/pages/Integrations/Create/CustomComponents/CreatedStep.tsx
+++ b/src/pages/Integrations/Create/CustomComponents/CreatedStep.tsx
@@ -62,9 +62,13 @@ export const CreatedStep: React.FunctionComponent<ProgressProps> = (props) => {
             <Button
               variant="link"
               component="a"
-              href={`/${getBundle()}/notifications/configure-events?bundle=${
-                props.data.bundle_name
-              }&tab=behaviorGroups`}
+              onClick={() => {
+                navigate(
+                  `/${getBundle()}/notifications/configure-events?bundle=${
+                    props.data.bundle_name
+                  }&tab=behaviorGroups`
+                );
+              }}
               size="lg"
             >
               View behavior group


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Selected bundle under 'product family' doesn't redirect to correct tab via 'View behavior group'

[RHCLOUD-34529](https://issues.redhat.com/browse/RHCLOUD-34529)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
