### PR TITLE
feat(wizard): Add severity to event types

### DIFF
--- a/src/components/Integrations/EventTypes.stories.tsx
+++ b/src/components/Integrations/EventTypes.stories.tsx
@@ -1,0 +1,194 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { HttpResponse, http } from 'msw';
+import EventTypes from './EventTypes';
+import { EventType, Facet } from '../../types/Notification';
+
+const mockBundle: Facet = {
+  id: 'bundle-1',
+  displayName: 'Red Hat Enterprise Linux',
+  name: 'rhel',
+};
+
+const mockApplications: Facet[] = [
+  { id: 'app-1', displayName: 'Advisor', name: 'advisor' },
+  { id: 'app-2', displayName: 'Compliance', name: 'compliance' },
+  { id: 'app-3', displayName: 'Drift', name: 'drift' },
+];
+
+const mockEventTypes = [
+  {
+    id: 'evt-1',
+    application_id: 'app-1',
+    application: { id: 'app-1', display_name: 'Advisor', name: 'advisor', bundle_id: 'bundle-1' },
+    display_name: 'New recommendation',
+    name: 'new-recommendation',
+    description: 'Triggered when a new recommendation is available for your systems.',
+    default_severity: 'CRITICAL' as const,
+  },
+  {
+    id: 'evt-2',
+    application_id: 'app-1',
+    application: { id: 'app-1', display_name: 'Advisor', name: 'advisor', bundle_id: 'bundle-1' },
+    display_name: 'Resolved recommendation',
+    name: 'resolved-recommendation',
+    description: 'Triggered when a recommendation is resolved.',
+    default_severity: 'LOW' as const,
+  },
+  {
+    id: 'evt-3',
+    application_id: 'app-2',
+    application: {
+      id: 'app-2',
+      display_name: 'Compliance',
+      name: 'compliance',
+      bundle_id: 'bundle-1',
+    },
+    display_name: 'Policy updated',
+    name: 'policy-updated',
+    description: 'Triggered when a compliance policy is updated.',
+    default_severity: 'MODERATE' as const,
+  },
+  {
+    id: 'evt-4',
+    application_id: 'app-2',
+    application: {
+      id: 'app-2',
+      display_name: 'Compliance',
+      name: 'compliance',
+      bundle_id: 'bundle-1',
+    },
+    display_name: 'System non-compliant',
+    name: 'system-non-compliant',
+    default_severity: 'IMPORTANT' as const,
+  },
+  {
+    id: 'evt-5',
+    application_id: 'app-3',
+    application: { id: 'app-3', display_name: 'Drift', name: 'drift', bundle_id: 'bundle-1' },
+    display_name: 'Baseline updated',
+    name: 'baseline-updated',
+    description: 'Triggered when a drift baseline is updated.',
+    default_severity: 'NONE' as const,
+  },
+  {
+    id: 'evt-6',
+    application_id: 'app-3',
+    application: { id: 'app-3', display_name: 'Drift', name: 'drift', bundle_id: 'bundle-1' },
+    display_name: 'Comparison completed',
+    name: 'comparison-completed',
+    // No severity — tests the fallback
+  },
+];
+
+const eventTypesHandler = http.get(
+  '/api/notifications/v2.0/notifications/eventTypes',
+  ({ request }) => {
+    const url = new URL(request.url);
+    const limit = Number(url.searchParams.get('limit') ?? 20);
+    const offset = Number(url.searchParams.get('offset') ?? 0);
+    const eventTypeName = url.searchParams.get('eventTypeName');
+
+    let filtered = [...mockEventTypes];
+
+    if (eventTypeName) {
+      filtered = filtered.filter((et) =>
+        et.display_name.toLowerCase().includes(eventTypeName.toLowerCase())
+      );
+    }
+
+    return HttpResponse.json({
+      data: filtered.slice(offset, offset + limit),
+      meta: { count: filtered.length },
+      links: {},
+    });
+  }
+);
+
+const EventTypesWrapper: React.FC<{ preSelected?: EventType[] }> = ({ preSelected }) => {
+  const [selectedEvents, setSelectedEvents] = useState<EventType[] | undefined>(preSelected);
+
+  return (
+    <EventTypes
+      currBundle={mockBundle}
+      applications={mockApplications}
+      selectedEvents={selectedEvents}
+      setSelectedEvents={setSelectedEvents}
+    />
+  );
+};
+
+const meta: Meta<typeof EventTypes> = {
+  title: 'Notifications/BehaviorGroupWizard/EventTypes',
+  component: EventTypes,
+  parameters: {
+    layout: 'padded',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ height: '600px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof EventTypes>;
+
+/**
+ * Default view showing event types with severity column.
+ * Demonstrates severity labels with icons for CRITICAL, IMPORTANT,
+ * MODERATE, LOW, NONE, and the fallback for undefined severity.
+ */
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [eventTypesHandler],
+    },
+  },
+  render: () => <EventTypesWrapper />,
+};
+
+/**
+ * Event types with some pre-selected rows.
+ */
+export const WithSelection: Story = {
+  parameters: {
+    msw: {
+      handlers: [eventTypesHandler],
+    },
+  },
+  render: () => (
+    <EventTypesWrapper
+      preSelected={[
+        {
+          id: 'evt-1',
+          applicationDisplayName: 'Advisor',
+          eventTypeDisplayName: 'New recommendation',
+          defaultSeverity: 'CRITICAL',
+        },
+      ]}
+    />
+  ),
+};
+
+/**
+ * Empty state when no event types match filters.
+ */
+export const EmptyState: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/notifications/v2.0/notifications/eventTypes', () => {
+          return HttpResponse.json({
+            data: [],
+            meta: { count: 0 },
+            links: {},
+          });
+        }),
+      ],
+    },
+  },
+  render: () => <EventTypesWrapper />,
+};

--- a/src/components/Integrations/EventTypes.tsx
+++ b/src/components/Integrations/EventTypes.tsx
@@ -30,7 +30,6 @@ import { EventType, Facet } from '../../types/Notification';
 import { debouncePromise } from '../../pages/Integrations/Create/nameValidator';
 import { perPageOptions } from '../../config/Config';
 import {
-  SEVERITY_VALUES,
   severityDescription,
   severityDisplayName,
   toSeverityLabelProps,
@@ -39,7 +38,6 @@ import {
 interface EventTypeFilters {
   filterEventFilterName?: string;
   filterApplicationId?: string[];
-  filterSeverity?: string[];
 }
 
 interface EventTypesProps {
@@ -68,7 +66,7 @@ const EventTypes: React.FC<EventTypesProps> = ({
     });
   const isEventExpanded = (event: EventType) => expanded.includes(event.id);
   const { filters, onSetFilters, clearAllFilters } = useDataViewFilters<EventTypeFilters>({
-    initialFilters: { filterEventFilterName: '', filterApplicationId: [], filterSeverity: [] },
+    initialFilters: { filterEventFilterName: '', filterApplicationId: [] },
   });
 
   const { page, perPage, onSetPage, onPerPageSelect } = useDataViewPagination({
@@ -98,18 +96,6 @@ const EventTypes: React.FC<EventTypesProps> = ({
     onSelect(true, [...(selectedEvents || [])]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currBundle.id]);
-
-  // Filter data client-side by severity since the API does not support it
-  const filteredData = useMemo(() => {
-    if (!response.data || !filters.filterSeverity || filters.filterSeverity.length === 0) {
-      return response.data;
-    }
-
-    return response.data.filter((event) => {
-      const sev = event.defaultSeverity ?? 'UNDEFINED';
-      return filters.filterSeverity!.includes(sev);
-    });
-  }, [response.data, filters.filterSeverity]);
 
   const fetchNotifications = useCallback(
     async (pager, filters) => {
@@ -145,10 +131,10 @@ const EventTypes: React.FC<EventTypesProps> = ({
   }, [fetchNotifications, page, perPage]);
 
   const handleBulkSelect = (value: BulkSelectValue) => {
-    const dataForBulk = filteredData ?? [];
+    const pageData = response.data ?? [];
     value === BulkSelectValue.none && setSelected(false, selected, selected);
-    value === BulkSelectValue.nonePage && setSelected(false, dataForBulk, selected);
-    value === BulkSelectValue.page && setSelected(true, dataForBulk, selected);
+    value === BulkSelectValue.nonePage && setSelected(false, pageData, selected);
+    value === BulkSelectValue.page && setSelected(true, pageData, selected);
     if (value === BulkSelectValue.all) {
       (async () => {
         const { data } = await getEventTypes(
@@ -160,20 +146,12 @@ const EventTypes: React.FC<EventTypesProps> = ({
           })
         );
         const allData = toNotifications(data) ?? [];
-        // Apply severity filter to all data if active
-        const filtered =
-          filters.filterSeverity && filters.filterSeverity.length > 0
-            ? allData.filter((event) => {
-                const sev = event.defaultSeverity ?? 'UNDEFINED';
-                return filters.filterSeverity!.includes(sev);
-              })
-            : allData;
-        setSelected(true, filtered, selected);
+        setSelected(true, allData, selected);
       })();
     }
   };
 
-  const displayData = filteredData ?? [];
+  const displayData = response.data ?? [];
 
   const renderSeverityCell = (event: EventType) => {
     const severity = event.defaultSeverity;
@@ -229,11 +207,7 @@ const EventTypes: React.FC<EventTypesProps> = ({
                 aria-label="Event types bulk select"
                 canSelectAll
                 pageCount={displayData.length}
-                totalCount={
-                  filters.filterSeverity && filters.filterSeverity.length > 0
-                    ? displayData.length
-                    : response.meta?.count
-                }
+                totalCount={response.meta?.count}
                 selectedCount={selected.length}
                 pageSelected={
                   displayData.length !== 0 && displayData.every((item) => isSelected(item))
@@ -269,7 +243,6 @@ const EventTypes: React.FC<EventTypesProps> = ({
                       values
                     );
                   }
-                  // Severity filter is client-side, no need to refetch
                   onSetFilters(values);
                 }}
                 values={filters}
@@ -292,16 +265,6 @@ const EventTypes: React.FC<EventTypesProps> = ({
                     })) || []
                   }
                 />
-                <DataViewCheckboxFilter
-                  aria-label="Filter by severity"
-                  filterId="filterSeverity"
-                  title="Severity"
-                  placeholder="Filter by severity"
-                  options={SEVERITY_VALUES.map((sev) => ({
-                    label: severityDisplayName[sev],
-                    value: sev,
-                  }))}
-                />
               </DataViewFilters>
             }
             pagination={
@@ -309,11 +272,7 @@ const EventTypes: React.FC<EventTypesProps> = ({
                 aria-label="Event types top pagination"
                 isCompact
                 perPageOptions={perPageOptions}
-                itemCount={
-                  filters.filterSeverity && filters.filterSeverity.length > 0
-                    ? displayData.length
-                    : response.meta?.count
-                }
+                itemCount={response.meta?.count}
                 page={page}
                 perPage={perPage}
                 onSetPage={(e, newPage) => {
@@ -410,11 +369,7 @@ const EventTypes: React.FC<EventTypesProps> = ({
               <Pagination
                 aria-label="Event types footer pagination"
                 perPageOptions={perPageOptions}
-                itemCount={
-                  filters.filterSeverity && filters.filterSeverity.length > 0
-                    ? displayData.length
-                    : response.meta?.count
-                }
+                itemCount={response.meta?.count}
                 page={page}
                 perPage={perPage}
                 onSetPage={(e, newPage) => {

--- a/src/components/Integrations/EventTypes.tsx
+++ b/src/components/Integrations/EventTypes.tsx
@@ -169,7 +169,7 @@ const EventTypes: React.FC<EventTypesProps> = ({
 
     return (
       <Tooltip content={severityDescription.UNDEFINED}>
-        <Label {...toSeverityLabelProps(undefined)}>{'— Undefined'}</Label>
+        <Label {...toSeverityLabelProps(undefined)}>{severityDisplayName.UNDEFINED}</Label>
       </Tooltip>
     );
   };

--- a/src/components/Integrations/EventTypes.tsx
+++ b/src/components/Integrations/EventTypes.tsx
@@ -22,7 +22,7 @@ import {
   BulkSelectValue,
 } from '@patternfly/react-component-groups/dist/dynamic/BulkSelect';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useFlag } from '@unleash/proxy-client-react';
 import DataViewFilters from '@patternfly/react-data-view/dist/cjs/DataViewFilters';
 import { SkeletonTableBody, SkeletonTableHead } from '@patternfly/react-component-groups';
 import { toNotifications } from '../../types/adapters/NotificationAdapter';
@@ -54,8 +54,7 @@ const EventTypes: React.FC<EventTypesProps> = ({
   currBundle,
   applications,
 }) => {
-  const { isBeta } = useChrome();
-  const isPreview = isBeta();
+  const isSeverityEnabled = useFlag('platform.notifications.severity');
   const [loading, setLoading] = useState(true);
   const [response, setResponse] = useState<{
     meta?: { count: number };
@@ -306,7 +305,9 @@ const EventTypes: React.FC<EventTypesProps> = ({
             {loading ? (
               <SkeletonTableHead
                 columns={
-                  isPreview ? ['Event type', 'Service', 'Severity'] : ['Event type', 'Service']
+                  isSeverityEnabled
+                    ? ['Event type', 'Service', 'Severity']
+                    : ['Event type', 'Service']
                 }
               />
             ) : (
@@ -316,12 +317,12 @@ const EventTypes: React.FC<EventTypesProps> = ({
                   <Th screenReaderText="Row expansion" />
                   <Th>Event type</Th>
                   <Th>Service</Th>
-                  {isPreview && <Th>Severity</Th>}
+                  {isSeverityEnabled && <Th>Severity</Th>}
                 </Tr>
               </Thead>
             )}
             {loading ? (
-              <SkeletonTableBody rowsCount={5} columnsCount={isPreview ? 3 : 2} />
+              <SkeletonTableBody rowsCount={5} columnsCount={isSeverityEnabled ? 3 : 2} />
             ) : (
               displayData.map((row: EventType, index) => (
                 <Tbody key={index}>
@@ -356,11 +357,11 @@ const EventTypes: React.FC<EventTypesProps> = ({
                     />
                     <Td dataLabel="event-type">{row.eventTypeDisplayName}</Td>
                     <Td dataLabel="service">{row.applicationDisplayName}</Td>
-                    {isPreview && <Td dataLabel="severity">{renderSeverityCell(row)}</Td>}
+                    {isSeverityEnabled && <Td dataLabel="severity">{renderSeverityCell(row)}</Td>}
                   </Tr>
                   {row.description ? (
                     <Tr aria-label="Event type description" isExpanded={isEventExpanded(row)}>
-                      <Td dataLabel="Event type description" colSpan={isPreview ? 5 : 4}>
+                      <Td dataLabel="Event type description" colSpan={isSeverityEnabled ? 5 : 4}>
                         <ExpandableRowContent>{row.description}</ExpandableRowContent>
                       </Td>
                     </Tr>

--- a/src/components/Integrations/EventTypes.tsx
+++ b/src/components/Integrations/EventTypes.tsx
@@ -155,7 +155,8 @@ const EventTypes: React.FC<EventTypesProps> = ({
           paramsCreator({
             limit: `${response.meta?.count}`,
             offset: '0',
-            bundleId: currBundle.id,
+            filterBundleId: currBundle.id,
+            ...filters,
           })
         );
         const allData = toNotifications(data) ?? [];

--- a/src/components/Integrations/EventTypes.tsx
+++ b/src/components/Integrations/EventTypes.tsx
@@ -22,6 +22,7 @@ import {
   BulkSelectValue,
 } from '@patternfly/react-component-groups/dist/dynamic/BulkSelect';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 import DataViewFilters from '@patternfly/react-data-view/dist/cjs/DataViewFilters';
 import { SkeletonTableBody, SkeletonTableHead } from '@patternfly/react-component-groups';
 import { toNotifications } from '../../types/adapters/NotificationAdapter';
@@ -53,6 +54,8 @@ const EventTypes: React.FC<EventTypesProps> = ({
   currBundle,
   applications,
 }) => {
+  const { isBeta } = useChrome();
+  const isPreview = isBeta();
   const [loading, setLoading] = useState(true);
   const [response, setResponse] = useState<{
     meta?: { count: number };
@@ -301,7 +304,11 @@ const EventTypes: React.FC<EventTypesProps> = ({
           />
           <Table variant={'compact'} aria-label="Event types table">
             {loading ? (
-              <SkeletonTableHead columns={['Event type', 'Service', 'Severity']} />
+              <SkeletonTableHead
+                columns={
+                  isPreview ? ['Event type', 'Service', 'Severity'] : ['Event type', 'Service']
+                }
+              />
             ) : (
               <Thead aria-label="Event types table head">
                 <Tr>
@@ -309,12 +316,12 @@ const EventTypes: React.FC<EventTypesProps> = ({
                   <Th screenReaderText="Row expansion" />
                   <Th>Event type</Th>
                   <Th>Service</Th>
-                  <Th>Severity</Th>
+                  {isPreview && <Th>Severity</Th>}
                 </Tr>
               </Thead>
             )}
             {loading ? (
-              <SkeletonTableBody rowsCount={5} columnsCount={3} />
+              <SkeletonTableBody rowsCount={5} columnsCount={isPreview ? 3 : 2} />
             ) : (
               displayData.map((row: EventType, index) => (
                 <Tbody key={index}>
@@ -349,11 +356,11 @@ const EventTypes: React.FC<EventTypesProps> = ({
                     />
                     <Td dataLabel="event-type">{row.eventTypeDisplayName}</Td>
                     <Td dataLabel="service">{row.applicationDisplayName}</Td>
-                    <Td dataLabel="severity">{renderSeverityCell(row)}</Td>
+                    {isPreview && <Td dataLabel="severity">{renderSeverityCell(row)}</Td>}
                   </Tr>
                   {row.description ? (
                     <Tr aria-label="Event type description" isExpanded={isEventExpanded(row)}>
-                      <Td dataLabel="Event type description" colSpan={5}>
+                      <Td dataLabel="Event type description" colSpan={isPreview ? 5 : 4}>
                         <ExpandableRowContent>{row.description}</ExpandableRowContent>
                       </Td>
                     </Tr>

--- a/src/components/Integrations/EventTypes.tsx
+++ b/src/components/Integrations/EventTypes.tsx
@@ -1,4 +1,12 @@
-import { Content, Pagination, Stack, StackItem, Title } from '@patternfly/react-core';
+import {
+  Content,
+  Label,
+  Pagination,
+  Stack,
+  StackItem,
+  Title,
+  Tooltip,
+} from '@patternfly/react-core';
 import {
   DataView,
   DataViewCheckboxFilter,
@@ -21,10 +29,17 @@ import { getEventTypes, paramsCreator } from '../../api/helpers/notifications/ev
 import { EventType, Facet } from '../../types/Notification';
 import { debouncePromise } from '../../pages/Integrations/Create/nameValidator';
 import { perPageOptions } from '../../config/Config';
+import {
+  SEVERITY_VALUES,
+  severityDescription,
+  severityDisplayName,
+  toSeverityLabelProps,
+} from '../../utils/severityUtils';
 
 interface EventTypeFilters {
   filterEventFilterName?: string;
   filterApplicationId?: string[];
+  filterSeverity?: string[];
 }
 
 interface EventTypesProps {
@@ -53,7 +68,7 @@ const EventTypes: React.FC<EventTypesProps> = ({
     });
   const isEventExpanded = (event: EventType) => expanded.includes(event.id);
   const { filters, onSetFilters, clearAllFilters } = useDataViewFilters<EventTypeFilters>({
-    initialFilters: { filterEventFilterName: '', filterApplicationId: [] },
+    initialFilters: { filterEventFilterName: '', filterApplicationId: [], filterSeverity: [] },
   });
 
   const { page, perPage, onSetPage, onPerPageSelect } = useDataViewPagination({
@@ -83,6 +98,18 @@ const EventTypes: React.FC<EventTypesProps> = ({
     onSelect(true, [...(selectedEvents || [])]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currBundle.id]);
+
+  // Filter data client-side by severity since the API does not support it
+  const filteredData = useMemo(() => {
+    if (!response.data || !filters.filterSeverity || filters.filterSeverity.length === 0) {
+      return response.data;
+    }
+
+    return response.data.filter((event) => {
+      const sev = event.defaultSeverity ?? 'UNDEFINED';
+      return filters.filterSeverity!.includes(sev);
+    });
+  }, [response.data, filters.filterSeverity]);
 
   const fetchNotifications = useCallback(
     async (pager, filters) => {
@@ -118,9 +145,10 @@ const EventTypes: React.FC<EventTypesProps> = ({
   }, [fetchNotifications, page, perPage]);
 
   const handleBulkSelect = (value: BulkSelectValue) => {
+    const dataForBulk = filteredData ?? [];
     value === BulkSelectValue.none && setSelected(false, selected, selected);
-    value === BulkSelectValue.nonePage && setSelected(false, response.data, selected);
-    value === BulkSelectValue.page && setSelected(true, response.data, selected);
+    value === BulkSelectValue.nonePage && setSelected(false, dataForBulk, selected);
+    value === BulkSelectValue.page && setSelected(true, dataForBulk, selected);
     if (value === BulkSelectValue.all) {
       (async () => {
         const { data } = await getEventTypes(
@@ -130,9 +158,39 @@ const EventTypes: React.FC<EventTypesProps> = ({
             bundleId: currBundle.id,
           })
         );
-        setSelected(true, data, selected);
+        const allData = toNotifications(data) ?? [];
+        // Apply severity filter to all data if active
+        const filtered =
+          filters.filterSeverity && filters.filterSeverity.length > 0
+            ? allData.filter((event) => {
+                const sev = event.defaultSeverity ?? 'UNDEFINED';
+                return filters.filterSeverity!.includes(sev);
+              })
+            : allData;
+        setSelected(true, filtered, selected);
       })();
     }
+  };
+
+  const displayData = filteredData ?? [];
+
+  const renderSeverityCell = (event: EventType) => {
+    const severity = event.defaultSeverity;
+    if (severity) {
+      return (
+        <Tooltip content={severityDescription[severity]}>
+          <Label {...toSeverityLabelProps(severity)}>
+            {severityDisplayName[severity] ?? severity}
+          </Label>
+        </Tooltip>
+      );
+    }
+
+    return (
+      <Tooltip content={severityDescription.UNDEFINED}>
+        <Label {...toSeverityLabelProps(undefined)}>{'— Undefined'}</Label>
+      </Tooltip>
+    );
   };
 
   return (
@@ -150,7 +208,7 @@ const EventTypes: React.FC<EventTypesProps> = ({
       <StackItem>
         <DataView
           selection={selection}
-          activeState={loading ? 'loading' : (response.data?.length || 0) > 0 ? undefined : 'empty'}
+          activeState={loading ? 'loading' : displayData.length > 0 ? undefined : 'empty'}
         >
           <DataViewToolbar
             aria-label="Events type top toolbar"
@@ -169,15 +227,19 @@ const EventTypes: React.FC<EventTypesProps> = ({
               <BulkSelect
                 aria-label="Event types bulk select"
                 canSelectAll
-                pageCount={response.data?.length || 0}
-                totalCount={response.meta?.count}
+                pageCount={displayData.length}
+                totalCount={
+                  filters.filterSeverity && filters.filterSeverity.length > 0
+                    ? displayData.length
+                    : response.meta?.count
+                }
                 selectedCount={selected.length}
                 pageSelected={
-                  response.data?.length !== 0 && response.data?.every((item) => isSelected(item))
+                  displayData.length !== 0 && displayData.every((item) => isSelected(item))
                 }
                 pagePartiallySelected={
-                  response.data?.some((item) => isSelected(item)) &&
-                  !response.data?.every((item) => isSelected(item))
+                  displayData.some((item) => isSelected(item)) &&
+                  !displayData.every((item) => isSelected(item))
                 }
                 onSelect={handleBulkSelect}
               />
@@ -194,7 +256,10 @@ const EventTypes: React.FC<EventTypesProps> = ({
                       },
                       values
                     );
-                  } else {
+                  } else if (
+                    JSON.stringify(values.filterApplicationId) !==
+                    JSON.stringify(filters.filterApplicationId)
+                  ) {
                     fetchNotifications(
                       {
                         limit: perPage,
@@ -203,6 +268,7 @@ const EventTypes: React.FC<EventTypesProps> = ({
                       values
                     );
                   }
+                  // Severity filter is client-side, no need to refetch
                   onSetFilters(values);
                 }}
                 values={filters}
@@ -225,6 +291,16 @@ const EventTypes: React.FC<EventTypesProps> = ({
                     })) || []
                   }
                 />
+                <DataViewCheckboxFilter
+                  aria-label="Filter by severity"
+                  filterId="filterSeverity"
+                  title="Severity"
+                  placeholder="Filter by severity"
+                  options={SEVERITY_VALUES.map((sev) => ({
+                    label: severityDisplayName[sev],
+                    value: sev,
+                  }))}
+                />
               </DataViewFilters>
             }
             pagination={
@@ -232,7 +308,11 @@ const EventTypes: React.FC<EventTypesProps> = ({
                 aria-label="Event types top pagination"
                 isCompact
                 perPageOptions={perPageOptions}
-                itemCount={response.meta?.count}
+                itemCount={
+                  filters.filterSeverity && filters.filterSeverity.length > 0
+                    ? displayData.length
+                    : response.meta?.count
+                }
                 page={page}
                 perPage={perPage}
                 onSetPage={(e, newPage) => {
@@ -261,7 +341,7 @@ const EventTypes: React.FC<EventTypesProps> = ({
           />
           <Table variant={'compact'} aria-label="Event types table">
             {loading ? (
-              <SkeletonTableHead columns={['Event type', 'Service']} />
+              <SkeletonTableHead columns={['Event type', 'Service', 'Severity']} />
             ) : (
               <Thead aria-label="Event types table head">
                 <Tr>
@@ -269,13 +349,14 @@ const EventTypes: React.FC<EventTypesProps> = ({
                   <Th screenReaderText="Row expansion" />
                   <Th>Event type</Th>
                   <Th>Service</Th>
+                  <Th>Severity</Th>
                 </Tr>
               </Thead>
             )}
             {loading ? (
-              <SkeletonTableBody rowsCount={5} columnsCount={2} />
+              <SkeletonTableBody rowsCount={5} columnsCount={3} />
             ) : (
-              response.data?.map((row: EventType, index) => (
+              displayData.map((row: EventType, index) => (
                 <Tbody key={index}>
                   <Tr aria-label={`Event type ${row.id}`} isContentExpanded={isEventExpanded(row)}>
                     <Td
@@ -308,10 +389,11 @@ const EventTypes: React.FC<EventTypesProps> = ({
                     />
                     <Td dataLabel="event-type">{row.eventTypeDisplayName}</Td>
                     <Td dataLabel="service">{row.applicationDisplayName}</Td>
+                    <Td dataLabel="severity">{renderSeverityCell(row)}</Td>
                   </Tr>
                   {row.description ? (
                     <Tr aria-label="Event type description" isExpanded={isEventExpanded(row)}>
-                      <Td dataLabel="Event type description" colSpan={4}>
+                      <Td dataLabel="Event type description" colSpan={5}>
                         <ExpandableRowContent>{row.description}</ExpandableRowContent>
                       </Td>
                     </Tr>
@@ -327,7 +409,11 @@ const EventTypes: React.FC<EventTypesProps> = ({
               <Pagination
                 aria-label="Event types footer pagination"
                 perPageOptions={perPageOptions}
-                itemCount={response.meta?.count}
+                itemCount={
+                  filters.filterSeverity && filters.filterSeverity.length > 0
+                    ? displayData.length
+                    : response.meta?.count
+                }
                 page={page}
                 perPage={perPage}
                 onSetPage={(e, newPage) => {

--- a/src/components/Notifications/EventLog/EventLogTable.tsx
+++ b/src/components/Notifications/EventLog/EventLogTable.tsx
@@ -182,7 +182,7 @@ export const EventLogTable: React.FunctionComponent<EventLogTableProps> = (props
               </Tooltip>
             ) : (
               <Tooltip content={severityDescription.UNDEFINED}>
-                <Label {...toSeverityLabelProps(undefined)}>{'— Undefined'}</Label>
+                <Label {...toSeverityLabelProps(undefined)}>{severityDisplayName.UNDEFINED}</Label>
               </Tooltip>
             )}
           </Td>

--- a/src/components/Notifications/EventLog/EventLogTable.tsx
+++ b/src/components/Notifications/EventLog/EventLogTable.tsx
@@ -14,12 +14,6 @@ import {
   ExclamationTriangleIcon,
   HelpIcon,
   InProgressIcon,
-  SeverityCriticalIcon,
-  SeverityImportantIcon,
-  SeverityMinorIcon,
-  SeverityModerateIcon,
-  SeverityNoneIcon,
-  SeverityUndefinedIcon,
   UnknownIcon,
 } from '@patternfly/react-icons';
 import {
@@ -40,8 +34,13 @@ import { style } from 'typestyle';
 
 import Config from '../../../config/Config';
 import { Messages } from '../../../properties/Messages';
-import { EventSeverity, NotificationEvent, NotificationEventStatus } from '../../../types/Event';
+import { NotificationEvent, NotificationEventStatus } from '../../../types/Event';
 import { GetIntegrationRecipient } from '../../../types/Integration';
+import {
+  severityDescription,
+  severityDisplayName,
+  toSeverityLabelProps,
+} from '../../../utils/severityUtils';
 import { EmptyStateSearch } from '../../EmptyStateSearch';
 import { ActionsHelpPopover } from './ActionsHelpPopover';
 import { EventLogActionPopoverContent } from './EventLogActionPopoverContent';
@@ -68,120 +67,13 @@ const labelClassName = style({
   cursor: 'pointer',
 });
 
-/**
- * Filled label backgrounds use PatternFly global **severity** surface tokens
- * (`--pf-t--global--color--severity--*-100`), aligned with the severity palette in
- * https://www.patternfly.org/patterns/status-and-severity/#severity-icons
- *
- * Variables are set via inline `style` on `Label` so they are not overridden by
- * PatternFly stylesheet order (a prior class-only approach left all chips grey).
- *
- * Foreground uses white/black for contrast. Icons are severity-shaped, not status icons.
- */
-const severityLabelFgOnDark = 'var(--pf-t--color--white)';
-const severityLabelFgOnLight = 'var(--pf-t--color--black)';
-
-/** Inline Label `style` so PF label CSS does not override single-class typestyle rules (load order). */
-const severityLabelVars = (vars: Record<string, string>): React.CSSProperties =>
-  vars as React.CSSProperties;
-
-export const eventLogSeverityLabelStyles: Record<EventSeverity, React.CSSProperties> = {
-  CRITICAL: severityLabelVars({
-    '--pf-v6-c-label--BackgroundColor': 'var(--pf-t--global--color--severity--critical--100)',
-    '--pf-v6-c-label--Color': severityLabelFgOnDark,
-    '--pf-v6-c-label__icon--Color': severityLabelFgOnDark,
-  }),
-  IMPORTANT: severityLabelVars({
-    '--pf-v6-c-label--BackgroundColor': 'var(--pf-t--global--color--severity--important--100)',
-    '--pf-v6-c-label--Color': severityLabelFgOnDark,
-    '--pf-v6-c-label__icon--Color': severityLabelFgOnDark,
-  }),
-  MODERATE: severityLabelVars({
-    '--pf-v6-c-label--BackgroundColor': 'var(--pf-t--global--color--severity--moderate--100)',
-    '--pf-v6-c-label--Color': severityLabelFgOnLight,
-    '--pf-v6-c-label__icon--Color': severityLabelFgOnLight,
-  }),
-  LOW: severityLabelVars({
-    '--pf-v6-c-label--BackgroundColor': 'var(--pf-t--global--color--severity--minor--100)',
-    '--pf-v6-c-label--Color': severityLabelFgOnLight,
-    '--pf-v6-c-label__icon--Color': severityLabelFgOnLight,
-  }),
-  NONE: severityLabelVars({
-    '--pf-v6-c-label--BackgroundColor': 'var(--pf-t--global--color--severity--none--100)',
-    '--pf-v6-c-label--Color': severityLabelFgOnDark,
-    '--pf-v6-c-label__icon--Color': severityLabelFgOnDark,
-  }),
-  UNDEFINED: severityLabelVars({
-    '--pf-v6-c-label--BorderColor': 'var(--pf-t--global--color--severity--undefined--200)',
-    '--pf-v6-c-label--Color': severityLabelFgOnLight,
-    '--pf-v6-c-label__icon--Color': severityLabelFgOnLight,
-  }),
-};
-
-export const toSeverityLabelProps = (
-  severity?: EventSeverity
-): Pick<LabelProps, 'color' | 'icon' | 'style' | 'status' | 'variant'> => {
-  switch (severity) {
-    case 'CRITICAL':
-      return {
-        style: eventLogSeverityLabelStyles.CRITICAL,
-        icon: <SeverityCriticalIcon />,
-      };
-    case 'IMPORTANT':
-      return {
-        style: eventLogSeverityLabelStyles.IMPORTANT,
-        icon: <SeverityImportantIcon />,
-      };
-    case 'MODERATE':
-      return {
-        style: eventLogSeverityLabelStyles.MODERATE,
-        icon: <SeverityModerateIcon />,
-      };
-    case 'LOW':
-      return {
-        style: eventLogSeverityLabelStyles.LOW,
-        icon: <SeverityMinorIcon />,
-      };
-    case 'NONE':
-      return {
-        style: eventLogSeverityLabelStyles.NONE,
-        icon: <SeverityNoneIcon />,
-      };
-    case 'UNDEFINED':
-      return {
-        style: eventLogSeverityLabelStyles.UNDEFINED,
-        color: 'grey',
-        variant: 'outline',
-        icon: <SeverityUndefinedIcon />,
-      };
-    case undefined:
-    default:
-      return {
-        style: eventLogSeverityLabelStyles.UNDEFINED,
-        color: 'grey',
-        variant: 'outline',
-        icon: <SeverityUndefinedIcon />,
-      };
-  }
-};
-
-const severityDisplayName: Record<EventSeverity, string> = {
-  CRITICAL: 'Critical',
-  IMPORTANT: 'Important',
-  MODERATE: 'Moderate',
-  LOW: 'Low',
-  NONE: 'None',
-  UNDEFINED: 'Undefined',
-};
-
-export const severityDescription: Record<EventSeverity, string> = {
-  CRITICAL: 'Urgent notification about an event with impact to your systems',
-  IMPORTANT: 'Errors or other events that may impact your systems',
-  MODERATE: 'Warning',
-  LOW: 'Information only',
-  NONE: 'Debug or informative updates',
-  UNDEFINED: 'Severity level has not been defined for this event',
-};
+// Re-export severity utilities from shared module for backward compatibility
+export {
+  eventLogSeverityLabelStyles,
+  toSeverityLabelProps,
+  severityDisplayName,
+  severityDescription,
+} from '../../../utils/severityUtils';
 
 export const toLabelProps = (
   actionStatus: NotificationEventStatus

--- a/src/types/Notification.ts
+++ b/src/types/Notification.ts
@@ -3,12 +3,14 @@ import { UserIntegration } from './Integration';
 import { BaseNotificationRecipient } from './Recipient';
 
 export type UUID = Schemas.UUID;
+export type Severity = Schemas.Severity;
 
 export interface EventType {
   id: UUID;
   applicationDisplayName: string;
   eventTypeDisplayName: string;
   description?: string;
+  defaultSeverity?: Severity;
 }
 
 export interface Notification extends EventType {

--- a/src/types/adapters/NotificationAdapter.ts
+++ b/src/types/adapters/NotificationAdapter.ts
@@ -62,6 +62,7 @@ export const toNotification = (serverNotification: ServerNotificationResponse): 
     applicationDisplayName: serverNotification.application.display_name,
     eventTypeDisplayName: serverNotification.display_name,
     description: serverNotification.description || undefined,
+    defaultSeverity: serverNotification.default_severity || undefined,
   };
 };
 

--- a/src/types/adapters/__tests__/NotificationAdapter.test.ts
+++ b/src/types/adapters/__tests__/NotificationAdapter.test.ts
@@ -1,0 +1,112 @@
+import { toNotification, toNotifications } from '../NotificationAdapter';
+import { ServerNotificationResponse } from '../../Notification';
+
+const makeServerEventType = (
+  overrides: Partial<ServerNotificationResponse> = {}
+): ServerNotificationResponse => ({
+  id: 'test-id-1',
+  application_id: 'app-1',
+  application: {
+    display_name: 'Test Application',
+    name: 'test-app',
+    id: 'app-1',
+    bundle_id: 'bundle-1',
+  },
+  display_name: 'Test Event Type',
+  name: 'test-event-type',
+  ...overrides,
+});
+
+describe('NotificationAdapter', () => {
+  describe('toNotification', () => {
+    it('maps basic fields correctly', () => {
+      const server = makeServerEventType({
+        description: 'A test event',
+      });
+
+      const result = toNotification(server);
+
+      expect(result.id).toBe('test-id-1');
+      expect(result.applicationDisplayName).toBe('Test Application');
+      expect(result.eventTypeDisplayName).toBe('Test Event Type');
+      expect(result.description).toBe('A test event');
+    });
+
+    it('maps defaultSeverity from default_severity', () => {
+      const server = makeServerEventType({
+        default_severity: 'CRITICAL',
+      });
+
+      const result = toNotification(server);
+
+      expect(result.defaultSeverity).toBe('CRITICAL');
+    });
+
+    it('maps all severity values correctly', () => {
+      const severities = ['CRITICAL', 'IMPORTANT', 'MODERATE', 'LOW', 'NONE', 'UNDEFINED'] as const;
+
+      for (const severity of severities) {
+        const server = makeServerEventType({ default_severity: severity });
+        const result = toNotification(server);
+        expect(result.defaultSeverity).toBe(severity);
+      }
+    });
+
+    it('sets defaultSeverity to undefined when API omits it', () => {
+      const server = makeServerEventType({
+        default_severity: undefined,
+      });
+
+      const result = toNotification(server);
+
+      expect(result.defaultSeverity).toBeUndefined();
+    });
+
+    it('sets defaultSeverity to undefined when API returns null', () => {
+      const server = makeServerEventType({
+        default_severity: null,
+      });
+
+      const result = toNotification(server);
+
+      expect(result.defaultSeverity).toBeUndefined();
+    });
+
+    it('sets description to undefined when empty string', () => {
+      const server = makeServerEventType({
+        description: '',
+      });
+
+      const result = toNotification(server);
+
+      expect(result.description).toBeUndefined();
+    });
+
+    it('throws if id is missing', () => {
+      const server = makeServerEventType({ id: undefined });
+      expect(() => toNotification(server)).toThrow();
+    });
+
+    it('throws if application is missing', () => {
+      const server = makeServerEventType({ application: undefined });
+      expect(() => toNotification(server)).toThrow();
+    });
+  });
+
+  describe('toNotifications', () => {
+    it('maps an array of server notifications', () => {
+      const servers = [
+        makeServerEventType({ id: 'id-1', default_severity: 'CRITICAL' }),
+        makeServerEventType({ id: 'id-2', default_severity: 'LOW' }),
+        makeServerEventType({ id: 'id-3' }),
+      ];
+
+      const results = toNotifications(servers);
+
+      expect(results).toHaveLength(3);
+      expect(results[0].defaultSeverity).toBe('CRITICAL');
+      expect(results[1].defaultSeverity).toBe('LOW');
+      expect(results[2].defaultSeverity).toBeUndefined();
+    });
+  });
+});

--- a/src/utils/__tests__/severityUtils.test.tsx
+++ b/src/utils/__tests__/severityUtils.test.tsx
@@ -1,0 +1,77 @@
+import {
+  SEVERITY_VALUES,
+  severityDescription,
+  severityDisplayName,
+  toSeverityLabelProps,
+} from '../severityUtils';
+
+describe('severityUtils', () => {
+  describe('toSeverityLabelProps', () => {
+    it.each(['CRITICAL', 'IMPORTANT', 'MODERATE', 'LOW', 'NONE'] as const)(
+      'returns an icon and style for %s severity',
+      (severity) => {
+        const result = toSeverityLabelProps(severity);
+        expect(result.icon).toBeTruthy();
+        expect(result.style).toBeTruthy();
+      }
+    );
+
+    it('returns outline variant for UNDEFINED severity', () => {
+      const result = toSeverityLabelProps('UNDEFINED');
+      expect(result.icon).toBeTruthy();
+      expect(result.color).toBe('grey');
+      expect(result.variant).toBe('outline');
+      expect(result.style).toBeTruthy();
+    });
+
+    it('returns outline variant for undefined severity', () => {
+      const result = toSeverityLabelProps(undefined);
+      expect(result.icon).toBeTruthy();
+      expect(result.color).toBe('grey');
+      expect(result.variant).toBe('outline');
+      expect(result.style).toBeTruthy();
+    });
+  });
+
+  describe('severityDisplayName', () => {
+    it.each(['CRITICAL', 'IMPORTANT', 'MODERATE', 'LOW', 'NONE', 'UNDEFINED'] as const)(
+      'has a display name for %s',
+      (severity) => {
+        expect(severityDisplayName[severity]).toBeTruthy();
+        expect(typeof severityDisplayName[severity]).toBe('string');
+      }
+    );
+
+    it('maps to human-readable names', () => {
+      expect(severityDisplayName.CRITICAL).toBe('Critical');
+      expect(severityDisplayName.IMPORTANT).toBe('Important');
+      expect(severityDisplayName.MODERATE).toBe('Moderate');
+      expect(severityDisplayName.LOW).toBe('Low');
+      expect(severityDisplayName.NONE).toBe('None');
+      expect(severityDisplayName.UNDEFINED).toBe('Undefined');
+    });
+  });
+
+  describe('severityDescription', () => {
+    it.each(['CRITICAL', 'IMPORTANT', 'MODERATE', 'LOW', 'NONE', 'UNDEFINED'] as const)(
+      'has a non-empty description for %s',
+      (severity) => {
+        expect(severityDescription[severity]).toBeTruthy();
+        expect(typeof severityDescription[severity]).toBe('string');
+        expect(severityDescription[severity].length).toBeGreaterThan(0);
+      }
+    );
+  });
+
+  describe('SEVERITY_VALUES', () => {
+    it('contains all six severity levels', () => {
+      expect(SEVERITY_VALUES).toHaveLength(6);
+      expect(SEVERITY_VALUES).toContain('CRITICAL');
+      expect(SEVERITY_VALUES).toContain('IMPORTANT');
+      expect(SEVERITY_VALUES).toContain('MODERATE');
+      expect(SEVERITY_VALUES).toContain('LOW');
+      expect(SEVERITY_VALUES).toContain('NONE');
+      expect(SEVERITY_VALUES).toContain('UNDEFINED');
+    });
+  });
+});

--- a/src/utils/severityUtils.tsx
+++ b/src/utils/severityUtils.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { LabelProps } from '@patternfly/react-core/dist/dynamic/components/Label';
+import {
+  SeverityCriticalIcon,
+  SeverityImportantIcon,
+  SeverityMinorIcon,
+  SeverityModerateIcon,
+  SeverityNoneIcon,
+  SeverityUndefinedIcon,
+} from '@patternfly/react-icons';
+
+import { EventSeverity } from '../types/Event';
+
+/**
+ * Filled label backgrounds use PatternFly global **severity** surface tokens
+ * (`--pf-t--global--color--severity--*-100`), aligned with the severity palette in
+ * https://www.patternfly.org/patterns/status-and-severity/#severity-icons
+ *
+ * Variables are set via inline `style` on `Label` so they are not overridden by
+ * PatternFly stylesheet order (a prior class-only approach left all chips grey).
+ *
+ * Foreground uses white/black for contrast. Icons are severity-shaped, not status icons.
+ */
+const severityLabelFgOnDark = 'var(--pf-t--color--white)';
+const severityLabelFgOnLight = 'var(--pf-t--color--black)';
+
+/** Inline Label `style` so PF label CSS does not override single-class typestyle rules (load order). */
+const severityLabelVars = (vars: Record<string, string>): React.CSSProperties =>
+  vars as React.CSSProperties;
+
+export const eventLogSeverityLabelStyles: Record<EventSeverity, React.CSSProperties> = {
+  CRITICAL: severityLabelVars({
+    '--pf-v6-c-label--BackgroundColor': 'var(--pf-t--global--color--severity--critical--100)',
+    '--pf-v6-c-label--Color': severityLabelFgOnDark,
+    '--pf-v6-c-label__icon--Color': severityLabelFgOnDark,
+  }),
+  IMPORTANT: severityLabelVars({
+    '--pf-v6-c-label--BackgroundColor': 'var(--pf-t--global--color--severity--important--100)',
+    '--pf-v6-c-label--Color': severityLabelFgOnDark,
+    '--pf-v6-c-label__icon--Color': severityLabelFgOnDark,
+  }),
+  MODERATE: severityLabelVars({
+    '--pf-v6-c-label--BackgroundColor': 'var(--pf-t--global--color--severity--moderate--100)',
+    '--pf-v6-c-label--Color': severityLabelFgOnLight,
+    '--pf-v6-c-label__icon--Color': severityLabelFgOnLight,
+  }),
+  LOW: severityLabelVars({
+    '--pf-v6-c-label--BackgroundColor': 'var(--pf-t--global--color--severity--minor--100)',
+    '--pf-v6-c-label--Color': severityLabelFgOnLight,
+    '--pf-v6-c-label__icon--Color': severityLabelFgOnLight,
+  }),
+  NONE: severityLabelVars({
+    '--pf-v6-c-label--BackgroundColor': 'var(--pf-t--global--color--severity--none--100)',
+    '--pf-v6-c-label--Color': severityLabelFgOnDark,
+    '--pf-v6-c-label__icon--Color': severityLabelFgOnDark,
+  }),
+  UNDEFINED: severityLabelVars({
+    '--pf-v6-c-label--BorderColor': 'var(--pf-t--global--color--severity--undefined--200)',
+    '--pf-v6-c-label--Color': severityLabelFgOnLight,
+    '--pf-v6-c-label__icon--Color': severityLabelFgOnLight,
+  }),
+};
+
+export const toSeverityLabelProps = (
+  severity?: EventSeverity
+): Pick<LabelProps, 'color' | 'icon' | 'style' | 'status' | 'variant'> => {
+  switch (severity) {
+    case 'CRITICAL':
+      return {
+        style: eventLogSeverityLabelStyles.CRITICAL,
+        icon: <SeverityCriticalIcon />,
+      };
+    case 'IMPORTANT':
+      return {
+        style: eventLogSeverityLabelStyles.IMPORTANT,
+        icon: <SeverityImportantIcon />,
+      };
+    case 'MODERATE':
+      return {
+        style: eventLogSeverityLabelStyles.MODERATE,
+        icon: <SeverityModerateIcon />,
+      };
+    case 'LOW':
+      return {
+        style: eventLogSeverityLabelStyles.LOW,
+        icon: <SeverityMinorIcon />,
+      };
+    case 'NONE':
+      return {
+        style: eventLogSeverityLabelStyles.NONE,
+        icon: <SeverityNoneIcon />,
+      };
+    case 'UNDEFINED':
+      return {
+        style: eventLogSeverityLabelStyles.UNDEFINED,
+        color: 'grey',
+        variant: 'outline',
+        icon: <SeverityUndefinedIcon />,
+      };
+    case undefined:
+    default:
+      return {
+        style: eventLogSeverityLabelStyles.UNDEFINED,
+        color: 'grey',
+        variant: 'outline',
+        icon: <SeverityUndefinedIcon />,
+      };
+  }
+};
+
+export const severityDisplayName: Record<EventSeverity, string> = {
+  CRITICAL: 'Critical',
+  IMPORTANT: 'Important',
+  MODERATE: 'Moderate',
+  LOW: 'Low',
+  NONE: 'None',
+  UNDEFINED: 'Undefined',
+};
+
+export const severityDescription: Record<EventSeverity, string> = {
+  CRITICAL: 'Urgent notification about an event with impact to your systems',
+  IMPORTANT: 'Errors or other events that may impact your systems',
+  MODERATE: 'Warning',
+  LOW: 'Information only',
+  NONE: 'Debug or informative updates',
+  UNDEFINED: 'Severity level has not been defined for this event',
+};
+
+export const SEVERITY_VALUES: EventSeverity[] = [
+  'CRITICAL',
+  'IMPORTANT',
+  'MODERATE',
+  'LOW',
+  'NONE',
+  'UNDEFINED',
+];


### PR DESCRIPTION
## Summary

RHCLOUD-45326

- Add **Severity column** to the behavior group wizard's "Associate event types" table, showing PatternFly severity labels with icons (Critical, Important, Moderate, Low, None) and a "— Undefined" fallback when the API omits severity.
- Add **Severity checkbox filter** in the toolbar for client-side filtering by severity level.
- Extract shared severity utilities (`toSeverityLabelProps`, `severityDisplayName`, `severityDescription`) from `EventLogTable` into `src/utils/severityUtils.tsx` for reuse across components.
- Extend `EventType` interface with `defaultSeverity` field and update `NotificationAdapter` to map `default_severity` from the API response.
- Add unit tests for severity utils and the notification adapter (30 new tests).
- Add Storybook story for the EventTypes component demonstrating all severity levels.

<img width="1141" height="751" alt="Screenshot 2026-04-16 at 9 27 10 AM" src="https://github.com/user-attachments/assets/589f8e34-f3b4-4fad-ad9a-e5598dc99819" />



## Test plan

- [x] All 255 unit tests pass (225 existing + 30 new)
- [x] Linting passes
- [ ] Verify severity labels render correctly with proper icons and colors
- [ ] Verify severity filter correctly filters event types by severity level
- [ ] Verify "— Undefined" fallback appears when severity is missing
- [ ] Verify loading/error states still work correctly
- [ ] Screen reader accessibility: severity labels have proper ARIA attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)