### PR TITLE
Activate quickstart when clicked on configure slack

### DIFF
--- a/src/components/Integrations/DopeBox.tsx
+++ b/src/components/Integrations/DopeBox.tsx
@@ -25,17 +25,22 @@ import {
 import { IntegrationCategory } from '../../types/Integration';
 import '../../app/App.scss';
 import { Link } from 'react-router-dom';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 interface DopeBoxProps {
   category?: IntegrationCategory;
 }
 
 const DopeBox: React.FunctionComponent<DopeBoxProps> = ({ category }) => {
+  const chrome = useChrome();
+
   const communicationsDetails = [
     {
       id: 0,
       name: 'Configure Slack',
-      url: 'https://access.redhat.com/documentation/en-us/red_hat_hybrid_cloud_console/2023/html/integrating_the_red_hat_hybrid_cloud_console_with_third-party_applications/assembly-configuring-insights-integration-with-slack_integrations',
+      onClick: () => {
+        chrome.quickStarts.activateQuickstart('integrations-slack-notifs-qs');
+      },
     },
     {
       id: 1,
@@ -94,10 +99,18 @@ const DopeBox: React.FunctionComponent<DopeBoxProps> = ({ category }) => {
             <TextList className="pf-v5-u-font-size-sm pf-v5-u-link-color pf-v5-u-ml-0">
               {communicationsDetails.map((communication) => (
                 <TextListItem key={communication.id}>
-                  <Button variant="link" isInline>
-                    <Link to={communication.url} target="_blank">
-                      {communication.name}
-                    </Link>{' '}
+                  <Button
+                    variant="link"
+                    isInline
+                    onClick={() => communication.onClick?.()}
+                  >
+                    {communication.url ? (
+                      <Link to={communication.url} target="_blank">
+                        {communication.name}
+                      </Link>
+                    ) : (
+                      communication.name
+                    )}{' '}
                   </Button>
                 </TextListItem>
               ))}


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

Docs team requested a change on current link to configure integration to open quickstarts instead of directing user to the full docs site.

[RHCLOUD-35006](https://issues.redhat.com/browse/RHCLOUD-35006)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
![Screenshot 2024-10-10 at 14 24 36](https://github.com/user-attachments/assets/77fd91d3-e659-49a4-bb37-c6aeca8cdc62)



---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
