### PR TITLE
fix(permissions): Allow non-orgadmin users to access Notifications Log

### DIFF
--- a/src/components/CheckReadPermissions.tsx
+++ b/src/components/CheckReadPermissions.tsx
@@ -22,6 +22,10 @@ export const CheckReadPermissions: React.FunctionComponent<React.PropsWithChildr
           return rbac?.canReadEvents;
         }
 
+        if (location.pathname === linkTo.notificationsLog()) {
+          return true;
+        }
+
         return rbac?.canReadNotifications;
     }
 

--- a/src/components/__tests__/CheckReadPermissions.test.tsx
+++ b/src/components/__tests__/CheckReadPermissions.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import * as React from 'react';
+
+import {
+  appWrapperCleanup,
+  appWrapperSetup,
+  getConfiguredAppWrapper,
+} from '../../../test/AppWrapper';
+import { CheckReadPermissions } from '../CheckReadPermissions';
+
+const mockGetApp = jest.fn();
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => {
+  return () => ({
+    getApp: mockGetApp,
+    isBeta: () => false,
+    getEnvironment: () => 'ci',
+  });
+});
+
+const childText = 'Authorized Content';
+
+describe('CheckReadPermissions', () => {
+  beforeEach(() => {
+    appWrapperSetup();
+    fetchMock.get(`/api/featureflags/v0`, {
+      body: { toggles: [] },
+    });
+  });
+
+  afterEach(() => {
+    appWrapperCleanup();
+  });
+
+  it('Shows children when user has canReadNotifications for notification pages', () => {
+    mockGetApp.mockReturnValue('notifications');
+    const Wrapper = getConfiguredAppWrapper({
+      router: { initialEntries: ['/rhel'] },
+      appContext: { rbac: { canReadNotifications: true } },
+    });
+
+    render(
+      <CheckReadPermissions>
+        <div>{childText}</div>
+      </CheckReadPermissions>,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.getByText(childText)).toBeVisible();
+  });
+
+  it('Shows unauthorized when user lacks canReadNotifications for notification pages', () => {
+    mockGetApp.mockReturnValue('notifications');
+    const Wrapper = getConfiguredAppWrapper({
+      router: { initialEntries: ['/rhel'] },
+      appContext: { rbac: { canReadNotifications: false } },
+    });
+
+    render(
+      <CheckReadPermissions>
+        <div>{childText}</div>
+      </CheckReadPermissions>,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.queryByText(childText)).not.toBeInTheDocument();
+  });
+
+  it('Shows children for /notificationslog regardless of canReadNotifications', () => {
+    mockGetApp.mockReturnValue('notifications');
+    const Wrapper = getConfiguredAppWrapper({
+      router: { initialEntries: ['/notificationslog'] },
+      appContext: { rbac: { canReadNotifications: false } },
+    });
+
+    render(
+      <CheckReadPermissions>
+        <div>{childText}</div>
+      </CheckReadPermissions>,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.getByText(childText)).toBeVisible();
+  });
+
+  it('Shows children for /eventlog when user has canReadEvents', () => {
+    mockGetApp.mockReturnValue('notifications');
+    const Wrapper = getConfiguredAppWrapper({
+      router: { initialEntries: ['/eventlog'] },
+      appContext: { rbac: { canReadEvents: true } },
+    });
+
+    render(
+      <CheckReadPermissions>
+        <div>{childText}</div>
+      </CheckReadPermissions>,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.getByText(childText)).toBeVisible();
+  });
+
+  it('Shows unauthorized for /eventlog when user lacks canReadEvents', () => {
+    mockGetApp.mockReturnValue('notifications');
+    const Wrapper = getConfiguredAppWrapper({
+      router: { initialEntries: ['/eventlog'] },
+      appContext: { rbac: { canReadEvents: false } },
+    });
+
+    render(
+      <CheckReadPermissions>
+        <div>{childText}</div>
+      </CheckReadPermissions>,
+      { wrapper: Wrapper }
+    );
+
+    expect(screen.queryByText(childText)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/__tests__/CheckReadPermissions.test.tsx
+++ b/src/components/__tests__/CheckReadPermissions.test.tsx
@@ -65,6 +65,7 @@ describe('CheckReadPermissions', () => {
     );
 
     expect(screen.queryByText(childText)).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /User Preferences/i })).toBeInTheDocument();
   });
 
   it('Shows children for /notificationslog regardless of canReadNotifications', () => {
@@ -116,5 +117,6 @@ describe('CheckReadPermissions', () => {
     );
 
     expect(screen.queryByText(childText)).not.toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /User Preferences/i })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Fixes [RHCLOUD-29703](https://redhat.atlassian.net/browse/RHCLOUD-29703): Non-orgadmin users were blocked from the Notifications Log page with "You do not have access to Notifications"
- Root cause: `CheckReadPermissions` gated `/notificationslog` behind `canReadNotifications` (`notifications:notifications:read`), which controls access to notification **configuration/settings** — not viewing one's own notifications
- The Notifications Log page displays the same data as the notification drawer (which is accessible to all authenticated users), so it should not require this permission
- Added unit tests for `CheckReadPermissions` covering all permission paths

## Test plan

- [ ] Verify non-orgadmin users can access `/notificationslog` without `notifications:notifications:read` permission
- [ ] Verify orgadmin users can still access `/notificationslog`
- [ ] Verify `/eventlog` still requires `canReadEvents` permission
- [ ] Verify other notification pages still require `canReadNotifications` permission
- [ ] All 259 unit tests pass, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHCLOUD-29703]: https://redhat.atlassian.net/browse/RHCLOUD-29703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ