### PR TITLE
Remove notifications status endpoint

### DIFF
--- a/src/app/__tests__/App.test.tsx
+++ b/src/app/__tests__/App.test.tsx
@@ -69,7 +69,7 @@ const mockMaintenance = (isUp: boolean) => {
         status: 'MAINTENANCE',
       };
 
-  fetchMock.get('/api/notifications/v1.0/status', {
+  fetchMock.get('/api/rbac/v1/status/', {
     status: 200,
     body: response,
   });

--- a/src/services/GetServerStatus.ts
+++ b/src/services/GetServerStatus.ts
@@ -5,11 +5,11 @@ import {
 } from 'openapi2typescript';
 import { useQuery } from 'react-fetching-library';
 
-import { Operations } from '../generated/OpenapiPrivate';
+import { Operations } from '../generated/OpenapiRbac';
 import { toServer } from '../types/adapters/ServerAdapter';
 
 const adapter = validationResponseTransformer(
-  (payload: Operations.StatusResourceGetCurrentStatus.Payload) => {
+  (payload: Operations.GetStatus.Payload) => {
     if (payload.status === 200) {
       return validatedResponse('ServerStatus', 200, toServer(), payload.errors);
     }
@@ -20,7 +20,7 @@ const adapter = validationResponseTransformer(
 
 export const useGetServerStatus = () => {
   return useTransformQueryResponse(
-    useQuery(Operations.StatusResourceGetCurrentStatus.actionCreator()),
+    useQuery(Operations.GetStatus.actionCreator()),
     adapter
   );
 };


### PR DESCRIPTION
For [RHCLOUD-36131](https://issues.redhat.com/browse/RHCLOUD-36131).  Removes the `/api/notifications/v1.0/status` endpoint from `GetServerStatus` and replaces with `/api/rbac/v1/status/` as a health check