### PR TITLE
fix(drawer): bulk select count spacing

### DIFF
--- a/src/app/App.scss
+++ b/src/app/App.scss
@@ -50,6 +50,6 @@
   border-top: var(--pf-c-table--border-width--base) solid var(--pf-c-table--BorderColor);
 }
 
-.pf-v6-c-notification-drawer__header-action .ins-c-bulk-select {
+.pf-v6-c-notification-drawer__header-action > .pf-v6-c-menu-toggle {
   flex-shrink: 0;
 }

--- a/src/app/App.scss
+++ b/src/app/App.scss
@@ -49,3 +49,7 @@
 .noti-c-table-border-top {
   border-top: var(--pf-c-table--border-width--base) solid var(--pf-c-table--BorderColor);
 }
+
+.pf-v6-c-notification-drawer__header-action .ins-c-bulk-select {
+  flex-shrink: 0;
+}


### PR DESCRIPTION
## Summary

- Fixes the notification drawer bulk select component not having enough space to display the selected items count
- Adds `flex-shrink: 0` to the BulkSelect within the notification drawer header so the "X selected" text is not truncated

RHCLOUD-37880

## Test plan
- [x] Open the notification drawer
- [x] Select multiple notifications using bulk select
- [x] Verify the selected count (e.g. "3 selected") displays fully without being cut off

🤖 Generated with [Claude Code](https://claude.com/claude-code)