### PR TITLE
fix(Drawer): Update panel-level dropdown

### DIFF
--- a/src/components/NotificationsDrawer/ActionDropdown.stories.tsx
+++ b/src/components/NotificationsDrawer/ActionDropdown.stories.tsx
@@ -1,0 +1,98 @@
+import React, { useState } from 'react';
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { ActionDropdown } from './Dropdowns';
+
+const InteractiveActionDropdown = ({
+  selectedCount = 0,
+  isOrgAdmin = false,
+}: {
+  selectedCount?: number;
+  isOrgAdmin?: boolean;
+}) => {
+  const [isDropdownOpen, setIsDropdownOpen] = useState(true);
+
+  const onUpdateSelectedStatus = (read: boolean) => {
+    console.log(`Mark ${selectedCount} notifications as ${read ? 'read' : 'unread'}`);
+  };
+
+  const onNavigateTo = (link: string) => {
+    console.log(`Navigate to: ${link}`);
+  };
+
+  return (
+    <ActionDropdown
+      isDropdownOpen={isDropdownOpen}
+      setIsDropdownOpen={setIsDropdownOpen}
+      selectedCount={selectedCount}
+      onUpdateSelectedStatus={onUpdateSelectedStatus}
+      onNavigateTo={onNavigateTo}
+      isOrgAdmin={isOrgAdmin}
+    />
+  );
+};
+
+const meta: Meta<typeof ActionDropdown> = {
+  title: 'Components/ActionDropdown',
+  component: ActionDropdown,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '300px', height: '500px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof ActionDropdown>;
+
+export const NoSelection: Story = {
+  render: () => <InteractiveActionDropdown selectedCount={0} isOrgAdmin={true} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Action dropdown with no notifications selected. Both bulk action items ("Mark selected (0) as read/unread") are disabled.',
+      },
+    },
+  },
+};
+
+export const WithSelection: Story = {
+  render: () => <InteractiveActionDropdown selectedCount={3} isOrgAdmin={true} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Action dropdown with 3 notifications selected. Bulk action items show "Mark selected (3) as read/unread" and are enabled.',
+      },
+    },
+  },
+};
+
+export const NonAdminUser: Story = {
+  render: () => <InteractiveActionDropdown selectedCount={2} isOrgAdmin={false} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Action dropdown for non-admin user. "Manage event configuration" is disabled with "Admin-access required" tooltip.',
+      },
+    },
+  },
+};
+
+export const AdminUser: Story = {
+  render: () => <InteractiveActionDropdown selectedCount={2} isOrgAdmin={true} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Action dropdown for admin user. All menu items including "Manage event configuration" are enabled.',
+      },
+    },
+  },
+};

--- a/src/components/NotificationsDrawer/DrawerPanel.tsx
+++ b/src/components/NotificationsDrawer/DrawerPanel.tsx
@@ -190,11 +190,10 @@ const DrawerPanelBase = ({ toggleDrawer }: DrawerPanelProps) => {
         <ActionDropdown
           isDropdownOpen={isDropdownOpen}
           setIsDropdownOpen={toggleDropdown}
-          isDisabled={state.notificationData.length === 0}
+          selectedCount={state.notificationData.filter(({ selected }) => selected).length}
           onUpdateSelectedStatus={onUpdateSelectedStatus}
           onNavigateTo={onNavigateTo}
           isOrgAdmin={isOrgAdmin}
-          hasNotificationsPermissions={state.hasNotificationsPermissions}
         />
       </NotificationDrawerHeader>
       {state.filters.length > 0 && (

--- a/src/components/NotificationsDrawer/DrawerSingleton.tsx
+++ b/src/components/NotificationsDrawer/DrawerSingleton.tsx
@@ -156,7 +156,10 @@ export class DrawerSingleton {
         notification_ids: selected.map((notification) => notification.id),
         read_status: read,
       }).then(() => {
-        selected.forEach((notification) => this.updateNotificationRead(notification.id, read));
+        selected.forEach((notification) => {
+          this.updateNotificationRead(notification.id, read);
+          this.updateNotificationSelected(notification.id, false);
+        });
       });
     } catch (e) {
       console.error('failed to update notification read status', e);

--- a/src/components/NotificationsDrawer/DrawerSingleton.tsx
+++ b/src/components/NotificationsDrawer/DrawerSingleton.tsx
@@ -156,10 +156,15 @@ export class DrawerSingleton {
         notification_ids: selected.map((notification) => notification.id),
         read_status: read,
       }).then(() => {
-        selected.forEach((notification) => {
-          this.updateNotificationRead(notification.id, read);
-          this.updateNotificationSelected(notification.id, false);
-        });
+        const selectedIds = new Set(selected.map((n) => n.id));
+        DrawerSingleton._state.notificationData = DrawerSingleton._state.notificationData.map(
+          (notification) =>
+            selectedIds.has(notification.id)
+              ? { ...notification, read, selected: false }
+              : notification
+        );
+        DrawerSingleton._state.hasUnread = this.hasUnreadNotifications();
+        DrawerSingleton._subs.forEach((sub) => sub.rerenderer());
       });
     } catch (e) {
       console.error('failed to update notification read status', e);

--- a/src/components/NotificationsDrawer/Dropdowns.tsx
+++ b/src/components/NotificationsDrawer/Dropdowns.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useIntl } from 'react-intl';
 
 import {
   MenuToggle,
@@ -21,6 +22,7 @@ import { Tooltip } from '@patternfly/react-core/dist/dynamic/components/Tooltip'
 
 import FilterIcon from '@patternfly/react-icons/dist/dynamic/icons/filter-icon';
 import EllipsisVIcon from '@patternfly/react-icons/dist/dynamic/icons/ellipsis-v-icon';
+import messages from '../../properties/DefinedMessages';
 
 export const FilterDropdown = ({
   isFilterDropdownOpen,
@@ -127,6 +129,7 @@ const ActionDropdownItems = ({
   onNavigateTo,
   isOrgAdmin,
 }) => {
+  const intl = useIntl();
   const isBulkActionDisabled = selectedCount === 0;
 
   return (
@@ -137,14 +140,14 @@ const ActionDropdownItems = ({
           onClick={() => onUpdateSelectedStatus(true)}
           isDisabled={isBulkActionDisabled}
         >
-          Mark Selected ({selectedCount}) as read
+          {intl.formatMessage(messages.markSelectedAsRead, { count: selectedCount })}
         </DropdownItem>
         <DropdownItem
           key="unread selected"
           onClick={() => onUpdateSelectedStatus(false)}
           isDisabled={isBulkActionDisabled}
         >
-          Mark Selected ({selectedCount}) as unread
+          {intl.formatMessage(messages.markSelectedAsUnread, { count: selectedCount })}
         </DropdownItem>
       </DropdownList>
       <Divider />
@@ -153,23 +156,23 @@ const ActionDropdownItems = ({
           key="event log"
           onClick={() => onNavigateTo('/settings/notifications/eventlog')}
         >
-          View event log
+          {intl.formatMessage(messages.viewEventLog)}
         </DropdownItem>
         <DropdownItem
           key="event notifications"
           onClick={() => onNavigateTo('/settings/notifications/user-preferences')}
         >
-          Manage my event notifications
+          {intl.formatMessage(messages.manageMyEventNotifications)}
         </DropdownItem>
         {!isOrgAdmin ? (
-          <Tooltip content="Admin-access required">
+          <Tooltip content={intl.formatMessage(messages.adminAccessRequired)}>
             <span>
               <DropdownItem
                 key="event configuration"
                 onClick={() => onNavigateTo('/settings/notifications/configure-events')}
                 isDisabled={true}
               >
-                Manage event configuration
+                {intl.formatMessage(messages.manageEventConfiguration)}
               </DropdownItem>
             </span>
           </Tooltip>
@@ -178,7 +181,7 @@ const ActionDropdownItems = ({
             key="event configuration"
             onClick={() => onNavigateTo('/settings/notifications/configure-events')}
           >
-            Manage event configuration
+            {intl.formatMessage(messages.manageEventConfiguration)}
           </DropdownItem>
         )}
       </DropdownList>

--- a/src/components/NotificationsDrawer/Dropdowns.tsx
+++ b/src/components/NotificationsDrawer/Dropdowns.tsx
@@ -6,7 +6,6 @@ import {
 } from '@patternfly/react-core/dist/dynamic/components/MenuToggle';
 import {
   Dropdown,
-  DropdownGroup,
   DropdownItem,
   DropdownList,
 } from '@patternfly/react-core/dist/dynamic/components/Dropdown';
@@ -18,6 +17,7 @@ import { MenuFooter } from '@patternfly/react-core/dist/dynamic/components/Menu'
 import { Divider } from '@patternfly/react-core/dist/dynamic/components/Divider';
 import { PopoverPosition } from '@patternfly/react-core/dist/dynamic/components/Popover';
 import { Button } from '@patternfly/react-core/dist/dynamic/components/Button';
+import { Tooltip } from '@patternfly/react-core/dist/dynamic/components/Tooltip';
 
 import FilterIcon from '@patternfly/react-icons/dist/dynamic/icons/filter-icon';
 import EllipsisVIcon from '@patternfly/react-icons/dist/dynamic/icons/ellipsis-v-icon';
@@ -86,11 +86,10 @@ export const FilterDropdown = ({
 export const ActionDropdown = ({
   isDropdownOpen,
   setIsDropdownOpen,
-  isDisabled,
+  selectedCount,
   onUpdateSelectedStatus,
   onNavigateTo,
   isOrgAdmin,
-  hasNotificationsPermissions,
 }) => {
   return (
     <Dropdown
@@ -113,68 +112,76 @@ export const ActionDropdown = ({
       id="notifications-actions-dropdown"
     >
       <ActionDropdownItems
-        isDisabled={isDisabled}
+        selectedCount={selectedCount}
         onUpdateSelectedStatus={onUpdateSelectedStatus}
         onNavigateTo={onNavigateTo}
         isOrgAdmin={isOrgAdmin}
-        hasNotificationsPermissions={hasNotificationsPermissions}
       />
     </Dropdown>
   );
 };
 
 const ActionDropdownItems = ({
-  isDisabled,
+  selectedCount,
   onUpdateSelectedStatus,
   onNavigateTo,
   isOrgAdmin,
-  hasNotificationsPermissions,
 }) => {
+  const isBulkActionDisabled = selectedCount === 0;
+
   return (
     <>
-      <DropdownGroup label="Actions">
-        <DropdownList>
-          <DropdownItem
-            key="read selected"
-            onClick={() => onUpdateSelectedStatus(true)}
-            isDisabled={isDisabled}
-          >
-            Mark selected as read
-          </DropdownItem>
-          <DropdownItem
-            key="unread selected"
-            onClick={() => onUpdateSelectedStatus(false)}
-            isDisabled={isDisabled}
-          >
-            Mark selected as unread
-          </DropdownItem>
-        </DropdownList>
-      </DropdownGroup>
+      <DropdownList>
+        <DropdownItem
+          key="read selected"
+          onClick={() => onUpdateSelectedStatus(true)}
+          isDisabled={isBulkActionDisabled}
+        >
+          Mark Selected ({selectedCount}) as read
+        </DropdownItem>
+        <DropdownItem
+          key="unread selected"
+          onClick={() => onUpdateSelectedStatus(false)}
+          isDisabled={isBulkActionDisabled}
+        >
+          Mark Selected ({selectedCount}) as unread
+        </DropdownItem>
+      </DropdownList>
       <Divider />
-      <DropdownGroup label="Quick links">
-        <DropdownList>
+      <DropdownList>
+        <DropdownItem
+          key="event log"
+          onClick={() => onNavigateTo('/settings/notifications/eventlog')}
+        >
+          View event log
+        </DropdownItem>
+        <DropdownItem
+          key="event notifications"
+          onClick={() => onNavigateTo('/settings/notifications/user-preferences')}
+        >
+          Manage my event notifications
+        </DropdownItem>
+        {!isOrgAdmin ? (
+          <Tooltip content="Admin-access required">
+            <span>
+              <DropdownItem
+                key="event configuration"
+                onClick={() => onNavigateTo('/settings/notifications/configure-events')}
+                isDisabled={true}
+              >
+                Manage event configuration
+              </DropdownItem>
+            </span>
+          </Tooltip>
+        ) : (
           <DropdownItem
-            key="notifications log"
-            onClick={() => onNavigateTo('/settings/notifications/notificationslog')}
+            key="event configuration"
+            onClick={() => onNavigateTo('/settings/notifications/configure-events')}
           >
-            View notifications log
+            Manage event configuration
           </DropdownItem>
-          {(isOrgAdmin || hasNotificationsPermissions) && (
-            <DropdownItem
-              key="notification settings"
-              onClick={() => onNavigateTo('/settings/notifications/configure-events')}
-            >
-              Configure notification settings
-            </DropdownItem>
-          )}
-          <DropdownItem
-            key="notification preferences"
-            onClick={() => onNavigateTo('/settings/notifications/user-preferences')}
-          >
-            Manage my notification preferences
-          </DropdownItem>
-        </DropdownList>
-      </DropdownGroup>
+        )}
+      </DropdownList>
     </>
   );
 };

--- a/src/properties/DefinedMessages.ts
+++ b/src/properties/DefinedMessages.ts
@@ -138,4 +138,34 @@ export default defineMessages({
     description: 'severity',
     defaultMessage: 'Severity',
   },
+  markSelectedAsRead: {
+    id: 'markSelectedAsRead',
+    description: 'Mark selected notifications as read',
+    defaultMessage: 'Mark selected ({count}) as read',
+  },
+  markSelectedAsUnread: {
+    id: 'markSelectedAsUnread',
+    description: 'Mark selected notifications as unread',
+    defaultMessage: 'Mark selected ({count}) as unread',
+  },
+  viewEventLog: {
+    id: 'viewEventLog',
+    description: 'View event log menu item',
+    defaultMessage: 'View event log',
+  },
+  manageMyEventNotifications: {
+    id: 'manageMyEventNotifications',
+    description: 'Manage my event notifications menu item',
+    defaultMessage: 'Manage my event notifications',
+  },
+  manageEventConfiguration: {
+    id: 'manageEventConfiguration',
+    description: 'Manage event configuration menu item',
+    defaultMessage: 'Manage event configuration',
+  },
+  adminAccessRequired: {
+    id: 'adminAccessRequired',
+    description: 'Admin access required tooltip',
+    defaultMessage: 'Admin-access required',
+  },
 });


### PR DESCRIPTION
### Description
- Eliminated "Actions" and "Quick links" labels while keeping the divider between sections
- Changed to "Mark Selected (N) as read/unread" with live count updates 
- Now disabled only when no notifications are selected
-Updated navigation labels:
    - "View notifications log" → "View event log"
    - "Configure notification settings" → "Manage event configuration"
    - "Manage my notification preferences" → "Manage my event notifications"
- "Manage event configuration" is disabled for non-admin users with "Admin-access required" tooltip
- "View event log" now points to /settings/notifications/eventlog

[RHCLOUD-48098](https://redhat.atlassian.net/browse/RHCLOUD-48098)

---

### Screenshots
no admin access:
<img width="429" height="291" alt="Screenshot From 2026-06-08 09-47-39" src="https://github.com/user-attachments/assets/3aafbe06-4780-42b2-8831-9a3190ee027b" />

with admin access:
<img width="429" height="291" alt="Screenshot From 2026-06-08 09-48-29" src="https://github.com/user-attachments/assets/c086b64a-2507-4add-a474-6068feb8c7be" />

<img width="429" height="291" alt="Screenshot From 2026-06-08 09-48-55" src="https://github.com/user-attachments/assets/b5bec5b0-9acc-48da-9cf2-dd699d54dcbe" />

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##


[RHCLOUD-48098]: https://redhat.atlassian.net/browse/RHCLOUD-48098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ