### PR TITLE
Convert events widget to dataview

### DIFF
--- a/src/components/Widgets/EventsWidget.test.tsx
+++ b/src/components/Widgets/EventsWidget.test.tsx
@@ -6,33 +6,48 @@ import EventsWidget from './EventsWidget';
 const notifications = [
   {
     id: '1',
-    title: 'Policy triggered',
-    source: 'Policies - Red Hat Enterprise Linux',
-    created: '2 May 2023, 11:43 UTC',
+    event_type: 'Policy triggered',
+    application: 'Policies',
+    bundle: 'Red Hat Enterprise Linux',
+    read: false,
+    description: 'Policy triggered event',
+    created: '2023-05-02T11:43:00Z',
   },
   {
     id: '2',
-    title: 'New advisory',
-    source: 'Patch - Red Hat Enterprise Linux',
-    created: '2 May 2023, 11:43 UTC',
+    event_type: 'New advisory',
+    application: 'Patch',
+    bundle: 'Red Hat Enterprise Linux',
+    read: false,
+    description: 'New advisory event',
+    created: '2023-05-02T11:43:00Z',
   },
   {
     id: '3',
-    title: 'New recommendation',
-    source: 'Advisor - Red Hat Enterprise Linux',
-    created: '2 May 2023, 11:43 UTC',
+    event_type: 'New recommendation',
+    application: 'Advisor',
+    bundle: 'Red Hat Enterprise Linux',
+    read: false,
+    description: 'New recommendation event',
+    created: '2023-05-02T11:43:00Z',
   },
   {
     id: '4',
-    title: 'New advisory',
-    source: 'Patch - Red Hat Enterprise Linux',
-    created: '2 May 2023, 11:43 UTC',
+    event_type: 'New advisory',
+    application: 'Patch',
+    bundle: 'Red Hat Enterprise Linux',
+    read: false,
+    description: 'New advisory event',
+    created: '2023-05-02T11:43:00Z',
   },
   {
     id: '5',
-    title: 'New recommendation',
-    source: 'Advisor - Red Hat Enterprise Linux',
-    created: '2 May 2023, 11:43 UTC',
+    event_type: 'New recommendation',
+    application: 'Advisor',
+    bundle: 'Red Hat Enterprise Linux',
+    read: false,
+    description: 'New recommendation event',
+    created: '2023-05-02T11:43:00Z',
   },
 ];
 
@@ -46,6 +61,7 @@ describe('EventsWidget component', () => {
             json: () =>
               Promise.resolve({
                 data: [],
+                meta: { count: 0 },
               }),
           } as Response);
         })
@@ -72,6 +88,7 @@ describe('EventsWidget component', () => {
             json: () =>
               Promise.resolve({
                 data: notifications,
+                meta: { count: notifications.length },
               }),
           } as Response);
         })
@@ -84,6 +101,11 @@ describe('EventsWidget component', () => {
     expect(screen.getByText('Event')).toBeVisible();
     expect(screen.getByText('Service')).toBeVisible();
     expect(screen.getByText('Date')).toBeVisible();
+    // 1 header row + 5 data rows
     expect(screen.getAllByRole('row')).toHaveLength(6);
+    // Check that pagination is rendered (only bottom pagination)
+    expect(
+      screen.getByLabelText('Events widget footer pagination')
+    ).toBeVisible();
   });
 });

--- a/src/components/Widgets/EventsWidget.tsx
+++ b/src/components/Widgets/EventsWidget.tsx
@@ -1,14 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
-  Table,
-  TableVariant,
-  Tbody,
-  Td,
-  Th,
-  Thead,
-  Tr,
-} from '@patternfly/react-table';
-import {
   Button,
   ButtonVariant,
   EmptyState,
@@ -24,6 +15,10 @@ import {
   DataViewToolbar,
   useDataViewPagination,
 } from '@patternfly/react-data-view';
+import {
+  DataViewTable,
+  DataViewTh,
+} from '@patternfly/react-data-view/dist/dynamic/DataViewTable';
 import {
   SkeletonTableBody,
   SkeletonTableHead,
@@ -147,17 +142,28 @@ const EventsWidget: React.FunctionComponent = () => {
     [intl]
   );
 
-  const loadingStateHeader = useMemo(
-    () => (
-      <SkeletonTableHead
-        columns={[
-          intl.formatMessage(messages.event),
-          intl.formatMessage(messages.service),
-          intl.formatMessage(messages.date),
-        ]}
-      />
-    ),
+  const columns: DataViewTh[] = useMemo(
+    () => [
+      intl.formatMessage(messages.event),
+      intl.formatMessage(messages.service),
+      intl.formatMessage(messages.date),
+    ],
     [intl]
+  );
+
+  const rows = useMemo(
+    () =>
+      notifications.map((event) => [
+        event.event_type,
+        `${event.application} - ${event.bundle}`,
+        <DateFormat key={event.id} date={event.created} />,
+      ]),
+    [notifications]
+  );
+
+  const loadingStateHeader = useMemo(
+    () => <SkeletonTableHead columns={columns} />,
+    [columns]
   );
 
   const loadingStateBody = useMemo(
@@ -171,44 +177,17 @@ const EventsWidget: React.FunctionComponent = () => {
         loading ? 'loading' : notifications.length === 0 ? 'empty' : undefined
       }
     >
-      <Table aria-label="Events widget table" variant={TableVariant.compact}>
-        {loading ? (
-          loadingStateHeader
-        ) : (
-          <Thead>
-            <Tr>
-              <Th>{intl.formatMessage(messages.event)}</Th>
-              <Th>{intl.formatMessage(messages.service)}</Th>
-              <Th>{intl.formatMessage(messages.date)}</Th>
-            </Tr>
-          </Thead>
-        )}
-        {loading ? (
-          loadingStateBody
-        ) : notifications.length === 0 ? (
-          <Tbody>
-            <Tr>
-              <Td colSpan={3}>{emptyState}</Td>
-            </Tr>
-          </Tbody>
-        ) : (
-          <Tbody>
-            {notifications.map((event) => (
-              <Tr key={event.id}>
-                <Td dataLabel={intl.formatMessage(messages.event)}>
-                  {event.event_type}
-                </Td>
-                <Td dataLabel={intl.formatMessage(messages.service)}>
-                  {event.application} - {event.bundle}
-                </Td>
-                <Td dataLabel={intl.formatMessage(messages.date)}>
-                  <DateFormat date={event.created} />
-                </Td>
-              </Tr>
-            ))}
-          </Tbody>
-        )}
-      </Table>
+      <DataViewTable
+        aria-label="Events widget table"
+        variant="compact"
+        columns={columns}
+        rows={rows}
+        headStates={{ loading: loadingStateHeader }}
+        bodyStates={{
+          loading: loadingStateBody,
+          empty: emptyState,
+        }}
+      />
       <DataViewToolbar
         ouiaId="EventsWidgetFooter"
         aria-label="Events widget footer"

--- a/src/components/Widgets/EventsWidget.tsx
+++ b/src/components/Widgets/EventsWidget.tsx
@@ -88,29 +88,6 @@ const EventsWidget: React.FunctionComponent = () => {
     fetchNotifications(page, perPage);
   }, [fetchNotifications, page, perPage]);
 
-  const handlePageChange = useCallback(
-    (
-      event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
-      newPage: number
-    ) => {
-      onSetPage(event, newPage);
-      fetchNotifications(newPage, perPage);
-    },
-    [onSetPage, fetchNotifications, perPage]
-  );
-
-  const handlePerPageChange = useCallback(
-    (
-      event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
-      newPerPage: number
-    ) => {
-      onPerPageSelect(event, newPerPage);
-      onSetPage(event, 1);
-      fetchNotifications(1, newPerPage);
-    },
-    [onPerPageSelect, onSetPage, fetchNotifications]
-  );
-
   const emptyState = useMemo(
     () => (
       <EmptyState
@@ -199,8 +176,8 @@ const EventsWidget: React.FunctionComponent = () => {
             itemCount={totalCount}
             page={page}
             perPage={perPage}
-            onSetPage={handlePageChange}
-            onPerPageSelect={handlePerPageChange}
+            onSetPage={onSetPage}
+            onPerPageSelect={onPerPageSelect}
           />
         }
       />


### PR DESCRIPTION
For [RHCLOUD-37773](https://issues.redhat.com/browse/RHCLOUD-37773). The events widget was limited to 5 events. Converting it to DataView fixes this and we get pagination for free.

Before:
<img width="796" height="657" alt="image" src="https://github.com/user-attachments/assets/27a12aec-1adf-486c-9bc7-0002927d6f46" />

After:
<img width="796" height="657" alt="image" src="https://github.com/user-attachments/assets/be1767e7-3e6b-44fe-8b2d-a5e08d64f093" />
