### PR TITLE
Change server status check to event endpoint

### DIFF
--- a/src/app/__tests__/App.test.tsx
+++ b/src/app/__tests__/App.test.tsx
@@ -61,13 +61,13 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => {
 const mockMaintenance = (isUp: boolean) => {
   const response = isUp
     ? {
-        status: 'UP',
+        data: [],
+        links: {},
+        meta: {
+          count: 0,
+        },
       }
-    : {
-        start_time: '2021-06-11T13:09:31.213141',
-        end_time: '2021-06-11T18:09:31.213141',
-        status: 'MAINTENANCE',
-      };
+    : {};
 
   fetchMock.get('/api/notifications/v1.0/notifications/events', {
     status: 200,

--- a/src/app/__tests__/App.test.tsx
+++ b/src/app/__tests__/App.test.tsx
@@ -69,7 +69,7 @@ const mockMaintenance = (isUp: boolean) => {
         status: 'MAINTENANCE',
       };
 
-  fetchMock.get('/api/notifications/v1.0/status', {
+  fetchMock.get('/api/notifications/v1.0/notifications/events', {
     status: 200,
     body: response,
   });

--- a/src/app/useApp.ts
+++ b/src/app/useApp.ts
@@ -7,7 +7,7 @@ import { useEffect, useState } from 'react';
 
 import Config from '../config/Config';
 import { useGetServerStatus } from '../services/GetServerStatus';
-import { Server } from '../types/Server';
+import { Server, ServerStatus } from '../types/Server';
 import { AppContext } from './AppContext';
 
 export const useApp = (): Partial<AppContext> => {
@@ -32,8 +32,18 @@ export const useApp = (): Partial<AppContext> => {
   }, []);
 
   useEffect(() => {
-    if (serverStatus.payload?.type === 'ServerStatus') {
-      setServer(serverStatus.payload.value);
+    if (serverStatus.payload?.type === 'Events') {
+      if (serverStatus.payload?.status === 200) {
+        setServer({
+          status: ServerStatus.RUNNING,
+        });
+      } else {
+        setServer({
+          status: ServerStatus.MAINTENANCE,
+          from: new Date(),
+          to: new Date(),
+        });
+      }
     }
   }, [serverStatus.payload]);
 

--- a/src/services/GetServerStatus.ts
+++ b/src/services/GetServerStatus.ts
@@ -5,11 +5,11 @@ import {
 } from 'openapi2typescript';
 import { useQuery } from 'react-fetching-library';
 
-import { Operations } from '../generated/OpenapiPrivate';
+import { Operations } from '../generated/OpenapiNotifications';
 import { toServer } from '../types/adapters/ServerAdapter';
 
 const adapter = validationResponseTransformer(
-  (payload: Operations.StatusResourceGetCurrentStatus.Payload) => {
+  (payload: Operations.EventResource$v1GetEvents.Payload) => {
     if (payload.status === 200) {
       return validatedResponse('ServerStatus', 200, toServer(), payload.errors);
     }
@@ -20,7 +20,7 @@ const adapter = validationResponseTransformer(
 
 export const useGetServerStatus = () => {
   return useTransformQueryResponse(
-    useQuery(Operations.StatusResourceGetCurrentStatus.actionCreator()),
+    useQuery(Operations.EventResource$v1GetEvents.actionCreator({})),
     adapter
   );
 };

--- a/src/services/GetServerStatus.ts
+++ b/src/services/GetServerStatus.ts
@@ -6,12 +6,20 @@ import {
 import { useQuery } from 'react-fetching-library';
 
 import { Operations } from '../generated/OpenapiNotifications';
-import { toServer } from '../types/adapters/ServerAdapter';
+import { toNotificationEvent } from '../types/adapters/NotificationEventAdapter';
 
 const adapter = validationResponseTransformer(
   (payload: Operations.EventResource$v1GetEvents.Payload) => {
     if (payload.status === 200) {
-      return validatedResponse('ServerStatus', 200, toServer(), payload.errors);
+      return validatedResponse(
+        'Events',
+        200,
+        {
+          ...payload.value,
+          data: payload.value.data.map(toNotificationEvent),
+        },
+        payload.errors
+      );
     }
 
     return payload;

--- a/src/types/adapters/ServerAdapter.ts
+++ b/src/types/adapters/ServerAdapter.ts
@@ -1,7 +1,0 @@
-import { Server, ServerStatus } from '../Server';
-
-export const toServer = (): Server => {
-  return {
-    status: ServerStatus.RUNNING,
-  };
-};


### PR DESCRIPTION
For [RHCLOUD-36131](https://issues.redhat.com/browse/RHCLOUD-36131). Since the `/api/notifications/v1.0/status` endpoint is going away, this PR replaces it with the `/api/notifications/v1.0/notifications/events` endpoint instead when doing a health check. Still trying to figure out why a unit test is failing, but wanted to get some eyes on it. 