### PR TITLE
feat(Kessel): Check permissions based on kessel feature flag

### DIFF
--- a/cypress/components/NotificationsDrawer.cy.tsx
+++ b/cypress/components/NotificationsDrawer.cy.tsx
@@ -36,21 +36,11 @@ const notificationDrawerData: NotificationData[] = [
   },
 ];
 
-const notificationPerms = [
-  {
-    resourceDefinitions: [],
-    permission: 'notifications:*:*',
-  },
-  {
-    resourceDefinitions: [],
-    permission: 'notifications:notifications:read',
-  },
-];
-
 const DrawerLayout = ({ markAll = false }: { markAll?: boolean }) => {
   const drawerPanelRef = useRef<HTMLDivElement>(null);
   const [isExpanded, setIsExpanded] = useState(false);
-  const { initialize, addNotification } = DrawerSingleton.Instance;
+  const { initialize, addNotification, setHasNotificationsPermissions } =
+    DrawerSingleton.Instance;
   const toggleDrawer = () => setIsExpanded((prev) => !prev);
   const notificationProps = {
     panelRef: drawerPanelRef,
@@ -76,7 +66,8 @@ const DrawerLayout = ({ markAll = false }: { markAll?: boolean }) => {
         <button
           id="populate-notifications"
           onClick={async () => {
-            await initialize(true, notificationPerms, () => () => {});
+            setHasNotificationsPermissions(true);
+            await initialize(true, () => () => {});
             notificationDrawerData.map((item) => addNotification({ ...item, read: markAll }));
           }}
         >
@@ -94,9 +85,6 @@ const DrawerLayout = ({ markAll = false }: { markAll?: boolean }) => {
 describe('Notification Drawer', () => {
   beforeEach(() => {
     cy.viewport(1200, 800);
-    cy.intercept('GET', '/api/rbac/v1/access/?application=notifications&limit=1000', {
-      data: notificationPerms,
-    });
     cy.intercept('GET', '/api/notifications/v1/notifications/drawer?limit=50&startDate=*', {
       data: [],
     });

--- a/fec.config.js
+++ b/fec.config.js
@@ -53,7 +53,7 @@ module.exports = {
       ),
       './NotificationsDrawerBell': path.resolve(
         __dirname,
-        './src/components/NotificationsDrawer/DrawerBell.tsx'
+        './src/components/NotificationsDrawer/DrawerBellEntry.tsx'
       ),
       './DrawerPanel': path.resolve(
         __dirname,

--- a/src/components/NotificationsDrawer/DrawerBellEntry.tsx
+++ b/src/components/NotificationsDrawer/DrawerBellEntry.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+
+import DrawerBell from './DrawerBell';
+import DrawerPermissionsSync from './DrawerPermissionsSync';
+import { NotificationsDrawerProvider } from './NotificationsDrawerProvider';
+
+interface DrawerBellProps {
+  isNotificationDrawerExpanded: boolean;
+}
+
+const DrawerBellEntry: React.ComponentType<DrawerBellProps> = (props) => (
+  <NotificationsDrawerProvider>
+    <DrawerPermissionsSync />
+    <DrawerBell {...props} />
+  </NotificationsDrawerProvider>
+);
+
+export default DrawerBellEntry;

--- a/src/components/NotificationsDrawer/DrawerPermissionsSync.tsx
+++ b/src/components/NotificationsDrawer/DrawerPermissionsSync.tsx
@@ -1,0 +1,34 @@
+import { useFlag } from '@unleash/proxy-client-react';
+import React, { useEffect } from 'react';
+
+import {
+  useV1HasNotificationsPermissions,
+  useV2HasNotificationsPermissions,
+} from '../../hooks/useHasNotificationsPermissions';
+import { DrawerSingleton } from './DrawerSingleton';
+
+type UsePermissionsHook = () => boolean | undefined;
+
+const PermissionsSyncBranch = ({ usePermissions }: { usePermissions: UsePermissionsHook }) => {
+  const hasPermissions = usePermissions();
+
+  useEffect(() => {
+    if (hasPermissions !== undefined) {
+      DrawerSingleton.Instance.setHasNotificationsPermissions(hasPermissions);
+    }
+  }, [hasPermissions]);
+
+  return null;
+};
+
+const DrawerPermissionsSync = () => {
+  const isV2Org = useFlag('platform.rbac.workspaces');
+
+  return (
+    <PermissionsSyncBranch
+      usePermissions={isV2Org ? useV2HasNotificationsPermissions : useV1HasNotificationsPermissions}
+    />
+  );
+};
+
+export default DrawerPermissionsSync;

--- a/src/components/NotificationsDrawer/DrawerSingleton.tsx
+++ b/src/components/NotificationsDrawer/DrawerSingleton.tsx
@@ -1,6 +1,4 @@
-import { Access, AccessApi } from '@redhat-cloud-services/rbac-client';
 import { ChromeAPI } from '@redhat-cloud-services/types';
-import axios from 'axios';
 import { getDateDaysAgo } from '../UtcDate';
 
 import { getBundleFacets } from '../../api/helpers/notifications/bundle-facets-helper';
@@ -13,8 +11,6 @@ import {
   NotificationDrawerState,
   isNotificationData,
 } from '../../types/Drawer';
-
-const rbacApi = new AccessApi(undefined, '/api/rbac/v1', axios.create());
 
 interface Bundle {
   id: string;
@@ -45,11 +41,7 @@ export class DrawerSingleton {
     // Run the init procedure if the state is not ready for subscriber
     if (!DrawerSingleton._state.initializing && !DrawerSingleton._state.ready) {
       DrawerSingleton._state.initializing = true;
-      rbacApi
-        .getPrincipalAccess('notifications', undefined, undefined, 1000)
-        .then(({ data: { data } }) =>
-          DrawerSingleton.Instance.initialize(true, data, addWsEventListener)
-        )
+      DrawerSingleton.Instance.initialize(true, addWsEventListener)
         .then(() => {
           DrawerSingleton._state.ready = true;
         })
@@ -77,15 +69,12 @@ export class DrawerSingleton {
     return DrawerSingleton._instance;
   }
 
-  // initialize function calls the three functions below
   public initialize = async (
     mounted: boolean,
-    permissions: Access[],
     addWsEventListener?: ChromeAPI['addWsEventListener']
   ) => {
     await this.fetchFilterConfig(mounted);
     await this.getNotifications();
-    await this.setNotificationsPermissions(mounted, permissions);
     if (addWsEventListener) {
       addWsEventListener('com.redhat.console.notifications.drawer', (event) => {
         if (isNotificationData(event.data)) {
@@ -100,20 +89,6 @@ export class DrawerSingleton {
   public static getState() {
     return DrawerSingleton._state;
   }
-
-  private setNotificationsPermissions = async (mounted: boolean, permissions) => {
-    if (mounted) {
-      DrawerSingleton._state.hasNotificationsPermissions =
-        permissions?.some((item) =>
-          [
-            'notifications:*:*',
-            'notifications:notifications:read',
-            'notifications:notifications:write',
-          ].includes((typeof item === 'string' && item) || item?.permission)
-        ) || false;
-      DrawerSingleton._subs.forEach((sub) => sub.rerenderer());
-    }
-  };
 
   private fetchFilterConfig = async (mounted: boolean) => {
     if (!mounted) {

--- a/src/components/NotificationsDrawer/NotificationsDrawerProvider.tsx
+++ b/src/components/NotificationsDrawer/NotificationsDrawerProvider.tsx
@@ -1,0 +1,12 @@
+import { AccessCheck } from '@project-kessel/react-kessel-access-check';
+import * as React from 'react';
+
+import { KesselRbacAccessProvider } from '../../app/rbac/KesselRbacAccessProvider';
+
+export const NotificationsDrawerProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => (
+  <AccessCheck.Provider baseUrl={window.location.origin} apiPath="/api/kessel/v1beta2">
+    <KesselRbacAccessProvider>{children}</KesselRbacAccessProvider>
+  </AccessCheck.Provider>
+);

--- a/src/components/NotificationsDrawer/__tests__/drawerNotificationsPermissions.test.ts
+++ b/src/components/NotificationsDrawer/__tests__/drawerNotificationsPermissions.test.ts
@@ -1,0 +1,40 @@
+import { hasV1DrawerNotificationsPermissions } from '../drawerNotificationsPermissions';
+
+describe('hasV1DrawerNotificationsPermissions', () => {
+  it('returns true for read permission', () => {
+    expect(
+      hasV1DrawerNotificationsPermissions([
+        { permission: 'notifications:notifications:read', resourceDefinitions: [] },
+      ])
+    ).toBe(true);
+  });
+
+  it('returns true for write permission', () => {
+    expect(
+      hasV1DrawerNotificationsPermissions([
+        { permission: 'notifications:notifications:write', resourceDefinitions: [] },
+      ])
+    ).toBe(true);
+  });
+
+  it('returns true for wildcard permission', () => {
+    expect(
+      hasV1DrawerNotificationsPermissions([
+        { permission: 'notifications:*:*', resourceDefinitions: [] },
+      ])
+    ).toBe(true);
+  });
+
+  it('returns false for unrelated permissions', () => {
+    expect(
+      hasV1DrawerNotificationsPermissions([
+        { permission: 'notifications:events:read', resourceDefinitions: [] },
+      ])
+    ).toBe(false);
+  });
+
+  it('returns false when permissions are empty', () => {
+    expect(hasV1DrawerNotificationsPermissions([])).toBe(false);
+    expect(hasV1DrawerNotificationsPermissions(undefined)).toBe(false);
+  });
+});

--- a/src/components/NotificationsDrawer/drawerNotificationsPermissions.ts
+++ b/src/components/NotificationsDrawer/drawerNotificationsPermissions.ts
@@ -1,0 +1,16 @@
+import { Access } from '@redhat-cloud-services/rbac-client';
+
+export const DRAWER_NOTIFICATIONS_V1_PERMISSIONS = [
+  'notifications:*:*',
+  'notifications:notifications:read',
+  'notifications:notifications:write',
+] as const;
+
+const isDrawerNotificationsV1Permission = (permission: string | undefined): boolean =>
+  DRAWER_NOTIFICATIONS_V1_PERMISSIONS.some((allowed) => allowed === permission);
+
+export const hasV1DrawerNotificationsPermissions = (permissions: Access[] | undefined): boolean =>
+  permissions?.some((item) => {
+    const permission = (typeof item === 'string' && item) || item?.permission;
+    return isDrawerNotificationsV1Permission(permission);
+  }) ?? false;

--- a/src/hooks/useHasNotificationsPermissions.ts
+++ b/src/hooks/useHasNotificationsPermissions.ts
@@ -1,0 +1,38 @@
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
+import { useEffect, useState } from 'react';
+
+import { useKesselRbacAccess } from '../app/rbac/KesselRbacAccessContext';
+import { hasV1DrawerNotificationsPermissions } from '../components/NotificationsDrawer/drawerNotificationsPermissions';
+
+export const useV1HasNotificationsPermissions = (): boolean | undefined => {
+  const chrome = useChrome();
+  const [hasPermissions, setHasPermissions] = useState<boolean | undefined>();
+
+  useEffect(() => {
+    chrome
+      .getUserPermissions('notifications')
+      .then((permissions) => {
+        setHasPermissions(hasV1DrawerNotificationsPermissions(permissions));
+      })
+      .catch(() => {
+        setHasPermissions(false);
+      });
+  }, [chrome]);
+
+  return hasPermissions;
+};
+
+export const useV2HasNotificationsPermissions = (): boolean | undefined => {
+  const { permissions, isLoading, workspaceId } = useKesselRbacAccess();
+  console.log('DEBUG permissions', permissions);
+
+  if (isLoading) {
+    return undefined;
+  }
+
+  if (!workspaceId) {
+    return false;
+  }
+
+  return permissions.canViewNotifications || permissions.canEditNotifications;
+};


### PR DESCRIPTION
### Description
Check permissions for notifications based on kessel feature flag.

How to test:

1. Using this PR navigate to https://stage.foo.redhat.com:1337/settings/notifications/
2. If you are using org with v2 enabled - see that there is no v1 calls, and kessel call is in place
3. If you are using org with v2 disabled - see v1 call is made

---

### Screenshots

#### Before:
(when kessel is enabled for org) v1 is still called:
<img width="1318" height="784" alt="Screenshot 2026-06-01 at 16 08 59" src="https://github.com/user-attachments/assets/4eac3bb0-879b-4b31-afd7-939c37ac8f96" />

#### After:
(kessel is enabled for org) no v1 call, but kessel `checkselfbulk`
<img width="1318" height="784" alt="Screenshot 2026-06-01 at 16 06 15" src="https://github.com/user-attachments/assets/9511d1f7-5eb8-4524-9ba8-21b0682efb60" />
<img width="1318" height="784" alt="Screenshot 2026-06-01 at 16 06 25" src="https://github.com/user-attachments/assets/3f7be1cd-499c-4084-9046-66994b701f84" />

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
