### PR TITLE
Fix time config cancel

### DIFF
--- a/src/components/Notifications/TimeConfig.tsx
+++ b/src/components/Notifications/TimeConfig.tsx
@@ -148,8 +148,9 @@ export const TimeConfigComponent: React.FunctionComponent = () => {
   const handleButtonSave = React.useCallback(() => {
     if (timeSelect) {
       setTimeConfig(`${timeSelect.utcTime}:00`)
-        .then(() => {
+        .then(async () => {
           addSuccessNotification('Action settings saved', '');
+          setTimePref(await getTimeConfig());
         })
         .catch(() => {
           addDangerNotification('Failed to save action settings', '');
@@ -163,6 +164,13 @@ export const TimeConfigComponent: React.FunctionComponent = () => {
 
   const handleModalToggle = () => {
     setIsModalOpen(!isModalOpen);
+    if (timePref) {
+      setTimeSelect({
+        baseCustomTime: timePref,
+        utcTime: timePref,
+        timezoneText: undefined,
+      });
+    }
   };
 
   return (


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

When user cancels the set daily digest modal the value is still present in the description. However after refreshing the correct value is shown. This PR fixes such issue by pulling the timeconfig data when submit happens and when user cancels the modal the timeconfig of server value is used.

[RHCLOUD-36282](https://issues.redhat.com/browse/RHCLOUD-36282)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


https://github.com/user-attachments/assets/8dede972-5392-4db4-b9bf-97a0c700966d


#### After:

https://github.com/user-attachments/assets/2add0dd7-f93b-476f-b3c3-aae48b653685



---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [x] _(Optional) QE: Has been mentioned: @Saba7826 FYI
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
