### PR TITLE
fix(drawer): Remove extra spacing from kebab menu

### DIFF
--- a/src/components/NotificationsDrawer/Dropdowns.tsx
+++ b/src/components/NotificationsDrawer/Dropdowns.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { Flex, FlexItem } from '@patternfly/react-core/dist/dynamic/layouts/Flex';
 import {
   MenuToggle,
   MenuToggleElement,
@@ -120,15 +119,13 @@ export const ActionDropdown = ({
       }}
       id="notifications-actions-dropdown"
     >
-      <DropdownList>
-        <ActionDropdownItems
-          isDisabled={isDisabled}
-          onUpdateSelectedStatus={onUpdateSelectedStatus}
-          onNavigateTo={onNavigateTo}
-          isOrgAdmin={isOrgAdmin}
-          hasNotificationsPermissions={hasNotificationsPermissions}
-        />
-      </DropdownList>
+      <ActionDropdownItems
+        isDisabled={isDisabled}
+        onUpdateSelectedStatus={onUpdateSelectedStatus}
+        onNavigateTo={onNavigateTo}
+        isOrgAdmin={isOrgAdmin}
+        hasNotificationsPermissions={hasNotificationsPermissions}
+      />
     </Dropdown>
   );
 };
@@ -142,54 +139,49 @@ const ActionDropdownItems = ({
 }) => {
   return (
     <>
-      <DropdownItem key="actions" description="Actions" />,
-      <DropdownItem
-        key="read selected"
-        onClick={() => onUpdateSelectedStatus(true)}
-        isDisabled={isDisabled}
-      >
-        Mark selected as read
-      </DropdownItem>
-      ,
-      <DropdownItem
-        key="unread selected"
-        onClick={() => onUpdateSelectedStatus(false)}
-        isDisabled={isDisabled}
-      >
-        Mark selected as unread
-      </DropdownItem>
-      ,
-      <Divider key="divider" />,
-      <DropdownItem key="quick links" description="Quick links" />,
-      <DropdownItem
-        key="notifications log"
-        onClick={() => onNavigateTo('/settings/notifications/notificationslog')}
-      >
-        <Flex>
-          <FlexItem>View notifications log</FlexItem>
-        </Flex>
-      </DropdownItem>
-      ,
-      {(isOrgAdmin || hasNotificationsPermissions) && (
-        <DropdownItem
-          key="notification settings"
-          onClick={() => onNavigateTo('/settings/notifications/configure-events')}
-        >
-          <Flex>
-            <FlexItem>Configure notification settings</FlexItem>
-          </Flex>
-        </DropdownItem>
-      )}
-      ,
-      <DropdownItem
-        key="notification preferences"
-        onClick={() => onNavigateTo('/settings/notifications/user-preferences')}
-      >
-        <Flex>
-          <FlexItem>Manage my notification preferences</FlexItem>
-        </Flex>
-      </DropdownItem>
-      ,
+      <DropdownGroup label="Actions">
+        <DropdownList>
+          <DropdownItem
+            key="read selected"
+            onClick={() => onUpdateSelectedStatus(true)}
+            isDisabled={isDisabled}
+          >
+            Mark selected as read
+          </DropdownItem>
+          <DropdownItem
+            key="unread selected"
+            onClick={() => onUpdateSelectedStatus(false)}
+            isDisabled={isDisabled}
+          >
+            Mark selected as unread
+          </DropdownItem>
+        </DropdownList>
+      </DropdownGroup>
+      <Divider />
+      <DropdownGroup label="Quick links">
+        <DropdownList>
+          <DropdownItem
+            key="notifications log"
+            onClick={() => onNavigateTo('/settings/notifications/notificationslog')}
+          >
+            View notifications log
+          </DropdownItem>
+          {(isOrgAdmin || hasNotificationsPermissions) && (
+            <DropdownItem
+              key="notification settings"
+              onClick={() => onNavigateTo('/settings/notifications/configure-events')}
+            >
+              Configure notification settings
+            </DropdownItem>
+          )}
+          <DropdownItem
+            key="notification preferences"
+            onClick={() => onNavigateTo('/settings/notifications/user-preferences')}
+          >
+            Manage my notification preferences
+          </DropdownItem>
+        </DropdownList>
+      </DropdownGroup>
     </>
   );
 };


### PR DESCRIPTION
## Summary

- Replaced empty `DropdownItem` components (used as section headers via `description` prop) with proper `DropdownGroup` components using the `label` prop, matching the existing pattern used by `FilterDropdownItems`
- Removed trailing commas in JSX that rendered as text nodes
- Removed unnecessary `Flex`/`FlexItem` wrappers around dropdown item text

These changes eliminate the extra white space between options in the notification drawer's kebab (actions) menu by using default PatternFly styling instead of custom workarounds.

RHCLOUD-46540

## Test plan

- [ ] Open the notification drawer
- [ ] Click the kebab (⋮) menu
- [ ] Verify spacing between menu items uses default PatternFly styling with no extra whitespace
- [ ] Verify "Actions" and "Quick links" appear as proper group labels
- [ ] Verify all menu items remain functional (mark read/unread, navigation links)
- [ ] Verify conditional "Configure notification settings" item still shows for org admins

🤖 Generated with [Claude Code](https://claude.com/claude-code)