### PR TITLE
[RHCLOUD-39723] Align bundles order of integrations/event types workflow step, according "configure events" screen.

### DIFF
--- a/src/pages/Integrations/Create/eventTypesStep.ts
+++ b/src/pages/Integrations/Create/eventTypesStep.ts
@@ -22,11 +22,12 @@ export const eventTypesStep = () => ({
       isVisibleOnReview: false,
       name: 'product-family',
       label: 'Product family',
-      initialValue: 'openshift',
+      initialValue: 'rhel',
       options: [
-        { label: 'OpenShift', value: 'openshift' },
         { label: 'Red Hat Enterprise Linux', value: 'rhel' },
         { label: 'Console', value: 'console' },
+        { label: 'OpenShift', value: 'openshift' },
+        { label: 'Subscription Services', value: 'subscription-services' },
       ],
     },
     {


### PR DESCRIPTION
+ Add 'Subscription Services' bundle.

### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
On the new integration workflow, at "Associate event types" step:

- Bundles order should be align on "Configure Event" screen
- Bundle selected by default should be rhel like "Configure Event" screen
- "Subscription Services" bundle is missing

[RHCLOUD-39723](https://issues.redhat.com/browse/RHCLOUD-39723)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
![image](https://github.com/user-attachments/assets/d021845a-1ca1-4528-b8f9-5db7bc4962cd)

#### After:
![image](https://github.com/user-attachments/assets/628c5f1f-97db-47d2-83d0-f28193bf7d30)

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
