### PR TITLE
feat(drawer): Show unread notification count next to notification bell

### DIFF
--- a/.storybook/context-providers.tsx
+++ b/.storybook/context-providers.tsx
@@ -26,19 +26,21 @@ export interface AppContextConfig {
 
 // Chrome Context
 const ChromeContext = createContext<ChromeConfig>({
-  environment: 'prod'
+  environment: 'prod',
 });
 
-export const ChromeProvider: React.FC<{ value: ChromeConfig; children: ReactNode }> = ({ value, children }) => (
-  <ChromeContext.Provider value={value}>{children}</ChromeContext.Provider>
-);
+export const ChromeProvider: React.FC<{ value: ChromeConfig; children: ReactNode }> = ({
+  value,
+  children,
+}) => <ChromeContext.Provider value={value}>{children}</ChromeContext.Provider>;
 
 // Feature Flags Context
 const FeatureFlagsContext = createContext<FeatureFlagsConfig>({});
 
-export const FeatureFlagsProvider: React.FC<{ value: FeatureFlagsConfig; children: ReactNode }> = ({ value, children }) => (
-  <FeatureFlagsContext.Provider value={value}>{children}</FeatureFlagsContext.Provider>
-);
+export const FeatureFlagsProvider: React.FC<{ value: FeatureFlagsConfig; children: ReactNode }> = ({
+  value,
+  children,
+}) => <FeatureFlagsContext.Provider value={value}>{children}</FeatureFlagsContext.Provider>;
 
 // Chrome spy for testing - IS the spy function
 export const chromeAppNavClickSpy = fn();
@@ -46,56 +48,64 @@ export const chromeAppNavClickSpy = fn();
 // Mock Hook Implementations (only for Storybook)
 export const useChrome = () => {
   const chromeConfig = useContext(ChromeContext);
-  
-  return useMemo(() => ({
-    getEnvironment: () => chromeConfig.environment,
-    getEnvironmentDetails: () => ({
-      environment: chromeConfig.environment,
-      sso: 'https://sso.redhat.com',
-      portal: 'https://console.redhat.com'
+
+  return useMemo(
+    () => ({
+      getEnvironment: () => chromeConfig.environment,
+      getEnvironmentDetails: () => ({
+        environment: chromeConfig.environment,
+        sso: 'https://sso.redhat.com',
+        portal: 'https://console.redhat.com',
+      }),
+      isProd: () => chromeConfig.environment === 'prod',
+      isBeta: () => chromeConfig.environment !== 'prod',
+      appNavClick: chromeAppNavClickSpy,
+      appObjectId: () => undefined,
+      appAction: () => undefined,
+      drawerActions: {
+        toggleDrawerContent: fn().mockName('toggleDrawerContent'),
+      },
+      updateDocumentTitle: (title: string) => {
+        // Mock document title update for Storybook
+        if (typeof document !== 'undefined') {
+          document.title = title;
+        }
+      },
+      auth: chromeConfig.auth || {
+        getUser: () =>
+          Promise.resolve({
+            identity: {
+              user: {
+                username: 'test-user',
+                email: 'test@redhat.com',
+                is_org_admin: true,
+                is_internal: false,
+              },
+            },
+          }),
+        getToken: () => Promise.resolve('mock-jwt-token-12345'),
+      },
+      getBundle: () => 'settings',
+      getApp: () => 'notifications',
+      getUserPermissions: () =>
+        Promise.resolve([
+          {
+            permission: 'notifications:*:*',
+            resourceDefinitions: [],
+          },
+          {
+            permission: 'integrations:endpoints:read',
+            resourceDefinitions: [],
+          },
+          {
+            permission: 'integrations:endpoints:write',
+            resourceDefinitions: [],
+          },
+        ]),
+      ...chromeConfig,
     }),
-    isProd: () => chromeConfig.environment === 'prod',
-    isBeta: () => chromeConfig.environment !== 'prod',
-    appNavClick: chromeAppNavClickSpy,
-    appObjectId: () => undefined,
-    appAction: () => undefined,
-    updateDocumentTitle: (title: string) => {
-      // Mock document title update for Storybook
-      if (typeof document !== 'undefined') {
-        document.title = title;
-      }
-    },
-    auth: chromeConfig.auth || { 
-      getUser: () => Promise.resolve({ 
-        identity: { 
-          user: { 
-            username: 'test-user', 
-            email: 'test@redhat.com',
-            is_org_admin: true,
-            is_internal: false
-          } 
-        } 
-      }), 
-      getToken: () => Promise.resolve('mock-jwt-token-12345') 
-    },
-    getBundle: () => 'settings',
-    getApp: () => 'notifications',
-    getUserPermissions: () => Promise.resolve([
-      { 
-        permission: 'notifications:*:*',
-        resourceDefinitions: []
-      },
-      { 
-        permission: 'integrations:endpoints:read',
-        resourceDefinitions: []
-      }, 
-      { 
-        permission: 'integrations:endpoints:write',
-        resourceDefinitions: []
-      },
-    ]),
-    ...chromeConfig
-  }), [chromeConfig]);
+    [chromeConfig]
+  );
 };
 
 export const useFlag = (flagName: string): boolean => {

--- a/src/components/NotificationsDrawer/DrawerBell.stories.tsx
+++ b/src/components/NotificationsDrawer/DrawerBell.stories.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { Toolbar, ToolbarContent } from '@patternfly/react-core/dist/dynamic/components/Toolbar';
+import DrawerBell from './DrawerBell';
+import { DrawerSingleton } from './DrawerSingleton';
+import { NotificationData } from '../../types/Drawer';
+
+const seedState = (notificationData: NotificationData[], ready = true) => {
+  Object.assign(DrawerSingleton.getState(), {
+    notificationData,
+    hasUnread: notificationData.some((n) => !n.read),
+    ready,
+    initializing: !ready,
+  });
+};
+
+const unreadNotifications: NotificationData[] = [
+  {
+    id: '1',
+    title: 'New package updates available',
+    description:
+      'Security advisories RHSA-2024:1234 and RHSA-2024:1235 are available for your systems.',
+    read: false,
+    source: 'advisor',
+    bundle: 'rhel',
+    created: new Date(Date.now() - 1000 * 60 * 15).toISOString(),
+  },
+  {
+    id: '2',
+    title: 'OpenShift cluster upgrade available',
+    description: 'Cluster "prod-us-east-1" can be upgraded to OpenShift 4.15.3.',
+    read: false,
+    source: 'openshift',
+    bundle: 'openshift',
+    created: new Date(Date.now() - 1000 * 60 * 60 * 2).toISOString(),
+  },
+  {
+    id: '3',
+    title: 'Policy violation detected',
+    description: '3 systems are non-compliant with PCI-DSS policy "No SSH root login".',
+    read: false,
+    source: 'compliance',
+    bundle: 'rhel',
+    created: new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString(),
+  },
+  {
+    id: '4',
+    title: 'Integration webhook delivery failed',
+    description: 'Webhook to "https://hooks.example.com/notify" failed after 3 retries.',
+    read: true,
+    source: 'integrations',
+    bundle: 'console',
+    created: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+  },
+];
+
+const readNotifications: NotificationData[] = unreadNotifications.map((n) => ({
+  ...n,
+  read: true,
+}));
+
+const meta: Meta<typeof DrawerBell> = {
+  title: 'Components/DrawerBell',
+  component: DrawerBell,
+  decorators: [
+    (Story) => (
+      <Toolbar>
+        <ToolbarContent>
+          <Story />
+        </ToolbarContent>
+      </Toolbar>
+    ),
+  ],
+  args: {
+    isNotificationDrawerExpanded: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DrawerBell>;
+
+export const WithUnread: Story = {
+  loaders: [async () => seedState(unreadNotifications)],
+  parameters: {
+    docs: {
+      description: {
+        story: 'Bell with 3 unread notifications — badge shows the unread count.',
+      },
+    },
+  },
+};
+
+export const AllRead: Story = {
+  loaders: [async () => seedState(readNotifications)],
+  parameters: {
+    docs: {
+      description: {
+        story: 'Bell with all notifications read — no count badge.',
+      },
+    },
+  },
+};
+
+export const DrawerExpanded: Story = {
+  args: { isNotificationDrawerExpanded: true },
+  loaders: [async () => seedState(unreadNotifications)],
+  parameters: {
+    docs: {
+      description: {
+        story: 'Bell in expanded/active state while the drawer is open.',
+      },
+    },
+  },
+};
+
+export const Loading: Story = {
+  loaders: [async () => seedState([], false)],
+  parameters: {
+    docs: {
+      description: {
+        story: 'Bell disabled while notifications are still loading.',
+      },
+    },
+  },
+};

--- a/src/components/NotificationsDrawer/DrawerBell.tsx
+++ b/src/components/NotificationsDrawer/DrawerBell.tsx
@@ -15,8 +15,9 @@ const DrawerBell: React.ComponentType<DrawerBellProps> = ({ isNotificationDrawer
     drawerActions: { toggleDrawerContent },
   } = useChrome();
   const {
-    state: { hasUnread, ready },
+    state: { hasUnread, ready, notificationData },
   } = useNotificationDrawer();
+  const unreadCount = notificationData.filter((n) => !n.read).length;
   return (
     <ToolbarItem className="pf-v6-u-mx-0">
       <Tooltip
@@ -29,6 +30,7 @@ const DrawerBell: React.ComponentType<DrawerBellProps> = ({ isNotificationDrawer
         <NotificationBadge
           className="chr-c-notification-badge"
           variant={hasUnread ? 'unread' : 'read'}
+          count={unreadCount}
           onClick={() => {
             toggleDrawerContent({
               scope: 'notifications',

--- a/src/components/NotificationsDrawer/DrawerBell.tsx
+++ b/src/components/NotificationsDrawer/DrawerBell.tsx
@@ -17,7 +17,7 @@ const DrawerBell: React.ComponentType<DrawerBellProps> = ({ isNotificationDrawer
   const {
     state: { hasUnread, ready, notificationData },
   } = useNotificationDrawer();
-  const unreadCount = notificationData.filter((n) => !n.read).length;
+  const unreadCount = (notificationData ?? []).filter((n) => !n.read).length;
   return (
     <ToolbarItem className="pf-v6-u-mx-0">
       <Tooltip

--- a/src/components/NotificationsDrawer/__tests__/DrawerBell.test.tsx
+++ b/src/components/NotificationsDrawer/__tests__/DrawerBell.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen } from '@testing-library/react';
+import { fn } from 'jest-mock';
+import * as React from 'react';
+
+import DrawerBell from '../DrawerBell';
+import { NotificationData } from '../../../types/Drawer';
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => {
+  return () => ({
+    drawerActions: {
+      toggleDrawerContent: fn(),
+    },
+  });
+});
+
+jest.mock('../../../hooks/useNotificationDrawer');
+import useNotificationDrawer from '../../../hooks/useNotificationDrawer';
+
+const makeNotification = (id: string, read: boolean): NotificationData => ({
+  id,
+  title: `Notification ${id}`,
+  description: 'Test description',
+  read,
+  source: 'test',
+  bundle: 'rhel',
+  created: new Date().toISOString(),
+});
+
+const renderBell = (notificationData: NotificationData[], ready = true) => {
+  (useNotificationDrawer as jest.Mock).mockReturnValue({
+    state: {
+      notificationData,
+      hasUnread: notificationData.some((n) => !n.read),
+      ready,
+      count: 0,
+      filters: [],
+      filterConfig: [],
+      hasNotificationsPermissions: false,
+      initializing: false,
+    },
+  });
+
+  return render(<DrawerBell isNotificationDrawerExpanded={false} />);
+};
+
+describe('src/components/NotificationsDrawer/DrawerBell', () => {
+  it('shows the unread count when there are unread notifications', () => {
+    renderBell([
+      makeNotification('1', false),
+      makeNotification('2', false),
+      makeNotification('3', false),
+      makeNotification('4', true),
+    ]);
+
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('does not show a count when all notifications are read', () => {
+    renderBell([makeNotification('1', true), makeNotification('2', true)]);
+
+    expect(screen.queryByText('1')).not.toBeInTheDocument();
+    expect(screen.queryByText('2')).not.toBeInTheDocument();
+  });
+
+  it('renders the bell button when there are no notifications', () => {
+    renderBell([]);
+
+    expect(screen.getByRole('button', { name: /notifications/i })).toBeInTheDocument();
+  });
+
+  it('disables the button when not ready', () => {
+    renderBell([], false);
+
+    expect(screen.getByRole('button', { name: /notifications/i })).toBeDisabled();
+  });
+
+  it('enables the button when ready', () => {
+    renderBell([makeNotification('1', false)]);
+
+    expect(screen.getByRole('button', { name: /notifications/i })).toBeEnabled();
+  });
+});

--- a/src/components/NotificationsDrawer/__tests__/DrawerBell.test.tsx
+++ b/src/components/NotificationsDrawer/__tests__/DrawerBell.test.tsx
@@ -58,8 +58,7 @@ describe('src/components/NotificationsDrawer/DrawerBell', () => {
   it('does not show a count when all notifications are read', () => {
     renderBell([makeNotification('1', true), makeNotification('2', true)]);
 
-    expect(screen.queryByText('1')).not.toBeInTheDocument();
-    expect(screen.queryByText('2')).not.toBeInTheDocument();
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
   });
 
   it('renders the bell button when there are no notifications', () => {


### PR DESCRIPTION
### Description
Added an unread notification count to the bell icon using the number of unread notifications from the existing notificationData state and passing it as the count prop to NotificationBadge. Also added a Storybook story for DrawerBell covering some states(unread, lodaing, etc). See affected notification bell in the main navigation.
https://console.stage.redhat.com/settings/notifications

[RHCLOUD46542](https://issues.redhat.com/browse/RHCLOUD-46542)

---

### Screenshots
#### Before:

<img width="142" height="86" alt="Screenshot 2026-04-09 at 3 33 00 PM" src="https://github.com/user-attachments/assets/aab4c188-519b-4ce5-a11b-5fc88dc0a01f" />

#### After:

<img width="106" height="93" alt="Screenshot 2026-04-09 at 3 34 09 PM" src="https://github.com/user-attachments/assets/4ee74b36-6931-46ee-8011-cac28f7fde1a" />

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
