### PR TITLE
Add actions to integrations drawer

### DIFF
--- a/src/components/Integrations/IntegrationDetails.tsx
+++ b/src/components/Integrations/IntegrationDetails.tsx
@@ -4,6 +4,7 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
+  Icon,
 } from '@patternfly/react-core';
 import { IntegrationIcon, IntegrationType } from '../../types/Integration';
 import { IntegrationStatus, StatusUnknown } from './Table/IntegrationStatus';
@@ -16,6 +17,7 @@ import {
   PagerDutyContent,
   SlackContent,
 } from './IntegrationDetailsContent';
+import { CheckCircleIcon, StopCircleIcon } from '@patternfly/react-icons';
 
 export const getIntegrationIcon = (type: string): React.ReactElement | null => {
   const allIcons = {
@@ -99,7 +101,13 @@ const IntegrationDetails: React.FunctionComponent<IntegrationDetailsProps> = ({
           {intl.formatMessage(messages.enabled)}
         </DescriptionListTerm>
         <DescriptionListDescription>
-          {integration?.isEnabled}
+          <Icon status={integration?.isEnabled ? 'success' : 'warning'}>
+            {integration?.isEnabled ? (
+              <CheckCircleIcon data-testid="success-icon" />
+            ) : (
+              <StopCircleIcon data-testid="error-icon" />
+            )}
+          </Icon>
         </DescriptionListDescription>
         {integration && buildIntegrationDetails(integration)}
       </DescriptionListGroup>

--- a/src/pages/Integrations/List/List.tsx
+++ b/src/pages/Integrations/List/List.tsx
@@ -143,6 +143,19 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
     savedNotificationScope
   );
 
+  const focusedIntegrationEnabled = integrationRows.rows.find(
+    ({ id }) => id === focusedIntegration?.id
+  )?.isEnabled;
+
+  React.useEffect(() => {
+    if (focusedIntegration) {
+      setFocusedIntegration(
+        integrationRows.rows.find(({ id }) => id === focusedIntegration?.id)
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [focusedIntegrationEnabled]);
+
   const onAddIntegrationClicked = React.useCallback(() => {
     modalIsOpenActions.create();
   }, [modalIsOpenActions]);
@@ -319,6 +332,11 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
                   <DrawerContent
                     panelContent={
                       <IntegrationsDrawer
+                        actionResolver={actionResolver}
+                        selectedIndex={integrationRows.rows?.findIndex(
+                          ({ id }) =>
+                            focusedIntegration && id === focusedIntegration.id
+                        )}
                         selectedIntegration={focusedIntegration}
                         setSelectedIntegration={setFocusedIntegration}
                       />
@@ -338,6 +356,7 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
                         actionResolver={actionResolver}
                         onSort={sort.onSort}
                         sortBy={sort.sortBy}
+                        setFocusedIntegration={setFocusedIntegration}
                         selectedIntegration={focusedIntegration}
                       />
                     </DrawerContentBody>

--- a/src/pages/Integrations/List/__tests__/Page.test.tsx
+++ b/src/pages/Integrations/List/__tests__/Page.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable testing-library/prefer-screen-queries, testing-library/no-node-access */
-import { render, screen } from '@testing-library/react';
+import { getAllByText, render, screen } from '@testing-library/react';
 import fetchMock from 'fetch-mock';
 import * as React from 'react';
 
@@ -13,7 +13,7 @@ import { Schemas } from '../../../../generated/OpenapiIntegrations';
 import { IntegrationsListPage } from '../Page';
 import Endpoint = Schemas.Endpoint;
 import { ouiaSelectors } from '@redhat-cloud-services/frontend-components-testing';
-import { getByLabelText, getByText } from '@testing-library/react';
+import { getByLabelText } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => {
@@ -235,16 +235,19 @@ describe('src/pages/Integrations/List/Page', () => {
       await userEvent.click(dropdownContainer);
 
       expect(
-        getByText(dropdownContainer.parentElement as HTMLElement, /Edit/i)
+        getAllByText(dropdownContainer.parentElement as HTMLElement, /Edit/i)[0]
       ).toBeEnabled();
       expect(
-        getByText(dropdownContainer.parentElement as HTMLElement, /Delete/i)
+        getAllByText(
+          dropdownContainer.parentElement as HTMLElement,
+          /Delete/i
+        )[0]
       ).toBeEnabled();
       expect(
-        getByText(
+        getAllByText(
           dropdownContainer.parentElement as HTMLElement,
           /(Enable|Disable)/i
-        )
+        )[0]
       ).toBeEnabled();
     });
 
@@ -287,16 +290,19 @@ describe('src/pages/Integrations/List/Page', () => {
       await userEvent.click(dropdownContainer);
 
       expect(
-        getByText(dropdownContainer.parentElement as HTMLElement, /Edit/i)
+        getAllByText(dropdownContainer.parentElement as HTMLElement, /Edit/i)[0]
       ).toBeEnabled();
       expect(
-        getByText(dropdownContainer.parentElement as HTMLElement, /Delete/i)
+        getAllByText(
+          dropdownContainer.parentElement as HTMLElement,
+          /Delete/i
+        )[0]
       ).toBeEnabled();
       expect(
-        getByText(
+        getAllByText(
           dropdownContainer.parentElement as HTMLElement,
           /(Enable|Disable)/i
-        )
+        )[0]
       ).toBeEnabled();
     });
   });

--- a/src/pages/Integrations/List/useActionResolver.ts
+++ b/src/pages/Integrations/List/useActionResolver.ts
@@ -6,6 +6,8 @@ import {
 } from '../../../components/Integrations/Table';
 import { UserIntegration } from '../../../types/Integration';
 import { useFlag } from '@unleash/proxy-client-react';
+import { useIntl } from 'react-intl';
+import messages from '../../../properties/DefinedMessages';
 
 interface ActionResolverParams {
   onEdit: (integration: UserIntegration) => void;
@@ -17,6 +19,7 @@ interface ActionResolverParams {
 
 export const useActionResolver = (params: ActionResolverParams) => {
   const integrationTest = useFlag('insights.integrations.test');
+  const intl = useIntl();
   return useCallback(
     (integration: IntegrationRow, index: number) => {
       const onEdit = params.onEdit;
@@ -31,6 +34,9 @@ export const useActionResolver = (params: ActionResolverParams) => {
           title: 'Edit',
           isDisabled,
           onClick: () => onEdit(integration),
+          description: intl.formatMessage(
+            messages.integrationdropdownEditDescription
+          ),
         },
         ...(integrationTest
           ? [
@@ -38,22 +44,30 @@ export const useActionResolver = (params: ActionResolverParams) => {
                 title: 'Test',
                 isDisabled,
                 onClick: () => onTest(integration),
+                description: intl.formatMessage(
+                  messages.integrationdropdownTestDescription
+                ),
               },
             ]
           : []),
         {
           title: 'Delete',
           isDisabled,
+          description: intl.formatMessage(messages.removeDescription),
           onClick: () => onDelete(integration),
         },
         {
           title: integration.isEnabled ? 'Disable' : 'Enable',
           isDisabled,
+          description: integration.isEnabled
+            ? intl.formatMessage(messages.pauseDescription)
+            : intl.formatMessage(messages.resumeDescription),
           onClick: () => onEnable(integration, index, !integration.isEnabled),
         },
       ];
     },
     [
+      intl,
       params.onEdit,
       params.onTest,
       params.onDelete,

--- a/src/properties/DefinedMessages.ts
+++ b/src/properties/DefinedMessages.ts
@@ -63,6 +63,11 @@ export default defineMessages({
     description: 'integrations drawer dropdown pause action description',
     defaultMessage: 'Temporarily disable data collection',
   },
+  resumeDescription: {
+    id: 'resumeDescription',
+    description: 'integrations drawer dropdown resume action description',
+    defaultMessage: 'Enable data collection',
+  },
   integrationdropdownRemove: {
     id: 'integrationdropdownRemove',
     description: 'integrations drawer dropdown remove action',
@@ -78,6 +83,16 @@ export default defineMessages({
     id: 'integrationdropdownEdit',
     description: 'integrations drawer dropdown edit action',
     defaultMessage: 'Edit',
+  },
+  integrationdropdownEditDescription: {
+    id: 'integrationdropdownEditDescription',
+    description: 'integrations drawer dropdown edit action description',
+    defaultMessage: 'Edit this integration',
+  },
+  integrationdropdownTestDescription: {
+    id: 'integrationdropdownTestDescription',
+    description: 'integrations drawer dropdown test action description',
+    defaultMessage: 'Execute test command for this integration',
   },
   integrationDetailsTabTitle: {
     id: 'integrationDetailsTabTitle',


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

Use actions mapper which is used for each row in integrations drawer. Also adjust activating each row and how is Enabled is passed down to the active integration.

[RHCLOUD-35061](https://issues.redhat.com/browse/RHCLOUD-35061)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![Screenshot 2024-11-28 at 16 03 23](https://github.com/user-attachments/assets/083991d1-1589-4e1a-9447-9063ff497f49)
![Screenshot 2024-11-28 at 16 03 27](https://github.com/user-attachments/assets/426b8afc-4c65-4ee1-af3b-3168a834fb5e)



#### After:
![Screenshot 2024-11-28 at 16 01 46](https://github.com/user-attachments/assets/1617593d-f953-477a-9799-a47dc8ae1dca)
![Screenshot 2024-11-28 at 16 01 52](https://github.com/user-attachments/assets/f7c4df3a-46fc-4421-9263-f7805a536026)


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
