### PR TITLE
RHCLOUD-41723 Action dropdown on behavior group card stays open even after wizard opens

### DIFF
--- a/src/components/Notifications/BehaviorGroup/BehaviorGroupCard.tsx
+++ b/src/components/Notifications/BehaviorGroup/BehaviorGroupCard.tsx
@@ -75,7 +75,10 @@ const BehaviorGroupCardLayout: React.FunctionComponent<
                         {props.menuItems.map((item) => (
                           <MenuItem
                             key={item.key}
-                            onClick={item.onClick}
+                            onClick={() => {
+                              item.onClick();
+                              setOpen(false);
+                            }}
                             isDisabled={item.isDisabled}
                           >
                             {item.label}

--- a/src/components/Notifications/BehaviorGroup/Wizard/BehaviorGroupWizardFooter.tsx
+++ b/src/components/Notifications/BehaviorGroup/Wizard/BehaviorGroupWizardFooter.tsx
@@ -47,6 +47,7 @@ export const BehaviorGroupWizardFooter: React.FunctionComponent<
           variant={ButtonVariant.secondary}
           onClick={onBack}
           isDisabled={wizardContext.activeStep.id === 0 || props.isLoading}
+          className="pf-v5-u-ml-xs"
         >
           Back
         </Button>


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Action dropdown on behavior group card stays open even after wizard opens and added small spacing between buttons.

[RHCLOUD-41723](https://issues.redhat.com/browse/RHCLOUD-41723)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
