### PR TITLE
RHCLOUD-34366 add separate subtitle for non org admins

### DIFF
--- a/src/pages/Notifications/List/BundlePage.tsx
+++ b/src/pages/Notifications/List/BundlePage.tsx
@@ -5,12 +5,14 @@ import {
   Tab,
   TabTitleText,
   Tabs,
+  Text,
+  TextVariants,
 } from '@patternfly/react-core';
 import { global_spacer_lg } from '@patternfly/react-tokens';
 import Main from '@redhat-cloud-services/frontend-components/Main';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import { useFlag } from '@unleash/proxy-client-react';
-import { default as React, useEffect, useMemo } from 'react';
+import { default as React, useEffect, useMemo, useState } from 'react';
 import { style } from 'typestyle';
 
 import { useAppContext } from '../../../app/AppContext';
@@ -34,9 +36,19 @@ interface NotificationListBundlePageProps {
 export const NotificationListBundlePage: React.FunctionComponent<
   React.PropsWithChildren<NotificationListBundlePageProps>
 > = (props) => {
-  const { updateDocumentTitle } = useChrome();
+  const { updateDocumentTitle, auth } = useChrome();
   const navigate = useNavigate();
   const location = useLocation();
+
+  const [isOrgAdmin, setIsOrgAdmin] = useState(false);
+
+  useEffect(() => {
+    auth.getUser().then((user) => {
+      if (user) {
+        setIsOrgAdmin(!!user.identity.user?.is_org_admin);
+      }
+    });
+  }, [auth]);
 
   const bundle = useMemo(
     () => new URLSearchParams(location.search).get('bundle') ?? 'rhel',
@@ -126,10 +138,34 @@ export const NotificationListBundlePage: React.FunctionComponent<
         <PageHeader
           title={pageTitle()}
           subtitle={
-            <span>
-              Configure which event notifications different users within your
-              organization are entitled to receive.
-            </span>
+            isOrgAdmin ? (
+              <span>
+                Configure which event notifications different users within your
+                organization are entitled to receive. To manage your own
+                personal notification settings, go to{' '}
+                <Text
+                  component={TextVariants.a}
+                  href="/settings/notifications/user-preferences/"
+                >
+                  Notification Preferences
+                </Text>
+                .
+              </span>
+            ) : (
+              <span>
+                View how notifications are configured by your organization
+                admin. Contact your organization admin if you need access to
+                edit these configurations. To manage your own personal
+                notification settings, go to{' '}
+                <Text
+                  component={TextVariants.a}
+                  href="/settings/notifications/user-preferences/"
+                >
+                  Notification Preferences
+                </Text>
+                .
+              </span>
+            )
           }
           action={eventLogButton()}
         />


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
add separate subtitle for non org admins

[RHCLOUD-34366](https://issues.redhat.com/browse/RHCLOUD-34366)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
