### PR TITLE
feat(integrations): Use standard /endpoints API for email subscriptio…

### DIFF
--- a/src/api/helpers/integrations/endpoints-helper.ts
+++ b/src/api/helpers/integrations/endpoints-helper.ts
@@ -20,30 +20,20 @@ export async function createEndpoint(
   afterSubmit?: () => void
 ) {
   try {
-    // Handle email subscription integrations with special endpoint
-    if (config.type === 'email_subscription') {
-      const emailData = {
-        only_admins: false, // Default to false, could be made configurable
-        group_id: config.user_access_groups?.[0]?.id, // Use the first selected group's ID
-      };
+    // For email subscriptions, map user_access_groups to the correct properties shape.
+    // The regular /endpoints API now accepts email_subscription type directly.
+    const endpointConfig =
+      config.type === 'email_subscription'
+        ? {
+            ...config,
+            properties: {
+              only_admins: false,
+              group_id: config.user_access_groups?.[0]?.id,
+            },
+          }
+        : config;
 
-      // Use the email subscription specific API
-      const response = await fetch('/api/integrations/v1.0/endpoints/system/email_subscription', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(emailData),
-      });
-
-      if (!response.ok) {
-        const error = await response.text();
-        throw new Error(`Failed to create email subscription: ${response.status} - ${error}`);
-      }
-    } else {
-      // Use standard endpoint for other integrations
-      await integrationsApi.createEndpoint(config);
-    }
+    await integrationsApi.createEndpoint(endpointConfig);
 
     notifications.addSuccessNotification(
       'Integration created',


### PR DESCRIPTION
### Description
Consolidates email subscription endpoint creation to use the standard /endpoints API instead of emailsubscription-specific fetch call.

[RHCLOUD-43424](https://issues.redhat.com/browse/RHCLOUD-43424)

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##


[RHCLOUD-43424]: https://redhat.atlassian.net/browse/RHCLOUD-43424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ