### PR TITLE
Fix incorrect category from notifications overview

### DIFF
--- a/src/pages/Notifications/Overview/Page.tsx
+++ b/src/pages/Notifications/Overview/Page.tsx
@@ -282,7 +282,7 @@ export const NotificationsOverviewPage: React.FunctionComponent = () => {
                   isSourcesIntegrations
                     ? `${
                         isBeta() ? '/preview' : ''
-                      }/settings/sources?category=Integrations`
+                      }/settings/sources?category=Communications`
                     : `${
                         isBeta() ? '/preview' : ''
                       }/${getBundle()}/notifications/integrations`


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

When clicking on setup integrations from overview page I am brought to default tab in intgrations application. This PR fixes it by activating Communications tab.

[RHCLOUD-32021](https://issues.redhat.com/browse/RHCLOUD-32021)


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
