### PR TITLE
[RHCLOUD-36086] Refactor Splunk integration actions to not use behavior group apis anymore

### DIFF
--- a/src/pages/Integrations/SplunkSetup/useSplunkSetup.tsx
+++ b/src/pages/Integrations/SplunkSetup/useSplunkSetup.tsx
@@ -29,7 +29,7 @@ import {
   NewIntegrationTemplate,
 } from '../../../types/Integration';
 import { UUID } from '../../../types/Notification';
-import { useGetBundles } from '../../../services/Notifications/GetBundles';
+import { useGetBundleByName } from '../../../services/Notifications/GetBundles';
 
 export const SPLUNK_INTEGRATION_NAME = 'SPLUNK_AUTOMATION';
 export const BUNDLE_NAME = 'rhel';
@@ -61,7 +61,7 @@ export const useSplunkSetup = () => {
 
     onProgress(`Fetching Event types...\n`);
 
-    const rhelBundleId = getRhelBundleUuid();
+    const rhelBundleId = await getRhelBundleUuid();
 
     const eventTypeList = await attachEventTypes(
       rhelBundleId,
@@ -80,17 +80,16 @@ export const useSplunkSetup = () => {
 };
 
 const useGetRhelBundleUuid = () => {
-  const getBundles = useGetBundles();
+  const getBundleByName = useGetBundleByName();
+  return async () => {
+    const rhelBundle = await getBundleByName(BUNDLE_NAME);
 
-  const getbundleTabs = () => {
-    if (getBundles.payload?.status === 200) {
-      return getBundles.payload.value.find((b) => b.name === BUNDLE_NAME)?.id;
+    if (rhelBundle !== undefined) {
+      return rhelBundle?.id;
     } else {
       throw new Error(`Error when fetching bundle ${BUNDLE_NAME}`);
     }
   };
-
-  return getbundleTabs;
 };
 
 const useCreateSplunkIntegration = () => {

--- a/src/schemas/Integrations/Integration.ts
+++ b/src/schemas/Integrations/Integration.ts
@@ -32,6 +32,7 @@ export const IntegrationSchemaBase: Yup.SchemaOf<NewIntegrationBase> =
       .oneOf(Object.values(Schemas.EndpointStatus.Enum))
       .default(Schemas.EndpointStatus.Enum.UNKNOWN),
     serverErrors: Yup.number().default(0),
+    eventTypes: Yup.array().of(Yup.string()).optional(),
   });
 
 export const IntegrationHttpSchema: Yup.SchemaOf<

--- a/src/types/Integration.ts
+++ b/src/types/Integration.ts
@@ -62,6 +62,7 @@ export interface IntegrationBase<T extends IntegrationType> {
   isEnabled: boolean;
   status?: Schemas.EndpointStatus | undefined;
   serverErrors: number;
+  eventTypes?: Array<string> | undefined;
 }
 
 export interface IntegrationHttp

--- a/src/types/adapters/IntegrationAdapter.ts
+++ b/src/types/adapters/IntegrationAdapter.ts
@@ -282,5 +282,6 @@ export const toServerIntegrationRequest = (
     sub_type: subType,
     description: '',
     properties: toIntegrationProperties(integration),
+    event_types: integration.eventTypes,
   };
 };


### PR DESCRIPTION
### Description
Since we are moving away from Notifications behavior groups, Splunk integration have to be updated.
It's now possible create an integration and to link it to sevral event types of sevral bundles with a single request.

[RHCLOUD-36086](https://issues.redhat.com/browse/RHCLOUD-36086)

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
