### PR TITLE
Fix associated event types drawer info by checking for -1

### DIFF
--- a/src/components/Integrations/IntegrationsDrawer.tsx
+++ b/src/components/Integrations/IntegrationsDrawer.tsx
@@ -156,18 +156,20 @@ const IntegrationsDrawer: React.FunctionComponent<IntegrationsDrawerProps> = ({
           }
           ouiaId={`${ouiaId}-associated-event-types-tab`}
         >
-          {selectedIntegration && selectedIndex && (
-            <IntegrationEventDetails
-              id={selectedIntegration?.id}
-              onEdit={() => {
-                const editAction = actionResolver(
-                  selectedIntegration,
-                  selectedIndex
-                ).find(({ type }) => type === 'edit');
-                editAction?.onClick?.();
-              }}
-            />
-          )}
+          {selectedIntegration &&
+            selectedIndex !== undefined &&
+            selectedIndex !== -1 && (
+              <IntegrationEventDetails
+                id={selectedIntegration?.id}
+                onEdit={() => {
+                  const editAction = actionResolver(
+                    selectedIntegration,
+                    selectedIndex
+                  ).find(({ type }) => type === 'edit');
+                  editAction?.onClick?.();
+                }}
+              />
+            )}
         </Tab>
       </Tabs>
     </DrawerPanelContent>


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

When user clicks on first item in table the event types tab is empty. This is caused by checking for index which can be 0. This PR fixes such issue by checking if the index is undefined and not -1

[RHCLOUD-RHCLOUD-37417](https://issues.redhat.com/browse/RHCLOUD-RHCLOUD-37417)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![Screenshot 2025-01-21 at 17 24 32](https://github.com/user-attachments/assets/d32a022c-167a-493b-986a-87874558c6f3)


#### After:
![Screenshot 2025-01-21 at 17 24 15](https://github.com/user-attachments/assets/a2741260-8723-4cbb-b1ef-23c686e26d5a)


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
