### PR TITLE
Adds required prop to event log stories to fix CI

### DIFF
--- a/.tekton/notifications-frontend-pull-request.yaml
+++ b/.tekton/notifications-frontend-pull-request.yaml
@@ -47,6 +47,8 @@ spec:
         #!/bin/bash
         set -ex
         npm run lint
+        # TypeScript type-check to catch compilation errors
+        npx tsc --noEmit
         npm test -- --runInBand --no-cache
 
     # E2E tests - only run tests (dependencies installed in workspace-setup-script)

--- a/src/components/Notifications/EventLog/EventLogToolbar.stories.tsx
+++ b/src/components/Notifications/EventLog/EventLogToolbar.stories.tsx
@@ -390,6 +390,7 @@ const ToolbarWithEvents: React.FC<ToolbarWithEventsProps> = ({
       <EventLogTable
         events={pageEvents}
         loading={false}
+        showSeverity={true}
         onSort={onSort}
         sortColumn={sortColumn}
         sortDirection={sortDirection}


### PR DESCRIPTION
Also updates the PR contract to check for TS issues which would've caught this. Failure run: https://konflux-ui.apps.stone-prd-rh01.pg1f.p1.openshiftapps.com/ns/rh-platform-experien-tenant/applications/notifications-frontend/pipelineruns/notifications-frontend-on-pull-request-k8k9g/logs?task=build-container