### PR TITLE
fix(event-log): add missing timespan labels

### DIFF
--- a/src/components/Notifications/EventLog/EventLogDateFilter.tsx
+++ b/src/components/Notifications/EventLog/EventLogDateFilter.tsx
@@ -238,7 +238,9 @@ export const EventLogDateFilter: React.FunctionComponent<
   const options = React.useMemo(
     () =>
       Object.values(EventLogDateFilterValue).map((v) => (
-        <SelectOption key={v} value={new EventLogSelectObject(v)} />
+        <SelectOption key={v} value={new EventLogSelectObject(v)}>
+          {labels[v]}
+        </SelectOption>
       )),
     []
   );


### PR DESCRIPTION
## Summary
- **RHCLOUD-44667**: Timespan option labels empty in Settings / Notifications / Event Log
- `SelectOption` components in `EventLogDateFilter` were rendered without children, causing dropdown options (Today, Yesterday, Last 7 days, Last 14 days, Custom) to display as blank
- Added `labels[v]` as children to each `SelectOption` so the text is visible

## Test plan
- [x] Existing `EventLogFilter` tests pass
- [x] ESLint passes
- [ ] Verify in staging: navigate to Settings > Notifications > Event Log, click the timespan dropdown, and confirm labels are visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)