### PR TITLE
Fix infinit loading when selecting events

### DIFF
--- a/src/hooks/usePage.ts
+++ b/src/hooks/usePage.ts
@@ -19,15 +19,18 @@ export const usePage = <T>(
 ): PageAdapter => {
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage, setItemsPerPage] = useState(defaultPerPage);
+  const filterValues = filters ? Object.values(filters) : [];
 
   useEffect(() => {
     setCurrentPage(1);
-  }, [filters, setCurrentPage, itemsPerPage, category]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...filterValues, setCurrentPage, itemsPerPage, category]);
 
   const page = useMemo(() => {
-    const filter = filterBuilder ? filterBuilder(filters) : undefined;
+    const filter = filterBuilder?.(filters);
     return Page.of(currentPage, itemsPerPage, filter, sort);
-  }, [currentPage, itemsPerPage, filters, sort, filterBuilder]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentPage, itemsPerPage, ...filterValues, sort, filterBuilder]);
 
   const changePage = useCallback(
     (page: number) => {

--- a/src/pages/Integrations/Create/CustomComponents/SelectableTable.tsx
+++ b/src/pages/Integrations/Create/CustomComponents/SelectableTable.tsx
@@ -153,7 +153,7 @@ const SelectableTable = (props) => {
     };
 
     getEventData();
-  }, [input, integrationId, mapEventTypesToInput]);
+  }, [integrationId]);
 
   return currBundle && loaded ? (
     <AssociateEventTypesStep

--- a/src/services/useListNotifications.ts
+++ b/src/services/useListNotifications.ts
@@ -63,12 +63,12 @@ export const useListNotifications = (pager?: Page) => {
   const [response, setResponse] = useState<any>(null);
   const [error, setError] = useState<Error | null>(null);
 
+  const query = (pager ?? Page.defaultPage()).toQuery();
+
   const fetchNotifications = async () => {
     setLoading(true);
     setError(null);
-
     try {
-      const query = (pager ?? Page.defaultPage()).toQuery();
       const params = {
         limit: +query.limit,
         offset: +query.offset,
@@ -77,7 +77,6 @@ export const useListNotifications = (pager?: Page) => {
         bundleId: query.filterBundleId,
         sortBy: `${query.sortColumn}:${query.sortDirection}`,
       };
-
       const response = await getEventTypes(params);
       setResponse({ ...response, data: toNotifications(response.data) ?? [] });
     } catch (err) {
@@ -90,7 +89,13 @@ export const useListNotifications = (pager?: Page) => {
   useEffect(() => {
     fetchNotifications();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pager]);
+  }, [
+    query.offset,
+    query.limit,
+    query.filterBundleId,
+    query.filterApplicationId,
+    query.filterEventFilterName,
+  ]);
 
   return { loading, response, refresh: fetchNotifications, error };
 };


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

When user starts adding events to integration the wizard ends in inifinite loading state. This PR fixes such issue by correctly checking for dependencies in useEffect.

[RHCLOUD-41651](https://issues.redhat.com/browse/RHCLOUD-41651)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


https://github.com/user-attachments/assets/113aaa57-4d62-4881-ab61-914f38dc536c


#### After:

https://github.com/user-attachments/assets/04eff2fc-4a6b-4247-8ce1-346f69084c78



---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
