### PR TITLE
fix(drawer): Show mixed state for bulk select checkbox

### DIFF
--- a/src/components/NotificationsDrawer/DrawerPanel.tsx
+++ b/src/components/NotificationsDrawer/DrawerPanel.tsx
@@ -188,7 +188,11 @@ const DrawerPanelBase = ({ toggleDrawer }: DrawerPanelProps) => {
           count={state.notificationData.filter(({ selected }) => selected).length}
           checked={
             state.notificationData.length > 0 &&
-            state.notificationData.every(({ selected }) => selected)
+            state.notificationData.some(({ selected }) => selected)
+              ? state.notificationData.every(({ selected }) => selected)
+                ? true
+                : null
+              : false
           }
         />
         <ActionDropdown

--- a/src/components/NotificationsDrawer/__tests__/DrawerPanel.test.tsx
+++ b/src/components/NotificationsDrawer/__tests__/DrawerPanel.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react';
+import { fn } from 'jest-mock';
+import * as React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children: string }) => React.createElement('div', null, children),
+}));
+jest.mock('remark-gfm', () => ({ __esModule: true, default: () => {} }));
+
+import DrawerPanel from '../DrawerPanel';
+import { NotificationData } from '../../../types/Drawer';
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => {
+  return () => ({
+    addWsEventListener: () => fn(),
+    auth: {
+      getUser: () =>
+        Promise.resolve({
+          identity: { user: { is_org_admin: false } },
+        }),
+    },
+  });
+});
+
+jest.mock('../../../hooks/useNotificationDrawer');
+import useNotificationDrawer from '../../../hooks/useNotificationDrawer';
+
+const makeNotification = (id: string, read: boolean, selected = false): NotificationData => ({
+  id,
+  title: `Notification ${id}`,
+  description: 'Test description',
+  read,
+  selected,
+  source: 'test',
+  bundle: 'rhel',
+  created: new Date().toISOString(),
+});
+
+const renderDrawerPanel = (notificationData: NotificationData[]) => {
+  (useNotificationDrawer as jest.Mock).mockReturnValue({
+    state: {
+      notificationData,
+      hasUnread: notificationData.some((n) => !n.read),
+      ready: true,
+      count: notificationData.length,
+      filters: [],
+      filterConfig: [],
+      hasNotificationsPermissions: false,
+      initializing: false,
+    },
+    addNotification: fn(),
+    updateNotificationRead: fn(),
+    updateSelectedStatus: fn(),
+    updateNotificationsSelected: fn(),
+    updateNotificationSelected: fn(),
+    setFilters: fn(),
+  });
+
+  return render(
+    <MemoryRouter>
+      <DrawerPanel panelRef={React.createRef()} toggleDrawer={fn()} />
+    </MemoryRouter>
+  );
+};
+
+describe('DrawerPanel bulk select checkbox', () => {
+  it('shows unchecked state when no notifications are selected', () => {
+    renderDrawerPanel([makeNotification('1', false, false), makeNotification('2', false, false)]);
+
+    const checkbox = screen.getByRole('checkbox', { name: 'Select all' });
+    expect(checkbox).not.toBeChecked();
+    expect(checkbox).not.toBePartiallyChecked();
+  });
+
+  it('shows checked state when all notifications are selected', () => {
+    renderDrawerPanel([makeNotification('1', false, true), makeNotification('2', false, true)]);
+
+    const checkbox = screen.getByRole('checkbox', { name: 'Select all' });
+    expect(checkbox).toBeChecked();
+  });
+
+  it('shows mixed/indeterminate state when some notifications are selected', () => {
+    renderDrawerPanel([makeNotification('1', false, true), makeNotification('2', false, false)]);
+
+    const checkbox = screen.getByRole('checkbox', { name: 'Select all' });
+    expect(checkbox).toBePartiallyChecked();
+  });
+
+  it('shows unchecked state when only one of many is selected', () => {
+    renderDrawerPanel([
+      makeNotification('1', false, true),
+      makeNotification('2', false, false),
+      makeNotification('3', false, false),
+    ]);
+
+    const checkbox = screen.getByRole('checkbox', { name: 'Select all' });
+    expect(checkbox).toBePartiallyChecked();
+  });
+});

--- a/src/components/NotificationsDrawer/__tests__/DrawerPanel.test.tsx
+++ b/src/components/NotificationsDrawer/__tests__/DrawerPanel.test.tsx
@@ -88,7 +88,7 @@ describe('DrawerPanel bulk select checkbox', () => {
     expect(checkbox).toBePartiallyChecked();
   });
 
-  it('shows unchecked state when only one of many is selected', () => {
+  it('shows mixed/indeterminate state when only one of many is selected', () => {
     renderDrawerPanel([
       makeNotification('1', false, true),
       makeNotification('2', false, false),


### PR DESCRIPTION
## Summary
- Updates the bulk select checkbox in the notification drawer to show an indeterminate (mixed) state when some — but not all — notifications are selected
- Previously the checkbox only showed checked/unchecked, which was misleading during partial selection
- Passes `null` to PatternFly's `MenuToggleCheckbox` `checked` prop for partial selection, triggering the native indeterminate state

## Changes
- `src/components/NotificationsDrawer/DrawerPanel.tsx` — Updated `checked` prop logic on `BulkSelect`
- `src/components/NotificationsDrawer/__tests__/DrawerPanel.test.tsx` — Added 4 unit tests covering unchecked, checked, and mixed states

RHCLOUD-46536

## Test plan
- [x] All 258 existing tests pass
- [x] Lint clean (0 errors)
- [ ] Verify mixed checkbox state renders correctly in browser with partial selection
- [ ] Verify checked state still works when all selected
- [ ] Verify unchecked state still works when none selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)