### PR TITLE
feat(dataviewtable): convert integrations table to use dataview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@data-driven-forms/react-form-renderer": "^3.22.0",
         "@patternfly/patternfly": "^5.0.0",
         "@patternfly/react-core": "^5.0.2",
+        "@patternfly/react-data-view": "^5.2.0",
         "@patternfly/react-icons": "^5.0.0",
         "@patternfly/react-styles": "^5.0.0",
         "@patternfly/react-table": "^5.0.0",
@@ -3351,14 +3352,14 @@
       "integrity": "sha512-n5xFjyj1J4eIFZ7XeU6K44POKRAuDlO5yALPbn084y+jPy1j861AaQ+zIUbzCi4IzBlHrvoXVKij7p1zy7Ditg=="
     },
     "node_modules/@patternfly/react-component-groups": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-5.1.0.tgz",
-      "integrity": "sha512-DCEKc7Iyuf/7prI2a6mWyM/qwgBBtEzxDnNSpkZyes+Q3os0F5lUxW5qZVrg3JcNp0/J1183vwLdp1VoJRmcJw==",
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-component-groups/-/react-component-groups-5.5.4.tgz",
+      "integrity": "sha512-3qf0CU3vtHGGb38LkfCfZAfrm1zXReFVjpI5E0WryLOpWl+NamuYbKfyY7j1SCj8Zq4kqCTLdXj+je3WBs+GGg==",
       "dependencies": {
-        "@patternfly/react-core": "^5.1.1",
-        "@patternfly/react-icons": "^5.1.1",
-        "@patternfly/react-table": "^5.1.1",
-        "clsx": "^2.0.0",
+        "@patternfly/react-core": "^5.4.1",
+        "@patternfly/react-icons": "^5.4.0",
+        "@patternfly/react-table": "^5.4.1",
+        "clsx": "^2.1.1",
         "react-jss": "^10.10.0"
       },
       "peerDependencies": {
@@ -3367,55 +3368,80 @@
       }
     },
     "node_modules/@patternfly/react-component-groups/node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
       "engines": {
         "node": ">=6"
       }
     },
     "node_modules/@patternfly/react-core": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.2.3.tgz",
-      "integrity": "sha512-MJeOLyJFbZPV+cj4LjL15nUuhJUwFuqLFiv6f2YubRqHl/+z05oM0byhwfm/qu2VnKByY6X6lu3Hp+hMTZcbOA==",
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.4.8.tgz",
+      "integrity": "sha512-4KRsQsH39VmTiFPLdN34QqNZg6gKrTamJxKtWEPO1VKA0TpoRMwpFEGk9BDyxipxYST6WzXznAaLCidGkCDlWw==",
       "dependencies": {
-        "@patternfly/react-icons": "^5.2.1",
-        "@patternfly/react-styles": "^5.2.1",
-        "@patternfly/react-tokens": "^5.2.1",
-        "focus-trap": "7.5.2",
+        "@patternfly/react-icons": "^5.4.2",
+        "@patternfly/react-styles": "^5.4.1",
+        "@patternfly/react-tokens": "^5.4.1",
+        "focus-trap": "7.6.0",
         "react-dropzone": "^14.2.3",
-        "tslib": "^2.5.0"
+        "tslib": "^2.7.0"
       },
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
     },
+    "node_modules/@patternfly/react-data-view": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-data-view/-/react-data-view-5.4.0.tgz",
+      "integrity": "sha512-BoRRVJB73+Ziyis46pfBfzYWozpTCyE+yAOmnzDqWfzyQ3E2hi/MSUvc3J4FdW+kTFW3/qdifnTDEZpd1nQ2dw==",
+      "dependencies": {
+        "@patternfly/react-component-groups": "^5.5.2",
+        "@patternfly/react-core": "^5.4.1",
+        "@patternfly/react-icons": "^5.4.0",
+        "@patternfly/react-table": "^5.4.1",
+        "clsx": "^2.1.1",
+        "react-jss": "^10.10.0"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
+      }
+    },
+    "node_modules/@patternfly/react-data-view/node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@patternfly/react-icons": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.2.1.tgz",
-      "integrity": "sha512-aeJ0X+U2NDe8UmI5eQiT0iuR/wmUq97UkDtx3HoZcpRb9T6eUBfysllxjRqHS8rOOspdU8OWq+CUhQ/E2ZDibg==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.4.2.tgz",
+      "integrity": "sha512-CMQ5oHYzW6TPVTs2jpNJmP2vGCAKR/YeTPwHGO9dLkAUej1IcIxtCCWK2Fdo2UJsnBjuZihasyw2b6ehvbUm9Q==",
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.2.1.tgz",
-      "integrity": "sha512-GT96hzI1QenBhq6Pfc51kxnj9aVLjL1zSLukKZXcYVe0HPOy0BFm90bT1Fo4e/z7V9cDYw4SqSX1XLc3O4jsTw=="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-5.4.1.tgz",
+      "integrity": "sha512-XA8PXksD8uiA3RTwxdUwJXOCf+V6sVd+2HKapWAdRLvtSV+Sdk7NgCvalb4IAQncsddLopjPQD8gAHA298+N8w=="
     },
     "node_modules/@patternfly/react-table": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.2.4.tgz",
-      "integrity": "sha512-WCt4I6XYKRHXcasDqcOX70ctkgPVBAvlOv67KhaZsedxUU+B2NT1kiI7Jr7tD4SrR+jQs0MCF/bbRk1QM+rBqg==",
+      "version": "5.4.8",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.4.8.tgz",
+      "integrity": "sha512-YVRSP6luBHsDqWeblPLfg8tXasB409SbysDECsGPMR+y87vYTa6CHwpVhImhXOlIJW7KCRCgx4T1/siAxb3XkA==",
       "dependencies": {
-        "@patternfly/react-core": "^5.2.3",
-        "@patternfly/react-icons": "^5.2.1",
-        "@patternfly/react-styles": "^5.2.1",
-        "@patternfly/react-tokens": "^5.2.1",
-        "lodash": "^4.17.19",
-        "tslib": "^2.5.0"
+        "@patternfly/react-core": "^5.4.8",
+        "@patternfly/react-icons": "^5.4.2",
+        "@patternfly/react-styles": "^5.4.1",
+        "@patternfly/react-tokens": "^5.4.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.7.0"
       },
       "peerDependencies": {
         "react": "^17 || ^18",
@@ -3423,9 +3449,9 @@
       }
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.2.1.tgz",
-      "integrity": "sha512-8GYz/jnJTGAWUJt5eRAW5dtyiHPKETeFJBPGHaUQnvi/t1ZAkoy8i4Kd/RlHsDC7ktiu813SKCmlzwBwldAHKg=="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-5.4.1.tgz",
+      "integrity": "sha512-eygdHE7Krta1mijAv/E8RHiKIgysD0eeNTo8EXUYC8/M4e5K6sqpr2p6rQBF8QiRMN8FnbXvZT3K2OQ28pYt9Q=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -11185,9 +11211,9 @@
       "dev": true
     },
     "node_modules/focus-trap": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.2.tgz",
-      "integrity": "sha512-p6vGNNWLDGwJCiEjkSK6oERj/hEyI9ITsSwIUICBoKLlWiTWXJRfQibCwcoi50rTZdbi87qDtUlMCmQwsGSgPw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.0.tgz",
+      "integrity": "sha512-1td0l3pMkWJLFipobUcGaf+5DTY4PLDDrcqoSaKP8ediO/CoWCCYk/fT/Y2A4e6TNB+Sh6clRJCjOPPnKoNHnQ==",
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -22375,9 +22401,9 @@
       "dev": true
     },
     "node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.0.tgz",
+      "integrity": "sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@data-driven-forms/react-form-renderer": "^3.22.0",
     "@patternfly/patternfly": "^5.0.0",
     "@patternfly/react-core": "^5.0.2",
+    "@patternfly/react-data-view": "^5.2.0",
     "@patternfly/react-icons": "^5.0.0",
     "@patternfly/react-styles": "^5.0.0",
     "@patternfly/react-table": "^5.0.0",

--- a/src/components/Integrations/IntegrationsTable.tsx
+++ b/src/components/Integrations/IntegrationsTable.tsx
@@ -1,0 +1,199 @@
+import { Spinner } from '@patternfly/react-core/dist/dynamic/components/Spinner';
+import { Switch } from '@patternfly/react-core/dist/dynamic/components/Switch';
+import { EmptyStateVariant } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
+import { SearchIcon } from '@patternfly/react-icons';
+import { IActions, ISortBy, SortByDirection } from '@patternfly/react-table';
+import SkeletonTable from '@redhat-cloud-services/frontend-components/SkeletonTable';
+import {
+  Direction,
+  OuiaComponentProps,
+  Sort,
+  UseSortReturn,
+} from '@redhat-cloud-services/insights-common-typescript';
+import * as React from 'react';
+import { useIntl } from 'react-intl';
+
+import Config from '../../config/Config';
+import messages from '../../properties/DefinedMessages';
+import {
+  IntegrationConnectionAttempt,
+  UserIntegration,
+} from '../../types/Integration';
+import { getOuiaProps } from '../../utils/getOuiaProps';
+import { EmptyStateSearch } from '../EmptyStateSearch';
+import { IntegrationStatus, StatusUnknown } from './Table/IntegrationStatus';
+import { DataView } from '@patternfly/react-data-view/dist/dynamic/DataView';
+import { DataViewToolbar } from '@patternfly/react-data-view/dist/dynamic/DataViewToolbar';
+import {
+  DataViewTable,
+  DataViewTh,
+} from '@patternfly/react-data-view/dist/dynamic/DataViewTable';
+
+export type OnEnable = (
+  integration: IntegrationRow,
+  index: number,
+  isChecked: boolean
+) => void;
+
+interface IntegrationsTableProps extends OuiaComponentProps {
+  isLoading: boolean;
+  loadingCount?: number;
+  integrations: Array<IntegrationRow>;
+  onCollapse?: (
+    integration: IntegrationRow,
+    index: number,
+    isOpen: boolean
+  ) => void;
+  onEnable?: OnEnable;
+  actionResolver: (row: IntegrationRow, index: number) => IActions;
+  sortBy?: Sort;
+  onSort?: UseSortReturn['onSort'];
+}
+
+export type IntegrationRow = UserIntegration & {
+  isOpen: boolean;
+  isSelected: boolean;
+  isEnabledLoading: boolean;
+  isConnectionAttemptLoading: boolean;
+  lastConnectionAttempts?: Array<IntegrationConnectionAttempt>;
+  includeDetails: boolean;
+};
+
+const sortMapper = [
+  {
+    name: 'name',
+    index: 1,
+  },
+  {
+    name: 'enabled',
+    index: 4,
+  },
+];
+
+export const DataViewIntegrationsTable: React.FunctionComponent<
+  IntegrationsTableProps
+> = (props) => {
+  const intl = useIntl();
+
+  const onSort = React.useCallback(
+    (event, column: number, direction: SortByDirection) => {
+      const propsOnSort = props.onSort;
+      const mapping = sortMapper.find((p) => p.index === column);
+      if (propsOnSort && mapping) {
+        propsOnSort(
+          mapping.index,
+          mapping.name,
+          direction === SortByDirection.asc
+            ? Direction.ASCENDING
+            : Direction.DESCENDING
+        );
+      }
+    },
+    [props.onSort]
+  );
+
+  const sortBy = React.useMemo<ISortBy>(() => {
+    const propsSortBy = props.sortBy;
+    if (propsSortBy) {
+      const mapping = sortMapper.find((p) => p.name === propsSortBy.column);
+      if (mapping) {
+        return {
+          index: mapping.index,
+          direction:
+            propsSortBy.direction === Direction.ASCENDING
+              ? SortByDirection.asc
+              : SortByDirection.desc,
+        };
+      }
+    }
+    return {
+      defaultDirection: SortByDirection.asc,
+    };
+  }, [props.sortBy]);
+
+  const rows = React.useMemo(() => {
+    return props.integrations.map((integration, idx) => [
+      integration.name,
+      Config.integrations.types[integration.type].name,
+      integration.lastConnectionAttempts === undefined ? (
+        <StatusUnknown />
+      ) : (
+        <IntegrationStatus
+          status={integration.status}
+          lastConnectionAttempts={
+            integration.isConnectionAttemptLoading
+              ? undefined
+              : integration.lastConnectionAttempts
+          }
+          includeDetails={integration.includeDetails}
+        />
+      ),
+      integration.isEnabledLoading ? (
+        <Spinner className="pf-v5-u-ml-sm" size="md" />
+      ) : (
+        <Switch
+          id={`table-row-switch-id-${integration.id}`}
+          aria-label="Enabled"
+          isChecked={integration.isEnabled}
+          onChange={(_e, isChecked) =>
+            props.onEnable && props.onEnable(integration, idx, isChecked)
+          }
+          isDisabled={!props.onEnable}
+          ouiaId={`enabled-${integration.id}`}
+        />
+      ),
+    ]);
+  }, [props.integrations, props.onEnable]);
+
+  const COLUMNS: DataViewTh[] = [
+    {
+      cell: 'Name',
+      props: { sort: { sortBy: sortBy, onSort: onSort, columnIndex: 1 } },
+    },
+    'Type',
+    'Last connection attempt',
+    {
+      cell: 'Enabled',
+      props: { sort: { sortBy: sortBy, onSort: onSort, columnIndex: 4 } },
+    },
+  ];
+
+  if (props.isLoading) {
+    return (
+      <div
+        {...getOuiaProps('Integrations/Table', { ...props, ouiaSafe: false })}
+      >
+        <SkeletonTable
+          rows={
+            props.loadingCount && props.loadingCount > 0
+              ? props.loadingCount
+              : 10
+          }
+          columns={COLUMNS}
+        />
+      </div>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <EmptyStateSearch
+        variant={EmptyStateVariant.full}
+        icon={SearchIcon}
+        title={intl.formatMessage(messages.integrationsEmptyStateTitle)}
+        description={intl.formatMessage(
+          messages.integrationsTableEmptyStateBody
+        )}
+      />
+    );
+  }
+
+  return (
+    <div>
+      <DataView ouiaId="integrations-table">
+        <DataViewToolbar ouiaId="integrations-table-toolbar" />
+        <DataViewTable variant="compact" columns={COLUMNS} rows={rows} />
+      </DataView>
+    </div>
+  );
+};

--- a/src/components/Integrations/IntegrationsTable.tsx
+++ b/src/components/Integrations/IntegrationsTable.tsx
@@ -19,11 +19,9 @@ import {
   IntegrationConnectionAttempt,
   UserIntegration,
 } from '../../types/Integration';
-import { getOuiaProps } from '../../utils/getOuiaProps';
 import { EmptyStateSearch } from '../EmptyStateSearch';
 import { IntegrationStatus, StatusUnknown } from './Table/IntegrationStatus';
 import { DataView } from '@patternfly/react-data-view/dist/dynamic/DataView';
-import { DataViewToolbar } from '@patternfly/react-data-view/dist/dynamic/DataViewToolbar';
 import {
   DataViewTable,
   DataViewTh,
@@ -38,7 +36,7 @@ export type OnEnable = (
 interface IntegrationsTableProps extends OuiaComponentProps {
   isLoading: boolean;
   loadingCount?: number;
-  integrations: Array<IntegrationRow>;
+  integrations: IntegrationRow[];
   onCollapse?: (
     integration: IntegrationRow,
     index: number,
@@ -77,10 +75,10 @@ export const DataViewIntegrationsTable: React.FunctionComponent<
 
   const onSort = React.useCallback(
     (event, column: number, direction: SortByDirection) => {
-      const propsOnSort = props.onSort;
+      const { onSort } = props;
       const mapping = sortMapper.find((p) => p.index === column);
-      if (propsOnSort && mapping) {
-        propsOnSort(
+      if (onSort && mapping) {
+        onSort(
           mapping.index,
           mapping.name,
           direction === SortByDirection.asc
@@ -93,22 +91,20 @@ export const DataViewIntegrationsTable: React.FunctionComponent<
   );
 
   const sortBy = React.useMemo<ISortBy>(() => {
-    const propsSortBy = props.sortBy;
-    if (propsSortBy) {
-      const mapping = sortMapper.find((p) => p.name === propsSortBy.column);
+    const { sortBy } = props;
+    if (sortBy) {
+      const mapping = sortMapper.find((p) => p.name === sortBy.column);
       if (mapping) {
         return {
           index: mapping.index,
           direction:
-            propsSortBy.direction === Direction.ASCENDING
+            sortBy.direction === Direction.ASCENDING
               ? SortByDirection.asc
               : SortByDirection.desc,
         };
       }
     }
-    return {
-      defaultDirection: SortByDirection.asc,
-    };
+    return { defaultDirection: SortByDirection.asc };
   }, [props.sortBy]);
 
   const rows = React.useMemo(() => {
@@ -148,31 +144,18 @@ export const DataViewIntegrationsTable: React.FunctionComponent<
   const COLUMNS: DataViewTh[] = [
     {
       cell: 'Name',
-      props: { sort: { sortBy: sortBy, onSort: onSort, columnIndex: 1 } },
+      props: { sort: { sortBy, onSort, columnIndex: 1 } },
     },
     'Type',
     'Last connection attempt',
     {
       cell: 'Enabled',
-      props: { sort: { sortBy: sortBy, onSort: onSort, columnIndex: 4 } },
+      props: { sort: { sortBy, onSort, columnIndex: 4 } },
     },
   ];
 
   if (props.isLoading) {
-    return (
-      <div
-        {...getOuiaProps('Integrations/Table', { ...props, ouiaSafe: false })}
-      >
-        <SkeletonTable
-          rows={
-            props.loadingCount && props.loadingCount > 0
-              ? props.loadingCount
-              : 10
-          }
-          columns={COLUMNS}
-        />
-      </div>
-    );
+    return <SkeletonTable rows={props.loadingCount || 10} columns={COLUMNS} />;
   }
 
   if (rows.length === 0) {
@@ -191,7 +174,6 @@ export const DataViewIntegrationsTable: React.FunctionComponent<
   return (
     <div>
       <DataView ouiaId="integrations-table">
-        <DataViewToolbar ouiaId="integrations-table-toolbar" />
         <DataViewTable variant="compact" columns={COLUMNS} rows={rows} />
       </DataView>
     </div>

--- a/src/components/Integrations/IntegrationsTable.tsx
+++ b/src/components/Integrations/IntegrationsTable.tsx
@@ -3,7 +3,11 @@ import { Switch } from '@patternfly/react-core/dist/dynamic/components/Switch';
 import { EmptyStateVariant } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
 import { SearchIcon } from '@patternfly/react-icons';
 import { IActions, ISortBy, SortByDirection } from '@patternfly/react-table';
-import SkeletonTable from '@redhat-cloud-services/frontend-components/SkeletonTable';
+import {
+  SkeletonTableBody,
+  SkeletonTableHead,
+} from '@patternfly/react-component-groups';
+
 import {
   Direction,
   OuiaComponentProps,
@@ -154,27 +158,33 @@ export const DataViewIntegrationsTable: React.FunctionComponent<
     },
   ];
 
-  if (props.isLoading) {
-    return <SkeletonTable rows={props.loadingCount || 10} columns={COLUMNS} />;
-  }
+  const emptyState = (
+    <EmptyStateSearch
+      variant={EmptyStateVariant.full}
+      icon={SearchIcon}
+      title={intl.formatMessage(messages.integrationsEmptyStateTitle)}
+      description={intl.formatMessage(messages.integrationsTableEmptyStateBody)}
+    />
+  );
 
-  if (rows.length === 0) {
-    return (
-      <EmptyStateSearch
-        variant={EmptyStateVariant.full}
-        icon={SearchIcon}
-        title={intl.formatMessage(messages.integrationsEmptyStateTitle)}
-        description={intl.formatMessage(
-          messages.integrationsTableEmptyStateBody
-        )}
-      />
-    );
-  }
+  const loadingStateHeader = <SkeletonTableHead columns={COLUMNS} />;
+  const loadingStateBody = (
+    <SkeletonTableBody
+      rowsCount={props.loadingCount || 10}
+      columnsCount={COLUMNS.length}
+    />
+  );
 
   return (
     <div>
       <DataView ouiaId="integrations-table">
-        <DataViewTable variant="compact" columns={COLUMNS} rows={rows} />
+        <DataViewTable
+          variant="compact"
+          columns={COLUMNS}
+          rows={rows}
+          headStates={{ loading: loadingStateHeader }}
+          bodyStates={{ loading: loadingStateBody, empty: emptyState }}
+        />
       </DataView>
     </div>
   );

--- a/src/pages/Integrations/List/List.tsx
+++ b/src/pages/Integrations/List/List.tsx
@@ -40,6 +40,7 @@ import { useIntegrationFilter } from './useIntegrationFilter';
 import { useIntegrationRows } from './useIntegrationRows';
 import { useFlag } from '@unleash/proxy-client-react';
 import DopeBox from '../../../components/Integrations/DopeBox';
+import { DataViewIntegrationsTable } from '../../../components/Integrations/IntegrationsTable';
 
 const userIntegrationCopier = (userIntegration: Partial<UserIntegration>) => ({
   ...userIntegration,
@@ -59,6 +60,9 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
 }: IntegrationListProps) => {
   const dispatch = useDispatch();
   const wizardEnabled = useFlag('insights.integrations.wizard');
+  const isBehaviorGroupsEnabled = useFlag(
+    'platform.integrations.behavior-groups-move'
+  );
   const { savedNotificationScope } = useSelector(selector);
   const [selectedIntegration, setSelectedIntegration] =
     useState<UserIntegration>();
@@ -277,20 +281,37 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
             pageChanged={pageData.changePage}
             perPageChanged={pageData.changeItemsPerPage}
           >
-            <IntegrationsTable
-              isLoading={integrationsQuery.loading}
-              loadingCount={loadingCount}
-              integrations={integrationRows.rows}
-              onCollapse={integrationRows.onCollapse}
-              onEnable={
-                canWriteIntegrationsEndpoints
-                  ? integrationRows.onEnable
-                  : undefined
-              }
-              actionResolver={actionResolver}
-              onSort={sort.onSort}
-              sortBy={sort.sortBy}
-            />
+            {!isBehaviorGroupsEnabled ? (
+              <IntegrationsTable
+                isLoading={integrationsQuery.loading}
+                loadingCount={loadingCount}
+                integrations={integrationRows.rows}
+                onCollapse={integrationRows.onCollapse}
+                onEnable={
+                  canWriteIntegrationsEndpoints
+                    ? integrationRows.onEnable
+                    : undefined
+                }
+                actionResolver={actionResolver}
+                onSort={sort.onSort}
+                sortBy={sort.sortBy}
+              />
+            ) : (
+              <DataViewIntegrationsTable
+                isLoading={integrationsQuery.loading}
+                loadingCount={loadingCount}
+                integrations={integrationRows.rows}
+                onCollapse={integrationRows.onCollapse}
+                onEnable={
+                  canWriteIntegrationsEndpoints
+                    ? integrationRows.onEnable
+                    : undefined
+                }
+                actionResolver={actionResolver}
+                onSort={sort.onSort}
+                sortBy={sort.sortBy}
+              />
+            )}
           </IntegrationsToolbar>
         </>
       )}


### PR DESCRIPTION
### Description
This is phase1 of converting Communications, Reporting & Automation, and Webhooks tables to use the Dataview component. Currently hidden behind a feature flag. 

[RHCLOUD-35059](https://issues.redhat.com/browse/RHCLOUD-35059)

---

### Screenshots
![Screenshot from 2024-10-31 10-49-57](https://github.com/user-attachments/assets/dfc58fc2-cefd-41db-92c4-7a1af00450fa)


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
