### PR TITLE
Fix race condition

### DIFF
--- a/src/pages/Integrations/Create/CustomComponents/SelectableTable.tsx
+++ b/src/pages/Integrations/Create/CustomComponents/SelectableTable.tsx
@@ -83,6 +83,7 @@ const SelectableTable = (props) => {
   const [allBundles, setAllBundles] = useState<Facet[] | undefined>();
   const { getState } = useFormApi();
   const { input } = useFieldApi<Record<string, unknown>>(props);
+  const [loaded, setLoaded] = useState<boolean>(false);
   let value: readonly EventType[] = [];
   const productFamily = getState().values[props.bundleFieldName];
   const integrationId = getState().values['id'];
@@ -132,7 +133,10 @@ const SelectableTable = (props) => {
   };
 
   React.useEffect(() => {
-    if (!integrationId) return;
+    if (!integrationId) {
+      setLoaded(true);
+      return;
+    }
 
     const getEventData = async () => {
       const data = await getEndpoint(integrationId);
@@ -150,12 +154,13 @@ const SelectableTable = (props) => {
       );
 
       input.onChange(mapEventTypesToInput(eventTypes));
+      setLoaded(true);
     };
 
     getEventData();
   }, [integrationId]);
 
-  return currBundle ? (
+  return currBundle && loaded ? (
     <AssociateEventTypesStep
       applications={currBundle.children as readonly Facet[]}
       bundle={currBundle}


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

There's a possibility for the list of event types to be available sooner than list of assigned event types. This can break the edit flow as users can see empty table. There's even bigger problem if user would have clicked as soon as the next button is available and data are still loaded for assigned event types to clear out their selection. This PR introduces a `loaded` state variable which is set to `true` once the data for selected event types has been processed, this triggers the load of selectable table which enables the Next step as well.

---

### Before


https://github.com/user-attachments/assets/935c0aeb-afcd-448f-a1cc-c4ef43801bc6



### After


https://github.com/user-attachments/assets/c77900f2-9c7d-40c8-bd35-a43ac71f58d7



---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
