### PR TITLE
fix(Notifications): Mark notifications as read

### DIFF
--- a/src/api/helpers/notifications/update-read-status-helper.ts
+++ b/src/api/helpers/notifications/update-read-status-helper.ts
@@ -3,5 +3,9 @@ import { getNotificationsApi } from '../../api';
 const notificationsApi = getNotificationsApi();
 
 export async function updateNotificationReadStatus(config) {
-  return await notificationsApi.updateNotificationReadStatus(config);
+  return await notificationsApi.updateNotificationReadStatus(config, {
+    headers: {
+      'Content-Type': 'application/json',
+    },
+  });
 }

--- a/src/components/NotificationsDrawer/NotificationItem.tsx
+++ b/src/components/NotificationsDrawer/NotificationItem.tsx
@@ -63,7 +63,13 @@ const NotificationItem: React.FC<NotificationItemProps> = ({
       key="manage-event"
       onClick={() =>
         onNavigateTo(
-          `/settings/notifications/configure-events?bundle=${notification.bundle}&tab=configuration`
+          `/settings/notifications/configure-events?${new URLSearchParams({
+            bundle: notification.bundle,
+            tab: 'configuration',
+            app: notification.source,
+            name: notification.title,
+            autoEdit: 'true',
+          }).toString()}`
         )
       }
     >
@@ -75,7 +81,7 @@ const NotificationItem: React.FC<NotificationItemProps> = ({
       <NotificationDrawerList>
         <NotificationDrawerListItem
           aria-label={`Notification item ${notification.title}`}
-          variant="info"
+          variant={notification.read ? undefined : 'info'}
           isRead={notification.read}
         >
           <NotificationDrawerListItemHeader title={notification.title} srTitle="Info notification:">

--- a/src/components/NotificationsDrawer/__tests__/NotificationItem.test.tsx
+++ b/src/components/NotificationsDrawer/__tests__/NotificationItem.test.tsx
@@ -1,0 +1,120 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import NotificationItem from '../NotificationItem';
+import { NotificationData } from '../../../types/Drawer';
+
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children: string }) => React.createElement('div', null, children),
+}));
+jest.mock('remark-gfm', () => ({ __esModule: true, default: () => {} }));
+
+jest.mock('../../../api/helpers/notifications/update-read-status-helper', () => ({
+  updateNotificationReadStatus: jest.fn(() => Promise.resolve()),
+}));
+
+const makeNotification = (id: string, read: boolean, selected = false): NotificationData => ({
+  id,
+  title: `Notification ${id}`,
+  description: 'Test description',
+  read,
+  selected,
+  source: 'test-source',
+  bundle: 'rhel',
+  created: new Date().toISOString(),
+});
+
+const renderNotificationItem = (
+  notification: NotificationData,
+  updateNotificationSelected = jest.fn(),
+  updateNotificationRead = jest.fn(),
+  onNavigateTo = jest.fn()
+) => {
+  return render(
+    <NotificationItem
+      notification={notification}
+      onNavigateTo={onNavigateTo}
+      updateNotificationSelected={updateNotificationSelected}
+      updateNotificationRead={updateNotificationRead}
+    />
+  );
+};
+
+describe('NotificationItem variant based on read status', () => {
+  it('renders with info variant when notification is unread', () => {
+    const notification = makeNotification('1', false);
+    renderNotificationItem(notification);
+
+    const listItem = screen.getByRole('listitem');
+    expect(listItem).toHaveClass('pf-m-info');
+  });
+
+  it('renders without info variant when notification is read', () => {
+    const notification = makeNotification('1', true);
+    renderNotificationItem(notification);
+
+    const listItem = screen.getByRole('listitem');
+    expect(listItem).not.toHaveClass('pf-m-info');
+  });
+
+  it('applies isRead attribute when notification is read', () => {
+    const notification = makeNotification('1', true);
+    renderNotificationItem(notification);
+
+    const listItem = screen.getByRole('listitem');
+    expect(listItem).toHaveClass('pf-m-read');
+  });
+
+  it('does not apply isRead attribute when notification is unread', () => {
+    const notification = makeNotification('1', false);
+    renderNotificationItem(notification);
+
+    const listItem = screen.getByRole('listitem');
+    expect(listItem).not.toHaveClass('pf-m-read');
+  });
+});
+
+describe('NotificationItem read/unread toggle', () => {
+  it('shows "Mark as read" option when notification is unread', async () => {
+    const notification = makeNotification('1', false);
+    renderNotificationItem(notification);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Notification actions dropdown' }));
+    expect(screen.getByText('Mark as read')).toBeInTheDocument();
+  });
+
+  it('shows "Mark as unread" option when notification is read', async () => {
+    const notification = makeNotification('1', true);
+    renderNotificationItem(notification);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Notification actions dropdown' }));
+    expect(screen.getByText('Mark as unread')).toBeInTheDocument();
+  });
+});
+
+describe('NotificationItem interactions', () => {
+  it('calls updateNotificationSelected when checkbox is toggled', async () => {
+    const notification = makeNotification('1', false, false);
+    const updateNotificationSelected = jest.fn();
+    renderNotificationItem(notification, updateNotificationSelected);
+
+    const checkbox = screen.getByRole('checkbox', { name: '' });
+    await userEvent.click(checkbox);
+
+    expect(updateNotificationSelected).toHaveBeenCalledWith('1', true);
+  });
+
+  it('calls onNavigateTo when "Manage this event" is clicked', async () => {
+    const notification = makeNotification('1', false);
+    const onNavigateTo = jest.fn();
+    renderNotificationItem(notification, jest.fn(), jest.fn(), onNavigateTo);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Notification actions dropdown' }));
+    await userEvent.click(screen.getByText('Manage this event'));
+
+    expect(onNavigateTo).toHaveBeenCalledWith(
+      expect.stringContaining('/settings/notifications/configure-events')
+    );
+  });
+});


### PR DESCRIPTION
### Description
Fixes "Mark as read" action. Previously, the action would not send the right request and visually there was no difference between a notification that new and one that was marked as read. 

---

### Screenshots

<img width="414" height="372" alt="Screenshot From 2026-05-04 10-08-15" src="https://github.com/user-attachments/assets/ae6510be-a24d-48b9-b36e-844fd3d8da75" />


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
