### PR TITLE
Enable errata and ansible bundles in configure notif

### DIFF
--- a/src/pages/Notifications/List/BundlePage.tsx
+++ b/src/pages/Notifications/List/BundlePage.tsx
@@ -31,16 +31,10 @@ interface NotificationListBundlePageProps {
   applications: Array<Facet>;
 }
 
-const bundleMapping = {
-  rhel: 0,
-  console: 1,
-  openshift: 2,
-};
-
 export const NotificationListBundlePage: React.FunctionComponent<
   React.PropsWithChildren<NotificationListBundlePageProps>
 > = (props) => {
-  const { updateDocumentTitle, isFedramp } = useChrome();
+  const { updateDocumentTitle } = useChrome();
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -113,7 +107,7 @@ export const NotificationListBundlePage: React.FunctionComponent<
   useEffect(() => {
     if (notificationsOverhaul) {
       const query = getApplications.query;
-      query(props.bundleTabs[bundleMapping[bundle]].name);
+      query(props.bundleTabs.find(({ name }) => name === bundle)?.name);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bundle]);
@@ -142,12 +136,12 @@ export const NotificationListBundlePage: React.FunctionComponent<
         <Flex direction={{ default: 'column' }}>
           <FlexItem>
             <Tabs
-              activeKey={bundleMapping[bundle]}
+              activeKey={props.bundleTabs.findIndex(
+                ({ name }) => name === bundle
+              )}
               onSelect={(event, tabIndex) => {
                 const newSearchParams = new URLSearchParams(location.search);
-                const selectedBundle = Object.keys(bundleMapping).find(
-                  (key) => bundleMapping[key] === tabIndex
-                );
+                const selectedBundle = props.bundleTabs[tabIndex]?.name;
                 newSearchParams.set('bundle', selectedBundle ?? 'rhel');
                 navigate(`${location.pathname}?${newSearchParams.toString()}`, {
                   replace: true,
@@ -155,38 +149,20 @@ export const NotificationListBundlePage: React.FunctionComponent<
               }}
               className={paddingLeftClassName}
             >
-              {isFedramp ? null : (
+              {props.bundleTabs.map((item, key) => (
                 <Tab
-                  eventKey={2}
-                  title={<TabTitleText>OpenShift</TabTitleText>}
+                  key={key}
+                  eventKey={key}
+                  title={<TabTitleText>{item.displayName}</TabTitleText>}
                 >
                   <Main>
                     <BundlePageBehaviorGroupContent
                       applications={getInitialApplications}
-                      bundle={props.bundleTabs[2]}
+                      bundle={item}
                     />
                   </Main>
                 </Tab>
-              )}
-              <Tab
-                eventKey={0}
-                title={<TabTitleText>Red Hat Enterprise Linux</TabTitleText>}
-              >
-                <Main>
-                  <BundlePageBehaviorGroupContent
-                    applications={getInitialApplications}
-                    bundle={props.bundleTabs[0]}
-                  />
-                </Main>
-              </Tab>
-              <Tab eventKey={1} title={<TabTitleText>Console</TabTitleText>}>
-                <Main>
-                  <BundlePageBehaviorGroupContent
-                    applications={getInitialApplications}
-                    bundle={props.bundleTabs[1]}
-                  />
-                </Main>
-              </Tab>
+              ))}
             </Tabs>
           </FlexItem>
         </Flex>

--- a/src/pages/Notifications/List/Page.tsx
+++ b/src/pages/Notifications/List/Page.tsx
@@ -24,11 +24,19 @@ export const NotificationsListPage: React.FunctionComponent = () => {
   const { isFedramp } = useChrome();
   const params = useParams<Record<string, string | undefined>>();
   const notificationsOverhaul = useFlag('platform.notifications.overhaul');
-  const bundleList = ['rhel', 'console'];
-
-  if (!isFedramp) {
-    bundleList.push('openshift');
-  }
+  const errataNotifications = useFlag(
+    'platform.notifications.errata.userpreferences'
+  );
+  const ansibleAutomation = useFlag(
+    'platform.notifications.ansible-automation'
+  );
+  const bundleList = [
+    'rhel',
+    'console',
+    ...(!isFedramp ? ['openshift'] : []),
+    ...(errataNotifications ? ['subscription-services'] : []),
+    ...(ansibleAutomation ? ['ansible-automation-platform'] : []),
+  ];
 
   const bundleName = useMemo(
     () => (notificationsOverhaul ? 'rhel' : params.bundleName),


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Enable both errata and ansible bundles in configure events. This is controled by feature flags `platform.notifications.errata.userpreferences` and `platform.notifications.ansible-automation`

[RHCLOUD-34041](https://issues.redhat.com/browse/RHCLOUD-34041)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:

![Screenshot from 2024-08-16 10-35-04](https://github.com/user-attachments/assets/a0877c6a-7ee2-4157-ab89-515fa0daa921)

#### After:
![Screenshot from 2024-08-16 10-34-12](https://github.com/user-attachments/assets/7f63d06a-2f20-4a2e-a523-4dcb8f1609a5)

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
