### PR TITLE
fix(event-log): add missing dropdown labels

### DIFF
--- a/src/components/Notifications/EventLog/EventLogDateFilter.tsx
+++ b/src/components/Notifications/EventLog/EventLogDateFilter.tsx
@@ -238,7 +238,9 @@ export const EventLogDateFilter: React.FunctionComponent<
   const options = React.useMemo(
     () =>
       Object.values(EventLogDateFilterValue).map((v) => (
-        <SelectOption key={v} value={new EventLogSelectObject(v)} />
+        <SelectOption key={v} value={new EventLogSelectObject(v)}>
+          {labels[v]}
+        </SelectOption>
       )),
     []
   );

--- a/src/components/Notifications/EventLog/__tests__/EventLogDateFilter.test.tsx
+++ b/src/components/Notifications/EventLog/__tests__/EventLogDateFilter.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { EventPeriod } from '../../../../types/Event';
+import {
+  EventLogDateFilter,
+  EventLogDateFilterValue,
+} from '../EventLogDateFilter';
+import {
+  NotificationsLogDateFilter,
+  NotificationsLogDateFilterValue,
+} from '../../NotificationsLog/NotificationsLogDateFilter';
+
+const expectedLabels = ['Today', 'Yesterday', 'Last 7 days', 'Last 14 days', 'Custom'];
+
+describe.each([
+  {
+    name: 'EventLogDateFilter',
+    Component: EventLogDateFilter,
+    FilterValue: EventLogDateFilterValue,
+  },
+  {
+    name: 'NotificationsLogDateFilter',
+    Component: NotificationsLogDateFilter,
+    FilterValue: NotificationsLogDateFilterValue,
+  },
+])('$name', ({ Component, FilterValue }) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const DateFilter = Component as React.ComponentType<any>;
+  const defaultProps = {
+    value: FilterValue.TODAY,
+    setValue: jest.fn(),
+    retentionDays: 14,
+    period: [undefined, undefined] as EventPeriod,
+    setPeriod: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the current value label in the toggle', () => {
+    render(<DateFilter {...defaultProps} />);
+    expect(screen.getByRole('button', { name: 'Today' })).toBeVisible();
+  });
+
+  it('displays all dropdown options with correct labels', async () => {
+    render(<DateFilter {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Today' }));
+
+    const options = screen.getAllByRole('option');
+    expect(options).toHaveLength(5);
+    expectedLabels.forEach((label, i) => {
+      expect(options[i]).toHaveTextContent(label);
+    });
+  });
+
+  it('calls setValue when an option is selected', async () => {
+    render(<DateFilter {...defaultProps} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Today' }));
+    await userEvent.click(screen.getByText('Last 7 days'));
+
+    expect(defaultProps.setValue).toHaveBeenCalledWith(FilterValue.LAST_7);
+  });
+
+  it('shows custom date pickers when Custom is selected', () => {
+    render(<DateFilter {...defaultProps} value={FilterValue.CUSTOM} />);
+
+    expect(screen.getByPlaceholderText('Start')).toBeVisible();
+    expect(screen.getByPlaceholderText('End')).toBeVisible();
+  });
+
+  it('does not show custom date pickers for non-custom values', () => {
+    render(<DateFilter {...defaultProps} />);
+
+    expect(screen.queryByPlaceholderText('Start')).toBeNull();
+    expect(screen.queryByPlaceholderText('End')).toBeNull();
+  });
+});

--- a/src/components/Notifications/NotificationsLog/NotificationsLogDateFilter.tsx
+++ b/src/components/Notifications/NotificationsLog/NotificationsLogDateFilter.tsx
@@ -221,7 +221,9 @@ export const NotificationsLogDateFilter: React.FunctionComponent<
         >
           <SelectList>
             {Object.values(NotificationsLogDateFilterValue).map((v) => (
-              <SelectOption key={v} value={new EventLogSelectObject(v)} />
+              <SelectOption key={v} value={new EventLogSelectObject(v)}>
+                {labels[v]}
+              </SelectOption>
             ))}
           </SelectList>
         </Select>


### PR DESCRIPTION
## Summary

- Fix empty timespan dropdown labels in Event Log and Notifications Log pages
- `SelectOption` components were self-closing with no children text, causing blank options in the dropdown
- Added label text as children to `SelectOption` in both `EventLogDateFilter.tsx` and `NotificationsLogDateFilter.tsx`

RHCLOUD-44667

## Verification

![after](https://raw.githubusercontent.com/RedHatInsights/notifications-frontend/bot/RHCLOUD-44667/screenshot-after.png)

## Test plan

- [x] Existing tests pass (`EventLogFilter.test.tsx`)
- [x] Lint passes
- [x] Visual verification: dropdown now shows "Today", "Yesterday", "Last 7 days", "Last 14 days", "Custom"