### PR TITLE
fix: Severity label colors

### DIFF
--- a/src/components/Notifications/EventLog/EventLogTable.tsx
+++ b/src/components/Notifications/EventLog/EventLogTable.tsx
@@ -68,59 +68,99 @@ const labelClassName = style({
   cursor: 'pointer',
 });
 
+/**
+ * Filled label backgrounds use PatternFly global **severity** surface tokens
+ * (`--pf-t--global--color--severity--*-100`), aligned with the severity palette in
+ * https://www.patternfly.org/patterns/status-and-severity/#severity-icons
+ *
+ * Variables are set via inline `style` on `Label` so they are not overridden by
+ * PatternFly stylesheet order (a prior class-only approach left all chips grey).
+ *
+ * Foreground uses white/black for contrast. Icons are severity-shaped, not status icons.
+ */
+const severityLabelFgOnDark = 'var(--pf-t--color--white)';
+const severityLabelFgOnLight = 'var(--pf-t--color--black)';
+
+/** Inline Label `style` so PF label CSS does not override single-class typestyle rules (load order). */
+const severityLabelVars = (vars: Record<string, string>): React.CSSProperties =>
+  vars as React.CSSProperties;
+
+export const eventLogSeverityLabelStyles: Record<EventSeverity, React.CSSProperties> = {
+  CRITICAL: severityLabelVars({
+    '--pf-v6-c-label--BackgroundColor': 'var(--pf-t--global--color--severity--critical--100)',
+    '--pf-v6-c-label--Color': severityLabelFgOnDark,
+    '--pf-v6-c-label__icon--Color': severityLabelFgOnDark,
+  }),
+  IMPORTANT: severityLabelVars({
+    '--pf-v6-c-label--BackgroundColor': 'var(--pf-t--global--color--severity--important--100)',
+    '--pf-v6-c-label--Color': severityLabelFgOnDark,
+    '--pf-v6-c-label__icon--Color': severityLabelFgOnDark,
+  }),
+  MODERATE: severityLabelVars({
+    '--pf-v6-c-label--BackgroundColor': 'var(--pf-t--global--color--severity--moderate--100)',
+    '--pf-v6-c-label--Color': severityLabelFgOnLight,
+    '--pf-v6-c-label__icon--Color': severityLabelFgOnLight,
+  }),
+  LOW: severityLabelVars({
+    '--pf-v6-c-label--BackgroundColor': 'var(--pf-t--global--color--severity--minor--100)',
+    '--pf-v6-c-label--Color': severityLabelFgOnLight,
+    '--pf-v6-c-label__icon--Color': severityLabelFgOnLight,
+  }),
+  NONE: severityLabelVars({
+    '--pf-v6-c-label--BackgroundColor': 'var(--pf-t--global--color--severity--none--100)',
+    '--pf-v6-c-label--Color': severityLabelFgOnDark,
+    '--pf-v6-c-label__icon--Color': severityLabelFgOnDark,
+  }),
+  UNDEFINED: severityLabelVars({
+    '--pf-v6-c-label--BorderColor': 'var(--pf-t--global--color--severity--undefined--200)',
+    '--pf-v6-c-label--Color': severityLabelFgOnLight,
+    '--pf-v6-c-label__icon--Color': severityLabelFgOnLight,
+  }),
+};
+
 export const toSeverityLabelProps = (
   severity?: EventSeverity
-): Pick<LabelProps, 'color' | 'icon'> => {
+): Pick<LabelProps, 'color' | 'icon' | 'style' | 'status' | 'variant'> => {
   switch (severity) {
     case 'CRITICAL':
       return {
-        icon: (
-          <SeverityCriticalIcon
-            style={{ color: 'var(--pf-t--global--icon--color--severity--critical--default)' }}
-          />
-        ),
+        style: eventLogSeverityLabelStyles.CRITICAL,
+        icon: <SeverityCriticalIcon />,
       };
     case 'IMPORTANT':
       return {
-        icon: (
-          <SeverityImportantIcon
-            style={{ color: 'var(--pf-t--global--icon--color--severity--important--default)' }}
-          />
-        ),
+        style: eventLogSeverityLabelStyles.IMPORTANT,
+        icon: <SeverityImportantIcon />,
       };
     case 'MODERATE':
       return {
-        icon: (
-          <SeverityModerateIcon
-            style={{ color: 'var(--pf-t--global--icon--color--severity--moderate--default)' }}
-          />
-        ),
+        style: eventLogSeverityLabelStyles.MODERATE,
+        icon: <SeverityModerateIcon />,
       };
     case 'LOW':
       return {
-        icon: (
-          <SeverityMinorIcon
-            style={{ color: 'var(--pf-t--global--icon--color--severity--minor--default)' }}
-          />
-        ),
+        style: eventLogSeverityLabelStyles.LOW,
+        icon: <SeverityMinorIcon />,
       };
     case 'NONE':
       return {
-        icon: (
-          <SeverityNoneIcon
-            style={{ color: 'var(--pf-t--global--icon--color--severity--none--default)' }}
-          />
-        ),
+        style: eventLogSeverityLabelStyles.NONE,
+        icon: <SeverityNoneIcon />,
       };
     case 'UNDEFINED':
+      return {
+        style: eventLogSeverityLabelStyles.UNDEFINED,
+        color: 'grey',
+        variant: 'outline',
+        icon: <SeverityUndefinedIcon />,
+      };
     case undefined:
     default:
       return {
-        icon: (
-          <SeverityUndefinedIcon
-            style={{ color: 'var(--pf-t--global--icon--color--severity--undefined--default)' }}
-          />
-        ),
+        style: eventLogSeverityLabelStyles.UNDEFINED,
+        color: 'grey',
+        variant: 'outline',
+        icon: <SeverityUndefinedIcon />,
       };
   }
 };

--- a/src/components/Notifications/EventLog/__tests__/EventLogTable.test.tsx
+++ b/src/components/Notifications/EventLog/__tests__/EventLogTable.test.tsx
@@ -1,7 +1,11 @@
-import { severityDescription, toSeverityLabelProps } from '../EventLogTable';
+import {
+  eventLogSeverityLabelStyles,
+  severityDescription,
+  toSeverityLabelProps,
+} from '../EventLogTable';
 
 describe('EventLogTable severity', () => {
-  describe.each(['CRITICAL', 'IMPORTANT', 'MODERATE', 'LOW', 'NONE', 'UNDEFINED'] as const)(
+  describe.each(['CRITICAL', 'IMPORTANT', 'MODERATE', 'LOW', 'NONE'] as const)(
     'toSeverityLabelProps(%s)',
     (severity) => {
       it('returns an icon element', () => {
@@ -9,17 +13,34 @@ describe('EventLogTable severity', () => {
         expect(result.icon).toBeTruthy();
       });
 
-      it('does not set a color prop (uses PF tokens)', () => {
+      it('uses inline Label style with PatternFly severity surface tokens', () => {
         const result = toSeverityLabelProps(severity);
+        expect(result.style).toEqual(eventLogSeverityLabelStyles[severity]);
+        expect(result.status).toBeUndefined();
         expect(result.color).toBeUndefined();
+        expect(result.variant).toBeUndefined();
       });
     }
   );
 
-  it('returns icon for undefined severity', () => {
+  describe('toSeverityLabelProps(UNDEFINED)', () => {
+    it('returns outline grey label with severity undefined border style', () => {
+      const result = toSeverityLabelProps('UNDEFINED');
+      expect(result.icon).toBeTruthy();
+      expect(result.style).toEqual(eventLogSeverityLabelStyles.UNDEFINED);
+      expect(result.status).toBeUndefined();
+      expect(result.color).toBe('grey');
+      expect(result.variant).toBe('outline');
+    });
+  });
+
+  it('matches UNDEFINED styling when severity is missing', () => {
     const result = toSeverityLabelProps(undefined);
     expect(result.icon).toBeTruthy();
-    expect(result.color).toBeUndefined();
+    expect(result.style).toEqual(eventLogSeverityLabelStyles.UNDEFINED);
+    expect(result.status).toBeUndefined();
+    expect(result.color).toBe('grey');
+    expect(result.variant).toBe('outline');
   });
 
   describe('severityDescription', () => {


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
fix severity label colors.

[RHCLOUDXXXX](https://issues.redhat.com/browse/RHCLOUDXXXX)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
labels were grey with colors icons, we want colored labels with neutral icons.
#### After:

<img width="194" height="469" alt="Screenshot 2026-04-14 at 9 56 42 AM" src="https://github.com/user-attachments/assets/77b716e7-c1cd-45d8-8514-82f7916a0686" />

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
