### PR TITLE
fix(eventlog): add timespan labels

### DIFF
--- a/src/components/Notifications/EventLog/EventLogDateFilter.tsx
+++ b/src/components/Notifications/EventLog/EventLogDateFilter.tsx
@@ -238,7 +238,9 @@ export const EventLogDateFilter: React.FunctionComponent<
   const options = React.useMemo(
     () =>
       Object.values(EventLogDateFilterValue).map((v) => (
-        <SelectOption key={v} value={new EventLogSelectObject(v)} />
+        <SelectOption key={v} value={new EventLogSelectObject(v)}>
+          {labels[v]}
+        </SelectOption>
       )),
     []
   );

--- a/src/components/Notifications/EventLog/__tests__/EventLogDateFilter.test.tsx
+++ b/src/components/Notifications/EventLog/__tests__/EventLogDateFilter.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import {
+  EventLogDateFilter,
+  EventLogDateFilterValue,
+} from '../EventLogDateFilter';
+
+describe('EventLogDateFilter', () => {
+  it('renders all timespan option labels in the dropdown', async () => {
+    render(
+      <EventLogDateFilter
+        value={EventLogDateFilterValue.LAST_14}
+        setValue={jest.fn()}
+        retentionDays={14}
+        period={[undefined, undefined]}
+        setPeriod={jest.fn()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(5);
+    expect(options[0]).toHaveTextContent('Today');
+    expect(options[1]).toHaveTextContent('Yesterday');
+    expect(options[2]).toHaveTextContent('Last 7 days');
+    expect(options[3]).toHaveTextContent('Last 14 days');
+    expect(options[4]).toHaveTextContent('Custom');
+  });
+});

--- a/src/components/Notifications/NotificationsLog/NotificationsLogDateFilter.tsx
+++ b/src/components/Notifications/NotificationsLog/NotificationsLogDateFilter.tsx
@@ -221,7 +221,9 @@ export const NotificationsLogDateFilter: React.FunctionComponent<
         >
           <SelectList>
             {Object.values(NotificationsLogDateFilterValue).map((v) => (
-              <SelectOption key={v} value={new EventLogSelectObject(v)} />
+              <SelectOption key={v} value={new EventLogSelectObject(v)}>
+                {labels[v]}
+              </SelectOption>
             ))}
           </SelectList>
         </Select>

--- a/src/components/Notifications/NotificationsLog/__tests__/NotificationsLogDateFilter.test.tsx
+++ b/src/components/Notifications/NotificationsLog/__tests__/NotificationsLogDateFilter.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import {
+  NotificationsLogDateFilter,
+  NotificationsLogDateFilterValue,
+} from '../NotificationsLogDateFilter';
+
+describe('NotificationsLogDateFilter', () => {
+  it('renders all timespan option labels in the dropdown', async () => {
+    render(
+      <NotificationsLogDateFilter
+        value={NotificationsLogDateFilterValue.LAST_14}
+        setValue={jest.fn()}
+        retentionDays={14}
+        period={[undefined, undefined]}
+        setPeriod={jest.fn()}
+      />
+    );
+
+    await userEvent.click(screen.getByRole('button'));
+
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(5);
+    expect(options[0]).toHaveTextContent('Today');
+    expect(options[1]).toHaveTextContent('Yesterday');
+    expect(options[2]).toHaveTextContent('Last 7 days');
+    expect(options[3]).toHaveTextContent('Last 14 days');
+    expect(options[4]).toHaveTextContent('Custom');
+  });
+});


### PR DESCRIPTION
## Summary

- Fix empty timespan dropdown labels in Event Log and Notifications Log date filters (RHCLOUD-44667)
- Add explicit label text as children to `SelectOption` components in both `EventLogDateFilter` and `NotificationsLogDateFilter` — PF v5 Select requires labels as children, not via `value.toString()`
- Add unit tests verifying all 5 dropdown option labels render correctly

## Test plan
- [x] Existing EventLog tests pass
- [x] New EventLogDateFilter test passes
- [x] New NotificationsLogDateFilter test passes
- [x] TypeScript compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)