### PR TITLE
RHCLOUD-34528 Integrations Wizard shows error at creation if "product family" is not selected

### DIFF
--- a/src/pages/Integrations/Create/CustomComponents/CreatedStep.tsx
+++ b/src/pages/Integrations/Create/CustomComponents/CreatedStep.tsx
@@ -25,6 +25,8 @@ interface ProgressProps {
 export const CreatedStep: React.FunctionComponent<ProgressProps> = (props) => {
   const { isBeta, getBundle } = useChrome();
   const navigate = useNavigate();
+  const [behaviorGroupCreated] = React.useState(false);
+
   return (
     <EmptyState variant={EmptyStateVariant.lg}>
       <EmptyStateHeader
@@ -33,11 +35,21 @@ export const CreatedStep: React.FunctionComponent<ProgressProps> = (props) => {
         icon={<EmptyStateIcon icon={CheckCircleIcon} color="green" />}
       />
       <EmptyStateBody>
-        The integration <b>&apos;{props.integrationName}&apos;</b> was created
-        successfully. The behavior group{' '}
-        <b>&apos;{props.behaviorGroupName}&apos;</b> was created successfully.
-        You can configure additional events in the Hybrid Cloud Console
-        settings.
+        {behaviorGroupCreated ? (
+          <span>
+            The integration <b>&apos;{props.integrationName}&apos;</b> was
+            created successfully. The behavior group{' '}
+            <b>&apos;{props.behaviorGroupName}&apos;</b> was created
+            successfully. You can configure additional events in the Hybrid
+            Cloud Console settings.
+          </span>
+        ) : (
+          <span>
+            The integration <b>&apos;{props.integrationName}&apos;</b> was
+            created successfully. You can configure additional events in the
+            Hybrid Cloud Console settings.
+          </span>
+        )}
       </EmptyStateBody>
       <EmptyStateFooter>
         <Stack hasGutter>
@@ -59,25 +71,29 @@ export const CreatedStep: React.FunctionComponent<ProgressProps> = (props) => {
             </Button>
           </StackItem>
           <StackItem>
-            <Button
-              variant="link"
-              component="a"
-              href={`${
-                isBeta() ? '/preview' : ''
-              }/${getBundle()}/notifications/configure-events?bundle=${
-                props.data.bundle_name
-              }&tab=behaviorGroups`}
-              size="lg"
-              onClick={(e) => {
-                props.onClose();
-                e.preventDefault();
-                navigate(
-                  `/${getBundle()}/notifications/configure-events?tab=behaviorGroups`
-                );
-              }}
-            >
-              View behavior group
-            </Button>
+            {behaviorGroupCreated ? (
+              <Button
+                variant="link"
+                component="a"
+                href={`${
+                  isBeta() ? '/preview' : ''
+                }/${getBundle()}/notifications/configure-events?bundle=${
+                  props.data.bundle_name
+                }&tab=behaviorGroups`}
+                size="lg"
+                onClick={(e) => {
+                  props.onClose();
+                  e.preventDefault();
+                  navigate(
+                    `/${getBundle()}/notifications/configure-events?tab=behaviorGroups`
+                  );
+                }}
+              >
+                View behavior group
+              </Button>
+            ) : (
+              ''
+            )}
           </StackItem>
         </Stack>
       </EmptyStateFooter>

--- a/src/pages/Integrations/Create/CustomComponents/CreatedStep.tsx
+++ b/src/pages/Integrations/Create/CustomComponents/CreatedStep.tsx
@@ -20,12 +20,12 @@ interface ProgressProps {
   behaviorGroupName: string;
   onClose: () => void;
   data: IntegrationsData;
+  hasBehaviorGroup: boolean;
 }
 
 export const CreatedStep: React.FunctionComponent<ProgressProps> = (props) => {
   const { isBeta, getBundle } = useChrome();
   const navigate = useNavigate();
-  const [behaviorGroupCreated] = React.useState(false);
 
   return (
     <EmptyState variant={EmptyStateVariant.lg}>
@@ -35,7 +35,7 @@ export const CreatedStep: React.FunctionComponent<ProgressProps> = (props) => {
         icon={<EmptyStateIcon icon={CheckCircleIcon} color="green" />}
       />
       <EmptyStateBody>
-        {behaviorGroupCreated ? (
+        {props.hasBehaviorGroup ? (
           <span>
             The integration <b>&apos;{props.integrationName}&apos;</b> was
             created successfully. The behavior group{' '}
@@ -71,7 +71,7 @@ export const CreatedStep: React.FunctionComponent<ProgressProps> = (props) => {
             </Button>
           </StackItem>
           <StackItem>
-            {behaviorGroupCreated ? (
+            {props.hasBehaviorGroup ? (
               <Button
                 variant="link"
                 component="a"

--- a/src/pages/Integrations/Create/CustomComponents/FailedStep.tsx
+++ b/src/pages/Integrations/Create/CustomComponents/FailedStep.tsx
@@ -6,17 +6,16 @@ interface ProgressProps {
   integrationName: string;
   behaviorGroupName: string;
   onClose: () => void;
+  hasBehaviorGroup: boolean;
 }
 
 export const FailedStep: React.FunctionComponent<ProgressProps> = (props) => {
-  const [hasBehaviorGroupCreated] = React.useState(false);
-
   return (
     <>
       <ErrorState
         errorTitle="Integration creation failed"
         errorDescription={
-          hasBehaviorGroupCreated ? (
+          props.hasBehaviorGroup ? (
             <span>
               There was an error creating <b>&apos;{props.integrationName}</b>
               &apos; integrations and/or the

--- a/src/pages/Integrations/Create/CustomComponents/FailedStep.tsx
+++ b/src/pages/Integrations/Create/CustomComponents/FailedStep.tsx
@@ -8,30 +8,42 @@ interface ProgressProps {
   onClose: () => void;
 }
 
-export const FailedStep: React.FunctionComponent<ProgressProps> = (props) => (
-  <>
-    <ErrorState
-      errorTitle="Integration creation failed"
-      errorDescription={
-        <span>
-          There was an error creating <b>&apos;{props.integrationName}</b>
-          &apos; integrations and/or the <b>&apos;{props.behaviorGroupName}</b>
-          &apos; behavior group.
-        </span>
-      }
-      customFooter={
-        <>
-          <Stack hasGutter>
-            <StackItem>
-              <Button variant="link" onClick={props.onClose}>
-                Close
-              </Button>
-            </StackItem>
-          </Stack>
-        </>
-      }
-    />
-  </>
-);
+export const FailedStep: React.FunctionComponent<ProgressProps> = (props) => {
+  const [hasBehaviorGroupCreated] = React.useState(false);
+
+  return (
+    <>
+      <ErrorState
+        errorTitle="Integration creation failed"
+        errorDescription={
+          hasBehaviorGroupCreated ? (
+            <span>
+              There was an error creating <b>&apos;{props.integrationName}</b>
+              &apos; integrations and/or the
+              <b>&apos;{props.behaviorGroupName}</b>
+              &apos; behavior group.
+            </span>
+          ) : (
+            <span>
+              There was an error creating <b>&apos;{props.integrationName}</b>
+              &apos; integrations.
+            </span>
+          )
+        }
+        customFooter={
+          <>
+            <Stack hasGutter>
+              <StackItem>
+                <Button variant="link" onClick={props.onClose}>
+                  Close
+                </Button>
+              </StackItem>
+            </Stack>
+          </>
+        }
+      />
+    </>
+  );
+};
 
 export default FailedStep;

--- a/src/pages/Integrations/Create/CustomComponents/FinalStep.tsx
+++ b/src/pages/Integrations/Create/CustomComponents/FinalStep.tsx
@@ -81,7 +81,6 @@ export const FinalStep: React.FunctionComponent<ProgressProps> = ({
 
         if (isBehaviorGroupsEnabled && data?.event_type_id) {
           let ids: string[] = [];
-          setHasBehaviorGroup(true);
           Object.values(data.event_type_id).forEach((item) => {
             ids = [...ids, ...Object.keys(item)];
           });

--- a/src/pages/Integrations/Create/CustomComponents/FinalStep.tsx
+++ b/src/pages/Integrations/Create/CustomComponents/FinalStep.tsx
@@ -38,6 +38,7 @@ export const FinalStep: React.FunctionComponent<ProgressProps> = ({
 }) => {
   const [isFinished, setIsFinished] = React.useState(false);
   const [hasError, setHasError] = React.useState(false);
+  const [hasBehaviorGroup, setHasBehaviorGroup] = React.useState(false);
 
   const isBehaviorGroupsEnabled = useFlag(
     'platform.integrations.behavior-groups-move'
@@ -80,6 +81,7 @@ export const FinalStep: React.FunctionComponent<ProgressProps> = ({
 
         if (isBehaviorGroupsEnabled && data?.event_type_id) {
           let ids: string[] = [];
+          setHasBehaviorGroup(true);
           Object.values(data.event_type_id).forEach((item) => {
             ids = [...ids, ...Object.keys(item)];
           });
@@ -96,6 +98,8 @@ export const FinalStep: React.FunctionComponent<ProgressProps> = ({
               event_type_ids: ids,
             }),
           });
+
+          setHasBehaviorGroup(true);
 
           if (!behaviorGroupResponse.ok) {
             throw new Error('Failed to create behavior group');
@@ -116,7 +120,9 @@ export const FinalStep: React.FunctionComponent<ProgressProps> = ({
       <FailedStep
         integrationName={data?.name || ''}
         behaviorGroupName={
-          isBehaviorGroupsEnabled ? `${data?.name || ''} behavior group` : ''
+          isBehaviorGroupsEnabled && hasBehaviorGroup
+            ? `${data?.name || ''} behavior group`
+            : ''
         }
         onClose={onCancel}
       />
@@ -124,7 +130,9 @@ export const FinalStep: React.FunctionComponent<ProgressProps> = ({
       <CreatedStep
         integrationName={data?.name || ''}
         behaviorGroupName={
-          isBehaviorGroupsEnabled ? `${data?.name || ''} behavior group` : ''
+          isBehaviorGroupsEnabled && hasBehaviorGroup
+            ? `${data?.name || ''} behavior group`
+            : ''
         }
         onClose={onCancel}
         data={data}

--- a/src/pages/Integrations/Create/CustomComponents/FinalStep.tsx
+++ b/src/pages/Integrations/Create/CustomComponents/FinalStep.tsx
@@ -120,22 +120,20 @@ export const FinalStep: React.FunctionComponent<ProgressProps> = ({
       <FailedStep
         integrationName={data?.name || ''}
         behaviorGroupName={
-          isBehaviorGroupsEnabled && hasBehaviorGroup
-            ? `${data?.name || ''} behavior group`
-            : ''
+          isBehaviorGroupsEnabled ? `${data?.name || ''} behavior group` : ''
         }
         onClose={onCancel}
+        hasBehaviorGroup={hasBehaviorGroup}
       />
     ) : (
       <CreatedStep
         integrationName={data?.name || ''}
         behaviorGroupName={
-          isBehaviorGroupsEnabled && hasBehaviorGroup
-            ? `${data?.name || ''} behavior group`
-            : ''
+          isBehaviorGroupsEnabled ? `${data?.name || ''} behavior group` : ''
         }
         onClose={onCancel}
         data={data}
+        hasBehaviorGroup={hasBehaviorGroup}
       />
     )
   ) : (


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Integrations Wizard shows error at creation if "product family" is not selected

[RHCLOUD-34528](https://issues.redhat.com/browse/RHCLOUD-34528)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:

https://github.com/user-attachments/assets/47cf0047-fb0b-408d-9e7b-b3ad123134e8



---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
