### PR TITLE
fix(behavior-group): cap recipient dropdown height

### DIFF
--- a/src/components/Notifications/Form/IntegrationRecipientTypeahead.tsx
+++ b/src/components/Notifications/Form/IntegrationRecipientTypeahead.tsx
@@ -284,6 +284,7 @@ export const IntegrationRecipientTypeahead: React.FunctionComponent<
       id="multi-typeahead-checkbox-select"
       isOpen={isOpen}
       selected={selection}
+      maxMenuHeight="300px"
       onSelect={(_ev, selection) => {
         if (isRecipientOption(selection)) {
           onSelect(selection as RecipientOption);

--- a/src/components/Notifications/Form/RecipientTypeahead.tsx
+++ b/src/components/Notifications/Form/RecipientTypeahead.tsx
@@ -211,6 +211,7 @@ export const RecipientTypeahead: React.FunctionComponent<
         selected={selection}
         onSelect={onSelect}
         onOpenChange={(isOpen) => setOpen(isOpen)}
+        maxMenuHeight="300px"
         toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
           <MenuToggle
             ref={toggleRef}

--- a/src/components/Notifications/Form/__tests__/IntegrationRecipientTypeahead.test.tsx
+++ b/src/components/Notifications/Form/__tests__/IntegrationRecipientTypeahead.test.tsx
@@ -265,4 +265,28 @@ describe('src/components/Notifications/Form/IntegrationRecipientTypeAhead', () =
       expect(screen.getAllByRole('menuitem')[0]).toBeDisabled()
     );
   });
+
+  it('Constrains dropdown menu height to 300px', async () => {
+    render(
+      <IntegrationRecipientTypeahead
+        selected={undefined}
+        integrationType={IntegrationType.WEBHOOK}
+        onSelected={fn()}
+      />,
+      {
+        wrapper: getConfiguredWrapper(),
+      }
+    );
+
+    await userEvent.click(
+      await screen.findByRole('button', { name: /Menu toggle/i })
+    );
+
+    await waitFor(() => {
+      // eslint-disable-next-line testing-library/no-node-access
+      const menuContentElement = document.querySelector('.pf-v6-c-menu__content');
+      expect(menuContentElement).toBeInTheDocument();
+      expect(menuContentElement).toHaveStyle({ '--pf-v6-c-menu__content--MaxHeight': '300px' });
+    });
+  });
 });

--- a/src/components/Notifications/Form/__tests__/RecipientTypeAhead.test.tsx
+++ b/src/components/Notifications/Form/__tests__/RecipientTypeAhead.test.tsx
@@ -244,4 +244,30 @@ describe('src/components/Notifications/Form/RecipientTypeAhead', () => {
       /This User Access group was not found, and may have been deleted/i
     );
   });
+
+  it('Constrains dropdown menu height to 300px', async () => {
+    render(
+      <RecipientTypeahead
+        selected={SELECTED_ALL}
+        onSelected={fn()}
+        onClear={fn()}
+      />,
+      {
+        wrapper: getConfiguredWrapper(createDefaultGetMock()),
+      }
+    );
+
+    await userEvent.click(
+      screen.getByRole('button', {
+        name: /Label group category/,
+      })
+    );
+
+    await waitFor(() => {
+      // eslint-disable-next-line testing-library/no-node-access
+      const menuContentElement = document.querySelector('.pf-v6-c-menu__content');
+      expect(menuContentElement).toBeInTheDocument();
+      expect(menuContentElement).toHaveStyle({ '--pf-v6-c-menu__content--MaxHeight': '300px' });
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes recipient dropdown overflowing the screen when creating a behavior group with many recipients
- Adds `maxMenuHeight="300px"` to both `RecipientTypeahead` and `IntegrationRecipientTypeahead` Select components, making the dropdown scrollable instead of unbounded

## Details

**RHCLOUD-43430**

When creating a new behavior group, if the user's organization has many possible recipients, the recipient dropdown list would overflow the screen with no way to select items at the bottom.

The fix uses PatternFly's built-in `maxMenuHeight` prop on the `Select` component, which caps the dropdown menu height and enables scrolling automatically.

## Test plan

- [x] Existing unit tests pass (27/27)
- [x] Lint passes
- [ ] Verify visually that the recipient dropdown is scrollable when there are many recipients
- [ ] Verify that selecting recipients still works correctly with the scrollable list

🤖 Generated with [Claude Code](https://claude.com/claude-code)