### PR TITLE
Self initialize drawer global shared state.

### DIFF
--- a/src/components/NotificationsDrawer/DrawerBell.tsx
+++ b/src/components/NotificationsDrawer/DrawerBell.tsx
@@ -18,7 +18,7 @@ const DrawerBell: React.ComponentType<DrawerBellProps> = ({
     drawerActions: { toggleDrawerContent },
   } = useChrome();
   const {
-    state: { hasUnread },
+    state: { hasUnread, ready },
   } = useNotificationDrawer();
   return (
     <ToolbarItem className="pf-v6-u-mx-0">
@@ -38,6 +38,7 @@ const DrawerBell: React.ComponentType<DrawerBellProps> = ({
               module: './DrawerPanel',
             });
           }}
+          isDisabled={!ready}
           aria-label="Notifications"
           isExpanded={isNotificationDrawerExpanded}
         >

--- a/src/components/NotificationsDrawer/DrawerPanel.tsx
+++ b/src/components/NotificationsDrawer/DrawerPanel.tsx
@@ -12,6 +12,7 @@ import {
   NotificationDrawerList,
 } from '@patternfly/react-core/dist/dynamic/components/NotificationDrawer';
 import { Badge } from '@patternfly/react-core/dist/dynamic/components/Badge';
+import Spinner from '@redhat-cloud-services/frontend-components/Spinner';
 
 import orderBy from 'lodash/orderBy';
 import { useNavigate } from 'react-router-dom';
@@ -32,7 +33,7 @@ const DrawerPanelBase = ({ toggleDrawer }: DrawerPanelProps) => {
   const [isOrgAdmin, setIsOrgAdmin] = useState(false);
   const [isFilterDropdownOpen, setIsFilterDropdownOpen] = useState(false);
   const {
-    state,
+    state: { ready, ...state },
     addNotification,
     updateNotificationRead,
     updateSelectedStatus,
@@ -151,6 +152,10 @@ const DrawerPanelBase = ({ toggleDrawer }: DrawerPanelProps) => {
     ));
   };
 
+  if (!ready) {
+    return <Spinner centered />;
+  }
+
   return (
     <>
       <NotificationDrawerHeader
@@ -172,6 +177,7 @@ const DrawerPanelBase = ({ toggleDrawer }: DrawerPanelProps) => {
         />
         <BulkSelect
           id="notifications-bulk-select"
+          onSelect={(checked) => selectAllNotifications(checked)}
           items={[
             {
               title: 'Select none (0)',

--- a/src/components/NotificationsDrawer/initNotificationScope.tsx
+++ b/src/components/NotificationsDrawer/initNotificationScope.tsx
@@ -3,8 +3,14 @@ import DrawerPanel from './DrawerPanel';
 import useNotificationDrawer from '../../hooks/useNotificationDrawer';
 import { DrawerSingleton } from './DrawerSingleton';
 
+/**
+ * @deprecated The subscribe method checks if the state was initialized and if not, it will run the init method.
+ */
 function initNotificationScope() {
   const scope = getSharedScope();
+  console.error(
+    'This module is deprecated and will be removed in the future! Notification state is initialized if a subscription request is detected.'
+  );
   scope['@notif-module/drawer'] = {
     '1.0.0': {
       loaded: 1,

--- a/src/types/Drawer.ts
+++ b/src/types/Drawer.ts
@@ -27,6 +27,8 @@ export type NotificationDrawerState = {
   filterConfig: FilterConfigItem[];
   hasNotificationsPermissions: boolean;
   hasUnread: boolean;
+  ready: boolean;
+  initializing: boolean;
 };
 
 export interface FilterConfigItem {


### PR DESCRIPTION


### Description
https://issues.redhat.com/browse/RHCLOUD-38614

Currently, the notification drawer state has to be explicitly initialized by some other entity (Currently Chrome). However, because the state is a "Singleton" and shared across modules that consume it, we can move the initialization check and call to the "subscribe" method.

This means, that invoking the subscription to the singleton state, will trigger the state initialization if it was not yet initialized. The state has to be initialized if some other modules are consuming it, so it is safe to keep it "pending" if no modules are trying to access it.

[RHCLOUDXXXX](https://issues.redhat.com/browse/RHCLOUDXXXX)


### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
