### PR TITLE
patch: use upcomming root widget CSS selectors

### DIFF
--- a/src/components/Widgets/EventsWidget.scss
+++ b/src/components/Widgets/EventsWidget.scss
@@ -1,4 +1,4 @@
-.notifications-notificationsEvents {
+.notifications-notificationsEvents, [class*="notifications-notifications-./DashboardWidget"] {
   overflow-y: auto;
 }
 .pf-v5-c-empty-state {


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHCLOUD-41601

Changes
Ensures that the root widget element class names match the future widget ID