### PR TITLE
Fix create new integration by selecting Openshift in event types

### DIFF
--- a/src/pages/Integrations/Create/eventTypesStep.ts
+++ b/src/pages/Integrations/Create/eventTypesStep.ts
@@ -22,6 +22,7 @@ export const eventTypesStep = () => ({
       isVisibleOnReview: false,
       name: 'product-family',
       label: 'Product family',
+      initialValue: 'openshift',
       options: [
         { label: 'OpenShift', value: 'openshift' },
         { label: 'Red Hat Enterprise Linux', value: 'rhel' },


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

When user wants to create new integration they have to click on application select in event types step. This is not ideal as this step is optional. This PR fixes it by selecting Openshift by default.

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:

![Screenshot 2025-02-26 at 17 31 02](https://github.com/user-attachments/assets/87b403bf-4a0f-4003-a373-5ccde78d54f5)


#### After:

![Screenshot 2025-02-26 at 17 32 20](https://github.com/user-attachments/assets/ba50db9c-dc97-4129-8252-8b0114cf8771)


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
