### PR TITLE
fix(integration): create inegration now succeeds

### DIFF
--- a/src/pages/Integrations/Create/CustomComponents/SelectableTable.tsx
+++ b/src/pages/Integrations/Create/CustomComponents/SelectableTable.tsx
@@ -160,12 +160,16 @@ const SelectableTable = (props) => {
       applications={currBundle.children as readonly Facet[]}
       currBundle={currBundle}
       selectedEvents={value}
-      setSelectedEvents={(events) => {
+      setSelectedEvents={(events = []) => {
         input.onChange({
           ...input.value,
-          [currBundle?.displayName]: {
-            ...events,
-          },
+          [currBundle?.displayName]: (events as EventType[]).reduce(
+            (acc, curr) => ({
+              ...acc,
+              [curr.id]: curr,
+            }),
+            {}
+          ),
         });
       }}
     />


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

Currently if user submits a create integration the action fails on incorrect data for event types. That's because we are sending keys instead of IDs. This PR fixes it by changing how events are stored in data driven forms.

[RHCLOUD-42245](https://issues.redhat.com/browse/RHCLOUD-42245)

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [-] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [-] _(Optional) QE: Has been mentioned_
- [-] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [-] _(Optional) UX: Has been mentioned_
##
