### PR TITLE
fix(drawer): Add notifications addColumnHeader prop, update notfications log page

### DIFF
--- a/.rhcicd/frontend.yaml
+++ b/.rhcicd/frontend.yaml
@@ -19,15 +19,15 @@ objects:
           - v1
         specs:
           - url: https://console.redhat.com/api/notifications/v1/openapi.json
-            bundleLabels: ["settings"]
+            bundleLabels: ['settings']
           - url: https://console.redhat.com/api/notifications/v2/openapi.json
-            bundleLabels: ["settings"]
+            bundleLabels: ['settings']
       frontend:
         paths:
           - /apps/notifications
       image: ${IMAGE}:${IMAGE_TAG}
       module:
-        manifestLocation: "/apps/notifications/fed-mods.json"
+        manifestLocation: '/apps/notifications/fed-mods.json'
         defaultDocumentTitle: Notifications | Settings
         config:
           supportCaseData:
@@ -35,11 +35,11 @@ objects:
             version: Notifications
 
         modules:
-        - id: notifications
-          module: "./RootApp"
-          routes:
-          - pathname: "/settings/notifications"
-          - pathname: "/settings/integrations/splunk-setup"
+          - id: notifications
+            module: './RootApp'
+            routes:
+              - pathname: '/settings/notifications'
+              - pathname: '/settings/integrations/splunk-setup'
 
       bundleSegments:
         - segmentId: notifications-settings
@@ -49,29 +49,37 @@ objects:
               id: notifications
               expandable: true
               routes:
-              - id: notificationOverview
-                icon: PlaceholderIcon
-                title: Overview
-                href: "/settings/notifications"
-              - id: configureEvents
-                title: Configure Events
-                href: "/settings/notifications/configure-events"
-                permissions:
-                - method: loosePermissions
-                  args:
-                  - - integrations:*:*
-                    - integrations:endpoints:write
-              - id: eventLog
-                title: Event Log
-                href: "/settings/notifications/eventlog"
-                permissions:
-                - method: loosePermissions
-                  args:
-                  - - notifications:*:*
-                    - notifications:notifications:write
-              - id: myUserPreferences
-                title: Notification Preferences
-                href: "/settings/notifications/user-preferences"
+                - id: notificationOverview
+                  icon: PlaceholderIcon
+                  title: Overview
+                  href: '/settings/notifications'
+                - id: configureEvents
+                  title: Configure Events
+                  href: '/settings/notifications/configure-events'
+                  permissions:
+                    - method: loosePermissions
+                      args:
+                        - - integrations:*:*
+                          - integrations:endpoints:write
+                - id: eventLog
+                  title: Event Log
+                  href: '/settings/notifications/eventlog'
+                  permissions:
+                    - method: loosePermissions
+                      args:
+                        - - notifications:*:*
+                          - notifications:notifications:write
+                - id: notificationsLog
+                  title: Notifications Log
+                  href: '/settings/notifications/notificationslog'
+                  permissions:
+                    - method: loosePermissions
+                      args:
+                        - - notifications:*:*
+                          - notifications:notifications:write
+                - id: myUserPreferences
+                  title: Notification Preferences
+                  href: '/settings/notifications/user-preferences'
           position: 1000
 
       searchEntries:
@@ -79,17 +87,17 @@ objects:
           title: Notifications
           href: /settings/notifications
           description: A standardized way of notifying users of events for supported services on the Hybrid Cloud Console.
-      
+
       widgetRegistry:
         - scope: notifications
-          module: "./DashboardWidget"
+          module: './DashboardWidget'
           featureFlag: widget.notifications.enable
           config:
             icon: BellIcon
             title: Events
             headerLink:
               title: View event log
-              href: "/settings/notifications/eventlog"
+              href: '/settings/notifications/eventlog'
             permissions:
               - method: isOrgAdmin
           defaults:

--- a/src/components/Notifications/EventLog/EventLogTable.tsx
+++ b/src/components/Notifications/EventLog/EventLogTable.tsx
@@ -48,6 +48,7 @@ export interface EventLogTableProps {
   sortColumn: EventLogTableColumns;
   sortDirection: SortDirection;
   getIntegrationRecipient: GetIntegrationRecipient;
+  actionColumnHeader?: string;
 }
 
 export enum EventLogTableColumns {
@@ -236,7 +237,7 @@ export const EventLogTable: React.FunctionComponent<EventLogTableProps> = (props
             <Th sort={sortOptions[EventLogTableColumns.SEVERITY]}>Severity</Th>
           )}
           <Th>
-            Action taken{' '}
+            {props.actionColumnHeader ?? 'Action taken'}{' '}
             <ActionsHelpPopover>
               <Button icon={<HelpIcon />} variant={ButtonVariant.plain} />
             </ActionsHelpPopover>

--- a/src/pages/Notifications/NotificationsLog/Page.tsx
+++ b/src/pages/Notifications/NotificationsLog/Page.tsx
@@ -1,179 +1,172 @@
-import { Card } from '@patternfly/react-core';
-import Main from '@redhat-cloud-services/frontend-components/Main';
-import { format, sub, toDate } from 'date-fns';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useFlag } from '@unleash/proxy-client-react';
+import assertNever from 'assert-never';
+import * as React from 'react';
+import { useParameterizedQuery } from 'react-fetching-library';
 
-import { NotificationsLogDateFilterValue } from '../../../components/Notifications/NotificationsLog/NotificationsLogDateFilter';
-import NotificationsLogTable, {
-  DrawerType,
-  PaginationType,
-} from '../../../components/Notifications/NotificationsLog/NotificationsLogTable';
-import NotificationsLogToolbar from '../../../components/Notifications/NotificationsLog/NotificationsLogToolbar';
+import { EventLogDateFilterValue } from '../../../components/Notifications/EventLog/EventLogDateFilter';
+import { EventLogFilters } from '../../../components/Notifications/EventLog/EventLogFilter';
+import {
+  EventLogTable,
+  EventLogTableColumns,
+  SortDirection,
+} from '../../../components/Notifications/EventLog/EventLogTable';
+import { EventLogToolbar } from '../../../components/Notifications/EventLog/EventLogToolbar';
 import { PageHeader } from '../../../components/PageHeader';
+import Config from '../../../config/Config';
+import { Schemas } from '../../../generated/OpenapiIntegrations';
+import { usePage } from '../../../hooks/usePage';
 import { Messages } from '../../../properties/Messages';
-import { Filter, Operator, toUtc } from '../../../utils/insights-common-typescript';
-
-export type NotificationsPeriod = [Date | undefined, Date | undefined];
-
-const sortMapper = {
-  0: 'title',
-  2: 'created',
-};
+import { useGetEvents } from '../../../services/EventLog/GetNotificationEvents';
+import { getEndpointAction } from '../../../services/Integrations/GetEndpoint';
+import { useGetBundles } from '../../../services/Notifications/GetBundles';
+import { EventPeriod } from '../../../types/Event';
+import { UUID } from '../../../types/Notification';
+import { useEventLogFilter } from '../EventLog/useEventLogFilter';
+import { useFilterBuilder } from '../EventLog/useFilterBuilder';
+import { Direction, Sort } from '../../../utils/insights-common-typescript';
 
 const RETENTION_DAYS = 14;
 
-const filterPeriodMapper = (dateFilter) => {
-  const today = toUtc(new Date());
-  const yesterday = sub(toDate(today), {
-    days: 1,
-  });
-  return {
-    [NotificationsLogDateFilterValue.LAST_14]: [
-      sub(toDate(today), {
-        days: 14,
-      }),
-      today,
-    ],
-    [NotificationsLogDateFilterValue.LAST_7]: [
-      sub(toDate(today), {
-        days: 7,
-      }),
-      today,
-    ],
-    [NotificationsLogDateFilterValue.TODAY]: [today, today],
-    [NotificationsLogDateFilterValue.YESTERDAY]: [yesterday, yesterday],
-  }[dateFilter];
-};
-
-const createFilter = (dateFilter, period) => {
-  const filterPeriod = [undefined, undefined] as [Date | undefined, Date | undefined];
-  const DATE_FORMAT = 'yyyy-MM-dd';
-  const filter = new Filter();
-
-  filterPeriodMapper(dateFilter) || period;
-
-  if (filterPeriod[0] && filterPeriod[1]) {
-    filter.and('start', Operator.EQUAL, format(filterPeriod[0], DATE_FORMAT));
-    filter.and('end', Operator.EQUAL, format(filterPeriod[1], DATE_FORMAT));
-  }
-
-  return {
-    startDate: filterPeriod[0] ? format(filterPeriod[0], DATE_FORMAT) : undefined,
-    endDate: filterPeriod[1] ? format(filterPeriod[1], DATE_FORMAT) : undefined,
-  };
-};
-
 export const NotificationsLogPage: React.FunctionComponent = () => {
-  const [data, setData] = useState<DrawerType>([]);
-  const [period, setPeriod] = useState<NotificationsPeriod>([undefined, undefined]);
-  const [dateFilter, setDateFilter] = useState<NotificationsLogDateFilterValue>(
-    NotificationsLogDateFilterValue.LAST_14
-  );
-  const [pagination, setPagination] = useState<PaginationType>({
-    offset: 0,
-    limit: 20,
-    count: 0,
-  });
-  const [sort, setSort] = useState<{
-    columnIndex: number;
-    direction: 'asc' | 'desc';
-  }>({
-    columnIndex: 2,
-    direction: 'desc',
-  });
+  const isEventLogSeverityEnabled = useFlag('platform.notifications.severity');
+  const getEndpoint = useParameterizedQuery(getEndpointAction);
 
-  const filterBuilder = useMemo(
-    () => createFilter(dateFilter, period),
-    [dateFilter, period[0]?.toString(), period[1]?.toString()] // eslint-disable-line react-hooks/exhaustive-deps
-  );
-
-  //TODO: use new JS client instead of directly calling fetch
-  const callApi = useCallback((pagination, sort, filterBuilder) => {
-    const search = new URLSearchParams({
-      offset: `${pagination.offset}`,
-      limit: `${pagination.limit}`,
-      sort_by: `${sortMapper[sort.columnIndex]}:${sort.direction}`,
-    });
-
-    if (filterBuilder.startDate) {
-      search.append('startDate', filterBuilder.startDate + 'T00:00:00');
+  const getBundles = useGetBundles(true);
+  const bundles = React.useMemo(() => {
+    const payload = getBundles.payload;
+    if (payload?.status === 200) {
+      return payload.value;
     }
 
-    if (filterBuilder.endDate) {
-      search.append('endDate', filterBuilder.endDate + 'T23:59:59');
+    return [];
+  }, [getBundles.payload]);
+
+  const [dateFilter, setDateFilter] = React.useState<EventLogDateFilterValue>(
+    EventLogDateFilterValue.LAST_14
+  );
+
+  const eventLogFilters = useEventLogFilter();
+
+  const [period, setPeriod] = React.useState<EventPeriod>([undefined, undefined]);
+
+  const [sortDirection, setSortDirection] = React.useState<SortDirection>('desc');
+  const [sortColumn, setSortColumn] = React.useState<EventLogTableColumns>(
+    EventLogTableColumns.DATE
+  );
+
+  const onSort = React.useCallback(
+    (column: EventLogTableColumns, direction: SortDirection) => {
+      setSortDirection(direction);
+      setSortColumn(column);
+    },
+    [setSortDirection, setSortColumn]
+  );
+
+  const filterBuilder = useFilterBuilder(bundles, dateFilter, period);
+
+  const sort: Sort = React.useMemo(() => {
+    const direction = sortDirection.toUpperCase() as Direction;
+    let column: string;
+    switch (sortColumn) {
+      case EventLogTableColumns.DATE:
+        column = 'created';
+        break;
+      default:
+        column = 'created';
+        break;
     }
 
-    fetch(`/api/notifications/v1/notifications/drawer?${search.toString()}`)
-      .then((response) => {
-        if (!response.ok) {
-          throw new Error('Network response was not ok');
+    return Sort.by(column, direction);
+  }, [sortColumn, sortDirection]);
+
+  const eventsPage = usePage<EventLogFilters>(
+    Config.paging.defaultPerPage,
+    filterBuilder,
+    eventLogFilters.filters,
+    sort
+  );
+  const eventsQuery = useGetEvents(eventsPage.page);
+
+  const events = React.useMemo(() => {
+    if (eventsQuery.payload?.status === 200) {
+      const allData = eventsQuery.payload.value.data;
+      const withActions = allData.filter((e) => e.actions.length > 0);
+      return {
+        data: withActions,
+        count: eventsQuery.payload.value.meta.count,
+      };
+    }
+
+    return {
+      data: [],
+      count: 0,
+    };
+  }, [eventsQuery]);
+
+  const getIntegrationRecipient = React.useCallback(
+    async (id: UUID) => {
+      const query = getEndpoint.query;
+      const endpoint = await query(id);
+      if (endpoint.payload?.type === 'Endpoint') {
+        const type = endpoint.payload.value.type;
+        switch (type) {
+          case 'camel':
+          case 'webhook':
+          case 'ansible':
+          case 'pagerduty':
+            return endpoint.payload.value.name;
+          case 'email_subscription':
+          case 'drawer': {
+            const properties = endpoint.payload.value
+              .properties as Schemas.SystemSubscriptionProperties;
+            if (properties.only_admins) {
+              return 'Users: Admin';
+            }
+
+            return 'Users: All';
+          }
+          default:
+            assertNever(type);
         }
+      }
 
-        return response.json();
-      })
-      .then((response) => {
-        setData(response.data);
-        setPagination((prevState) => ({
-          ...prevState,
-          count: response.meta.count,
-        }));
-      })
-      .catch((error) => {
-        console.error('Error while fetching data: ', error);
-      });
-  }, []);
-
-  useEffect(() => {
-    callApi(pagination, sort, filterBuilder);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dateFilter, period[0]?.toString(), period[1]?.toString()]);
+      return 'Error while loading';
+    },
+    [getEndpoint.query]
+  );
 
   return (
-    <React.Fragment>
+    <>
       <PageHeader
         title={Messages.pages.notifications.notificationsLog.title}
         subtitle={Messages.pages.notifications.notificationsLog.subtitle}
       />
-      <Main>
-        <Card>
-          <NotificationsLogToolbar
-            pagination={pagination}
-            onPagination={({ limit, offset }) => {
-              setPagination((prevState) => ({ ...prevState, offset, limit }));
-              callApi({ limit, offset }, sort, filterBuilder);
-            }}
-            dateFilter={dateFilter}
-            setDateFilter={setDateFilter}
-            retentionDays={RETENTION_DAYS}
-            period={period}
-            setPeriod={setPeriod}
-          />
-          <NotificationsLogTable
-            isEmptyState={data.length === 0}
-            sort={sort}
-            onSort={(index, direction) => {
-              setSort({
-                columnIndex: index,
-                direction,
-              });
-              callApi(
-                pagination,
-                {
-                  columnIndex: index,
-                  direction,
-                },
-                filterBuilder
-              );
-            }}
-            drawer={data}
-            pagination={pagination}
-            onPagination={({ limit, offset }) => {
-              setPagination((prevState) => ({ ...prevState, offset, limit }));
-              callApi({ limit, offset }, sort, filterBuilder);
-            }}
-          />
-        </Card>
-      </Main>
-    </React.Fragment>
+      <EventLogToolbar
+        {...eventLogFilters}
+        bundleOptions={bundles}
+        dateFilter={dateFilter}
+        setDateFilter={setDateFilter}
+        count={events.count}
+        perPageChanged={eventsPage.changeItemsPerPage}
+        pageChanged={eventsPage.changePage}
+        perPage={eventsPage.page.size}
+        page={eventsPage.page.index}
+        pageCount={events.data.length}
+        retentionDays={RETENTION_DAYS}
+        period={period}
+        setPeriod={setPeriod}
+      >
+        <EventLogTable
+          events={events.data}
+          loading={eventsQuery.loading}
+          showSeverity={isEventLogSeverityEnabled}
+          onSort={onSort}
+          sortColumn={sortColumn}
+          sortDirection={sortDirection}
+          getIntegrationRecipient={getIntegrationRecipient}
+          actionColumnHeader="Type"
+        />
+      </EventLogToolbar>
+    </>
   );
 };

--- a/src/pages/Notifications/NotificationsLog/Page.tsx
+++ b/src/pages/Notifications/NotificationsLog/Page.tsx
@@ -93,7 +93,7 @@ export const NotificationsLogPage: React.FunctionComponent = () => {
       const withActions = allData.filter((e) => e.actions.length > 0);
       return {
         data: withActions,
-        count: eventsQuery.payload.value.meta.count,
+        count: withActions.length,
       };
     }
 

--- a/src/pages/Notifications/NotificationsLog/__tests__/Page.test.tsx
+++ b/src/pages/Notifications/NotificationsLog/__tests__/Page.test.tsx
@@ -127,7 +127,6 @@ describe('src/pages/Notifications/NotificationsLog/Page', () => {
     await waitForAsyncEvents();
 
     const rows = screen.getAllByRole('row');
-    // 1 header row + 2 data rows (event without action is excluded)
     expect(rows.length).toBe(3);
   });
 });

--- a/src/pages/Notifications/NotificationsLog/__tests__/Page.test.tsx
+++ b/src/pages/Notifications/NotificationsLog/__tests__/Page.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from '@testing-library/react';
+import fetchMock from 'fetch-mock';
+import * as React from 'react';
+
+import {
+  appWrapperCleanup,
+  appWrapperSetup,
+  getConfiguredAppWrapper,
+} from '../../../../../test/AppWrapper';
+import { waitForAsyncEvents } from '../../../../../test/TestUtils';
+import { NotificationsLogPage } from '../Page';
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => {
+  return () => ({ getBundle: () => 'settings', getEnvironment: () => 'prod' });
+});
+
+const mockBundles = [
+  {
+    id: 'bundle-1',
+    name: 'rhel',
+    displayName: 'Red Hat Enterprise Linux',
+    children: [{ id: 'app-1', name: 'advisor', displayName: 'Advisor' }],
+  },
+  {
+    id: 'bundle-2',
+    name: 'openshift',
+    displayName: 'OpenShift',
+    children: [],
+  },
+];
+
+const makeEvent = (id: string, withActions = true) => ({
+  id,
+  bundle: 'rhel',
+  application: 'advisor',
+  event_type: 'new-recommendation',
+  created: '2024-01-15T10:00:00.000',
+  severity: null,
+  actions: withActions
+    ? [
+        {
+          id: `action-${id}`,
+          endpoint_id: `endpoint-${id}`,
+          endpoint_type: 'webhook',
+          endpoint_sub_type: null,
+          status: 'SUCCESS' as const,
+        },
+      ]
+    : [],
+});
+
+const mockEventsResponse = (events: ReturnType<typeof makeEvent>[]) => ({
+  data: events,
+  meta: { count: events.length },
+  links: {},
+});
+
+describe('src/pages/Notifications/NotificationsLog/Page', () => {
+  beforeEach(() => {
+    appWrapperSetup();
+    fetchMock.get(/\/api\/notifications\/v1\.0\/notifications\/facets\/bundles.*/, mockBundles);
+    fetchMock.get(/\/api\/notifications\/v1\.0\/notifications\/severities.*/, []);
+  });
+
+  afterEach(() => {
+    appWrapperCleanup();
+  });
+
+  it('renders the page header with correct title and subtitle', async () => {
+    fetchMock.get(/\/api\/notifications\/v1\.0\/notifications\/events.*/, mockEventsResponse([]));
+
+    render(<NotificationsLogPage />, { wrapper: getConfiguredAppWrapper() });
+    await waitForAsyncEvents();
+
+    expect(screen.getByRole('heading', { name: /notifications log/i })).toBeInTheDocument();
+    expect(
+      screen.getByText(/view details for all notifications delivered to my notification drawer/i)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the "Type" action column header', async () => {
+    fetchMock.get(
+      /\/api\/notifications\/v1\.0\/notifications\/events.*/,
+      mockEventsResponse([makeEvent('evt-1')])
+    );
+
+    render(<NotificationsLogPage />, { wrapper: getConfiguredAppWrapper() });
+    await waitForAsyncEvents();
+
+    expect(screen.getByText('Type')).toBeInTheDocument();
+    expect(screen.queryByText('Action taken')).not.toBeInTheDocument();
+  });
+
+  it('renders events returned by the API', async () => {
+    fetchMock.get(
+      /\/api\/notifications\/v1\.0\/notifications\/events.*/,
+      mockEventsResponse([makeEvent('evt-1'), makeEvent('evt-2')])
+    );
+
+    render(<NotificationsLogPage />, { wrapper: getConfiguredAppWrapper() });
+    await waitForAsyncEvents();
+
+    const rows = screen.getAllByRole('row');
+    // 1 header row + 2 data rows
+    expect(rows.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('shows empty state when no events are returned', async () => {
+    fetchMock.get(/\/api\/notifications\/v1\.0\/notifications\/events.*/, mockEventsResponse([]));
+
+    render(<NotificationsLogPage />, { wrapper: getConfiguredAppWrapper() });
+    await waitForAsyncEvents();
+
+    expect(screen.getByText(/no matching events found/i)).toBeInTheDocument();
+  });
+
+  it('filters out events with no actions', async () => {
+    const eventsWithActions = [makeEvent('evt-1'), makeEvent('evt-2')];
+    const eventsWithoutActions = [makeEvent('evt-no-action', false)];
+
+    fetchMock.get(
+      /\/api\/notifications\/v1\.0\/notifications\/events.*/,
+      mockEventsResponse([...eventsWithActions, ...eventsWithoutActions])
+    );
+
+    render(<NotificationsLogPage />, { wrapper: getConfiguredAppWrapper() });
+    await waitForAsyncEvents();
+
+    const rows = screen.getAllByRole('row');
+    // 1 header row + 2 data rows (event without action is excluded)
+    expect(rows.length).toBe(3);
+  });
+});


### PR DESCRIPTION


### Description
Adds a Notifications Log page, a filtered view of the Event Log showing only events that triggered at least one notification action, with the "Action taken" column  relabeled to "Type" and a matching left nav entry.

[RHCLOUD-46541](https://issues.redhat.com/browse/RHCLOUD-46541)

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##


[RHCLOUD-46541]: https://redhat.atlassian.net/browse/RHCLOUD-46541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ