### PR TITLE
fix(drawer): Prevent bulk select clipping

### DIFF
--- a/src/components/NotificationsDrawer/Dropdowns.tsx
+++ b/src/components/NotificationsDrawer/Dropdowns.tsx
@@ -109,7 +109,6 @@ export const ActionDropdown = ({
           variant="plain"
           id="notifications-actions-toggle"
           aria-label="Notifications actions dropdown"
-          isFullWidth
         >
           <EllipsisVIcon />
         </MenuToggle>


### PR DESCRIPTION
## Summary
- Fixed the bulk select dropdown text clipping and leftward shift when "Select All" is used in the notification drawer
- Removed the unnecessary `isFullWidth` from the menu toggle that was causing the clipping

[RHCLOUD-46538](https://redhat.atlassian.net/browse/RHCLOUD-46538)

## Before
<img width="459" height="173" alt="image" src="https://github.com/user-attachments/assets/5ce60e04-23ee-4474-a5aa-ca5a806e1655" />

## After
<img width="459" height="173" alt="image" src="https://github.com/user-attachments/assets/85c6f8d3-02a1-4612-8f23-fb7e5bdf9cc7" />

## Test plan
- [x] All 213 unit tests pass
- [x] Lint (ESLint + Stylelint) clean
- [x] Open the notification drawer, populate notifications, click "Select All" — the count text ("X selected") should display without clipping and the dropdown should not shift left

[RHCLOUD-46538]: https://redhat.atlassian.net/browse/RHCLOUD-46538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ