### PR TITLE
Update integrations adapter with new spec values

### DIFF
--- a/src/generated/OpenapiIntegrations.ts
+++ b/src/generated/OpenapiIntegrations.ts
@@ -176,9 +176,9 @@ export namespace Schemas {
   export const SystemSubscriptionProperties =
     zodSchemaSystemSubscriptionProperties();
   export type SystemSubscriptionProperties = {
-    groupId?: UUID | undefined | null;
-    ignorePreferences?: boolean | undefined | null;
-    onlyAdmins?: boolean | undefined | null;
+    group_id?: UUID | undefined | null;
+    ignore_preferences?: boolean | undefined | null;
+    only_admins?: boolean | undefined | null;
   };
 
   export const UUID = zodSchemaUUID();

--- a/src/pages/Notifications/EventLog/EventLogPage.tsx
+++ b/src/pages/Notifications/EventLog/EventLogPage.tsx
@@ -135,7 +135,7 @@ export const EventLogPage: React.FunctionComponent = () => {
           case 'drawer': {
             const properties = endpoint.payload.value
               .properties as Schemas.SystemSubscriptionProperties;
-            if (properties.onlyAdmins) {
+            if (properties.only_admins) {
               return 'Users: Admin';
             }
 

--- a/src/types/adapters/IntegrationAdapter.ts
+++ b/src/types/adapters/IntegrationAdapter.ts
@@ -113,9 +113,9 @@ const toIntegrationEmail = (
   properties: Schemas.SystemSubscriptionProperties
 ): IntegrationEmailSubscription => ({
   ...integrationBase,
-  ignorePreferences: properties.ignorePreferences,
-  groupId: properties.groupId === null ? undefined : properties.groupId,
-  onlyAdmin: properties.onlyAdmins === null ? undefined : properties.onlyAdmins,
+  ignorePreferences: properties.ignore_preferences,
+  groupId: properties.group_id === null ? undefined : properties.group_id,
+  onlyAdmin: properties.only_admins === null ? undefined : properties.only_admins,
 });
 
 const toIntegrationDrawer = (
@@ -123,9 +123,9 @@ const toIntegrationDrawer = (
   properties: Schemas.SystemSubscriptionProperties
 ): IntegrationDrawer => ({
   ...integrationBase,
-  ignorePreferences: properties.ignorePreferences,
-  groupId: properties.groupId === null ? undefined : properties.groupId,
-  onlyAdmin: properties.onlyAdmins,
+  ignorePreferences: properties.ignore_preferences,
+  groupId: properties.group_id === null ? undefined : properties.group_id,
+  onlyAdmin: properties.only_admins,
 });
 
 const toIntegrationPagerDuty = (
@@ -243,18 +243,18 @@ export const toIntegrationProperties = (
       const integrationEmail: IntegrationEmailSubscription =
         integration as IntegrationEmailSubscription;
       return {
-        onlyAdmins: integrationEmail.onlyAdmin,
-        groupId: integrationEmail.groupId,
-        ignorePreferences: integrationEmail.ignorePreferences,
+        only_admins: integrationEmail.onlyAdmin,
+        group_id: integrationEmail.groupId,
+        ignore_preferences: integrationEmail.ignorePreferences,
       };
     }
     case IntegrationType.DRAWER: {
       const integrationDrawer: IntegrationDrawer =
         integration as IntegrationDrawer;
       return {
-        onlyAdmins: integrationDrawer.onlyAdmin,
-        groupId: integrationDrawer.groupId,
-        ignorePreferences: integrationDrawer.ignorePreferences,
+        only_admins: integrationDrawer.onlyAdmin,
+        group_id: integrationDrawer.groupId,
+        ignore_preferences: integrationDrawer.ignorePreferences,
       };
     }
     case IntegrationType.PAGERDUTY: {

--- a/src/types/adapters/IntegrationAdapter.ts
+++ b/src/types/adapters/IntegrationAdapter.ts
@@ -115,7 +115,8 @@ const toIntegrationEmail = (
   ...integrationBase,
   ignorePreferences: properties.ignore_preferences,
   groupId: properties.group_id === null ? undefined : properties.group_id,
-  onlyAdmin: properties.only_admins === null ? undefined : properties.only_admins,
+  onlyAdmin:
+    properties.only_admins === null ? undefined : properties.only_admins,
 });
 
 const toIntegrationDrawer = (


### PR DESCRIPTION
Somewhere along the way, the OpenAPI spec was updated with these values but it was not updated in the adapter causing [RHCLOUD-38823](https://issues.redhat.com/browse/RHCLOUD-38823).

<img width="1103" alt="image" src="https://github.com/user-attachments/assets/67f42168-def8-4748-a0f4-64175b2b006b" />
