### PR TITLE
RHCLOUD-41867 fix notificationsProvider

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -83,18 +83,19 @@ const App: React.ComponentType = () => {
       }}
     >
       <RbacGroupContextProvider>
-        <NotificationsProvider />
-        <InsightsEnvDetector insights={insights} onEnvironment={staging}>
-          <RenderIfTrue>
-            <Switch
-              className="pf-v5-u-p-sm"
-              isChecked={usingExperimental}
-              onChange={toggleExperimental}
-              label="Disable experimental features"
-            />
-          </RenderIfTrue>
-        </InsightsEnvDetector>
-        <Routes />
+        <NotificationsProvider>
+          <InsightsEnvDetector insights={insights} onEnvironment={staging}>
+            <RenderIfTrue>
+              <Switch
+                className="pf-v5-u-p-sm"
+                isChecked={usingExperimental}
+                onChange={toggleExperimental}
+                label="Disable experimental features"
+              />
+            </RenderIfTrue>
+          </InsightsEnvDetector>
+          <Routes />
+        </NotificationsProvider>
       </RbacGroupContextProvider>
     </AppContext.Provider>
   );

--- a/src/app/IntegrationsApp.tsx
+++ b/src/app/IntegrationsApp.tsx
@@ -37,8 +37,9 @@ const IntegrationsApp: React.ComponentType<
       }}
     >
       <RbacGroupContextProvider>
-        <NotificationsProvider />
-        <IntegrationsList category={category} {...props} />
+        <NotificationsProvider>
+          <IntegrationsList category={category} {...props} />
+        </NotificationsProvider>
       </RbacGroupContextProvider>
     </AppContext.Provider>
   ) : (


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
notifications provider was broken during pf6 update. 

### Why this fixes the issue
The NotificationsProvider is rendered as a sibling (self-closing tag) rather than wrapping the child components. Looking at the package source, NotificationsProvider creates a React context and renders both a NotificationPortal and props.children. When used as a self-closing element, props.children is undefined, so only the portal is rendered but nothing is actually wrapped in the context.
The components using useNotifications() hook (like in AlertUtils.ts) won't have access to the context because they're not rendered inside the provider.
The fix should be to wrap the content with NotificationsProvider instead of using it as a sibling.

[RHCLOUD-41867](https://issues.redhat.com/browse/RHCLOUD-41867)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
