### PR TITLE
chore(severity): Remove undefined from ui

### DIFF
--- a/src/components/Integrations/EventTypes.stories.tsx
+++ b/src/components/Integrations/EventTypes.stories.tsx
@@ -77,7 +77,7 @@ const mockEventTypes = [
     application: { id: 'app-3', display_name: 'Drift', name: 'drift', bundle_id: 'bundle-1' },
     display_name: 'Comparison completed',
     name: 'comparison-completed',
-    // No severity — tests the fallback
+    // No severity — tests the blank severity cell
   },
 ];
 
@@ -139,7 +139,7 @@ type Story = StoryObj<typeof EventTypes>;
 /**
  * Default view showing event types with severity column.
  * Demonstrates severity labels with icons for CRITICAL, IMPORTANT,
- * MODERATE, LOW, NONE, and the fallback for undefined severity.
+ * MODERATE, LOW, NONE, and a blank cell for undefined severity.
  */
 export const Default: Story = {
   parameters: {

--- a/src/components/Integrations/EventTypes.tsx
+++ b/src/components/Integrations/EventTypes.tsx
@@ -31,6 +31,7 @@ import { EventType, Facet } from '../../types/Notification';
 import { debouncePromise } from '../../pages/Integrations/Create/nameValidator';
 import { perPageOptions } from '../../config/Config';
 import {
+  hasDisplayableSeverity,
   severityDescription,
   severityDisplayName,
   toSeverityLabelProps,
@@ -157,19 +158,15 @@ const EventTypes: React.FC<EventTypesProps> = ({
 
   const renderSeverityCell = (event: EventType) => {
     const severity = event.defaultSeverity;
-    if (severity) {
-      return (
-        <Tooltip content={severityDescription[severity]}>
-          <Label {...toSeverityLabelProps(severity)}>
-            {severityDisplayName[severity] ?? severity}
-          </Label>
-        </Tooltip>
-      );
+    if (!hasDisplayableSeverity(severity)) {
+      return null;
     }
 
     return (
-      <Tooltip content={severityDescription.UNDEFINED}>
-        <Label {...toSeverityLabelProps(undefined)}>{severityDisplayName.UNDEFINED}</Label>
+      <Tooltip content={severityDescription[severity]}>
+        <Label {...toSeverityLabelProps(severity)}>
+          {severityDisplayName[severity] ?? severity}
+        </Label>
       </Tooltip>
     );
   };

--- a/src/components/Notifications/EventLog/EventLogTable.tsx
+++ b/src/components/Notifications/EventLog/EventLogTable.tsx
@@ -30,6 +30,7 @@ import { Messages } from '../../../properties/Messages';
 import { NotificationEvent, NotificationEventStatus } from '../../../types/Event';
 import { GetIntegrationRecipient } from '../../../types/Integration';
 import {
+  hasDisplayableSeverity,
   severityDescription,
   severityDisplayName,
   toSeverityLabelProps,
@@ -169,19 +170,13 @@ export const EventLogTable: React.FunctionComponent<EventLogTableProps> = (props
           </Td>
           {showSeverity && (
             <Td>
-              {e.severity ? (
+              {hasDisplayableSeverity(e.severity) ? (
                 <Tooltip content={severityDescription[e.severity]}>
                   <Label {...toSeverityLabelProps(e.severity)}>
                     {severityDisplayName[e.severity] ?? e.severity}
                   </Label>
                 </Tooltip>
-              ) : (
-                <Tooltip content={severityDescription.UNDEFINED}>
-                  <Label {...toSeverityLabelProps(undefined)}>
-                    {severityDisplayName.UNDEFINED}
-                  </Label>
-                </Tooltip>
-              )}
+              ) : null}
             </Td>
           )}
           <Td>

--- a/src/components/Notifications/EventLog/EventLogToolbar.stories.tsx
+++ b/src/components/Notifications/EventLog/EventLogToolbar.stories.tsx
@@ -421,6 +421,17 @@ const meta: Meta<typeof EventLogToolbar> = {
 export default meta;
 type Story = StoryObj<typeof EventLogToolbar>;
 
+/** Toolbar + table; events without severity leave the severity cell blank. */
+export const BlankSeverityForMissingValue: Story = {
+  render: () => <ToolbarWithEvents />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await canvas.findByPlaceholderText('Filter by event');
+    await waitFor(() => expect(canvas.getByText('Legacy event (no severity)')).toBeVisible());
+    expect(canvas.queryByText('Undefined')).not.toBeInTheDocument();
+  },
+};
+
 /** Toolbar + table with mock data; no filter changes (initial “Event” filter only). */
 export const Default: Story = {
   render: () => <ToolbarWithEvents />,

--- a/src/components/Notifications/EventLog/EventLogToolbar.tsx
+++ b/src/components/Notifications/EventLog/EventLogToolbar.tsx
@@ -154,20 +154,22 @@ export const EventLogToolbar: React.FunctionComponent<
     const severities: EventSeverity[] =
       severitiesQuery.payload?.status === 200 ? severitiesQuery.payload.value : SEVERITY_VALUES;
 
-    return severities.map((severity: EventSeverity) => {
-      const labelProps = toSeverityLabelProps(severity);
+    return severities
+      .filter((severity) => severity !== 'UNDEFINED')
+      .map((severity: EventSeverity) => {
+        const labelProps = toSeverityLabelProps(severity);
 
-      return {
-        value: severity,
-        chipValue: severityDisplayName[severity],
-        label: (
-          <span>
-            <span style={{ color: getSeverityIconColor(severity) }}>{labelProps.icon}</span>{' '}
-            {severityDisplayName[severity]}
-          </span>
-        ),
-      };
-    });
+        return {
+          value: severity,
+          chipValue: severityDisplayName[severity],
+          label: (
+            <span>
+              <span style={{ color: getSeverityIconColor(severity) }}>{labelProps.icon}</span>{' '}
+              {severityDisplayName[severity]}
+            </span>
+          ),
+        };
+      });
   }, [severitiesQuery.payload]);
 
   const filterMetadata = React.useMemo<Partial<ColumnsMetada<typeof EventLogFilterColumn>>>(() => {

--- a/src/components/Notifications/EventLog/__tests__/EventLogFilter.test.tsx
+++ b/src/components/Notifications/EventLog/__tests__/EventLogFilter.test.tsx
@@ -8,6 +8,15 @@ import { EventLogFilters, SetEventLogFilters } from '../EventLogFilter';
 import { EventLogToolbar } from '../EventLogToolbar';
 import { EventLogTreeFilter } from '../EventLogTreeFilter';
 
+jest.mock('../../../../services/Notifications/GetSeverities', () => ({
+  useGetSeverities: jest.fn(() => ({
+    payload: {
+      status: 200,
+      value: ['CRITICAL', 'IMPORTANT', 'MODERATE', 'LOW', 'NONE', 'UNDEFINED'],
+    },
+  })),
+}));
+
 const applications = [
   {
     id: '3',
@@ -45,27 +54,30 @@ const setFilters = {
   severities: jest.fn(),
 };
 
+const renderToolbar = () =>
+  render(
+    <EventLogToolbar
+      filters={{} as EventLogFilters}
+      setFilters={setFilters as unknown as SetEventLogFilters}
+      clearFilter={jest.fn()}
+      bundleOptions={[]}
+      pageCount={0}
+      count={0}
+      page={0}
+      perPage={0}
+      pageChanged={jest.fn()}
+      perPageChanged={jest.fn()}
+      dateFilter={{} as EventLogDateFilterValue}
+      setDateFilter={jest.fn()}
+      retentionDays={0}
+      period={{} as EventPeriod}
+      setPeriod={jest.fn()}
+    />
+  );
+
 describe('src/components/Notifications/EventLog', () => {
   it('Render and verify filtering options', async () => {
-    render(
-      <EventLogToolbar
-        filters={{} as EventLogFilters}
-        setFilters={setFilters as unknown as SetEventLogFilters}
-        clearFilter={jest.fn()}
-        bundleOptions={[]}
-        pageCount={0}
-        count={0}
-        page={0}
-        perPage={0}
-        pageChanged={jest.fn()}
-        perPageChanged={jest.fn()}
-        dateFilter={{} as EventLogDateFilterValue}
-        setDateFilter={jest.fn()}
-        retentionDays={0}
-        period={{} as EventPeriod}
-        setPeriod={jest.fn()}
-      />
-    );
+    renderToolbar();
 
     const filterDropdownBtn = screen.getAllByRole('button')[0];
     await userEvent.click(filterDropdownBtn);
@@ -78,6 +90,19 @@ describe('src/components/Notifications/EventLog', () => {
     expect(filterDropdown[2]).toHaveTextContent('Action Type');
     expect(filterDropdown[3]).toHaveTextContent('Action Status');
     expect(filterDropdown[4]).toHaveTextContent('Severity');
+  });
+
+  it('does not offer Undefined as a severity filter option', async () => {
+    renderToolbar();
+
+    const filterDropdownBtn = screen.getAllByRole('button')[0];
+    await userEvent.click(filterDropdownBtn);
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Severity' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Options menu' }));
+
+    expect(screen.queryByText('Undefined')).not.toBeInTheDocument();
+    expect(screen.getByText('Critical')).toBeVisible();
+    expect(screen.getByText('None')).toBeVisible();
   });
 
   it('Render custom Service filter and perform basic tree filtering', async () => {

--- a/src/components/Notifications/EventLog/__tests__/EventLogTable.test.tsx
+++ b/src/components/Notifications/EventLog/__tests__/EventLogTable.test.tsx
@@ -1,8 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import React from 'react';
+
+import { NotificationEvent } from '../../../../types/Event';
 import {
+  EventLogTable,
+  EventLogTableColumns,
   eventLogSeverityLabelStyles,
   severityDescription,
   toSeverityLabelProps,
 } from '../EventLogTable';
+
+const mockGetIntegrationRecipient = jest.fn(async () => 'mock integration');
+
+const baseEvent: NotificationEvent = {
+  id: 'evt-1',
+  event: 'Test event',
+  application: 'advisor',
+  bundle: 'rhel',
+  date: new Date('2024-06-01T12:00:00Z'),
+  actions: [],
+};
+
+const renderEventLogTable = (events: NotificationEvent[]) =>
+  render(
+    <IntlProvider locale="en">
+      <EventLogTable
+        events={events}
+        loading={false}
+        showSeverity={true}
+        onSort={jest.fn()}
+        sortColumn={EventLogTableColumns.DATE}
+        sortDirection="desc"
+        getIntegrationRecipient={mockGetIntegrationRecipient}
+      />
+    </IntlProvider>
+  );
 
 describe('EventLogTable severity', () => {
   describe.each(['CRITICAL', 'IMPORTANT', 'MODERATE', 'LOW', 'NONE'] as const)(
@@ -52,5 +85,29 @@ describe('EventLogTable severity', () => {
         expect(severityDescription[severity].length).toBeGreaterThan(0);
       }
     );
+  });
+
+  describe('rendering', () => {
+    it('renders a severity label for defined severity values', () => {
+      renderEventLogTable([{ ...baseEvent, severity: 'CRITICAL' }]);
+
+      expect(screen.getByText('Critical')).toBeVisible();
+    });
+
+    it('leaves the severity cell blank when severity is missing', () => {
+      renderEventLogTable([{ ...baseEvent, event: 'Legacy event (no severity)' }]);
+
+      expect(screen.getByText('Legacy event (no severity)')).toBeVisible();
+      expect(screen.queryByText('Undefined')).not.toBeInTheDocument();
+    });
+
+    it('leaves the severity cell blank when severity is UNDEFINED', () => {
+      renderEventLogTable([
+        { ...baseEvent, event: 'Event without severity type', severity: 'UNDEFINED' },
+      ]);
+
+      expect(screen.getByText('Event without severity type')).toBeVisible();
+      expect(screen.queryByText('Undefined')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/types/adapters/NotificationAdapter.ts
+++ b/src/types/adapters/NotificationAdapter.ts
@@ -1,6 +1,7 @@
 import { assertNever } from 'assert-never';
 import produce, { castDraft } from 'immer';
 import { Schemas } from '../../generated/OpenapiIntegrations';
+import { normalizeSeverity } from '../../utils/severityUtils';
 import {
   IntegrationEmailSubscription,
   ServerIntegrationResponse,
@@ -62,7 +63,7 @@ export const toNotification = (serverNotification: ServerNotificationResponse): 
     applicationDisplayName: serverNotification.application.display_name,
     eventTypeDisplayName: serverNotification.display_name,
     description: serverNotification.description || undefined,
-    defaultSeverity: serverNotification.default_severity || undefined,
+    defaultSeverity: normalizeSeverity(serverNotification.default_severity),
   };
 };
 

--- a/src/types/adapters/NotificationEventAdapter.ts
+++ b/src/types/adapters/NotificationEventAdapter.ts
@@ -1,8 +1,9 @@
 import { Schemas } from '../../generated/OpenapiNotifications';
+import { normalizeSeverity } from '../../utils/severityUtils';
+import { fromUtc } from '../../utils/insights-common-typescript';
 import { NotificationEvent, NotificationEventAction } from '../Event';
 import { UUID } from '../Notification';
 import { getIntegrationType } from './IntegrationAdapter';
-import { fromUtc } from '../../utils/insights-common-typescript';
 
 type ServerEvent = Schemas.EventLogEntry;
 
@@ -13,7 +14,7 @@ export const toNotificationEvent = (serverEvent: ServerEvent): NotificationEvent
   event: serverEvent.event_type,
   date: fromUtc(new Date(serverEvent.created)),
   actions: sortEventActions(groupActions(serverEvent.actions)),
-  severity: serverEvent.severity ?? undefined,
+  severity: normalizeSeverity(serverEvent.severity),
 });
 
 const sortEventActions = (actions: Array<NotificationEventAction>) => {

--- a/src/types/adapters/__tests__/NotificationAdapter.test.ts
+++ b/src/types/adapters/__tests__/NotificationAdapter.test.ts
@@ -42,14 +42,24 @@ describe('NotificationAdapter', () => {
       expect(result.defaultSeverity).toBe('CRITICAL');
     });
 
-    it('maps all severity values correctly', () => {
-      const severities = ['CRITICAL', 'IMPORTANT', 'MODERATE', 'LOW', 'NONE', 'UNDEFINED'] as const;
+    it('maps defined severity values correctly', () => {
+      const severities = ['CRITICAL', 'IMPORTANT', 'MODERATE', 'LOW', 'NONE'] as const;
 
       for (const severity of severities) {
         const server = makeServerEventType({ default_severity: severity });
         const result = toNotification(server);
         expect(result.defaultSeverity).toBe(severity);
       }
+    });
+
+    it('sets defaultSeverity to undefined when API returns UNDEFINED', () => {
+      const server = makeServerEventType({
+        default_severity: 'UNDEFINED',
+      });
+
+      const result = toNotification(server);
+
+      expect(result.defaultSeverity).toBeUndefined();
     });
 
     it('sets defaultSeverity to undefined when API omits it', () => {

--- a/src/types/adapters/__tests__/NotificationEventAdapter.test.ts
+++ b/src/types/adapters/__tests__/NotificationEventAdapter.test.ts
@@ -161,4 +161,26 @@ describe('src/types/adapters/NotificationEventAdapter', () => {
       actions: [],
     });
   });
+
+  it('toNotificationEvent treats UNDEFINED severity as undefined', () => {
+    const event: ServerEvent = {
+      id: 'undefined-sev-id',
+      event_type: 'undefined-sev-event',
+      application: 'undefined-sev-app',
+      bundle: 'undefined-sev-bundle',
+      created: '2024-01-01 12:00:00.000',
+      severity: 'UNDEFINED',
+      actions: [],
+    };
+
+    expect(toNotificationEvent(event)).toStrictEqual({
+      id: 'undefined-sev-id',
+      bundle: 'undefined-sev-bundle',
+      application: 'undefined-sev-app',
+      event: 'undefined-sev-event',
+      date: new Date('2024-01-01T12:00:00.000Z'),
+      severity: undefined,
+      actions: [],
+    });
+  });
 });

--- a/src/utils/__tests__/severityUtils.test.tsx
+++ b/src/utils/__tests__/severityUtils.test.tsx
@@ -1,11 +1,45 @@
 import {
   SEVERITY_VALUES,
+  hasDisplayableSeverity,
+  normalizeSeverity,
   severityDescription,
   severityDisplayName,
   toSeverityLabelProps,
 } from '../severityUtils';
 
 describe('severityUtils', () => {
+  describe('normalizeSeverity', () => {
+    it.each(['CRITICAL', 'IMPORTANT', 'MODERATE', 'LOW', 'NONE'] as const)(
+      'returns %s unchanged',
+      (severity) => {
+        expect(normalizeSeverity(severity)).toBe(severity);
+      }
+    );
+
+    it.each([undefined, null, 'UNDEFINED'] as const)(
+      'returns undefined for empty severity values',
+      (severity) => {
+        expect(normalizeSeverity(severity)).toBeUndefined();
+      }
+    );
+  });
+
+  describe('hasDisplayableSeverity', () => {
+    it.each(['CRITICAL', 'IMPORTANT', 'MODERATE', 'LOW', 'NONE'] as const)(
+      'returns true for %s',
+      (severity) => {
+        expect(hasDisplayableSeverity(severity)).toBe(true);
+      }
+    );
+
+    it.each([undefined, null, 'UNDEFINED'] as const)(
+      'returns false for empty severity values',
+      (severity) => {
+        expect(hasDisplayableSeverity(severity)).toBe(false);
+      }
+    );
+  });
+
   describe('toSeverityLabelProps', () => {
     it.each(['CRITICAL', 'IMPORTANT', 'MODERATE', 'LOW', 'NONE'] as const)(
       'returns an icon and style for %s severity',
@@ -42,12 +76,15 @@ describe('severityUtils', () => {
       }
     );
 
-    it('maps to human-readable names', () => {
+    it('maps to human-readable names for displayable severities', () => {
       expect(severityDisplayName.CRITICAL).toBe('Critical');
       expect(severityDisplayName.IMPORTANT).toBe('Important');
       expect(severityDisplayName.MODERATE).toBe('Moderate');
       expect(severityDisplayName.LOW).toBe('Low');
       expect(severityDisplayName.NONE).toBe('None');
+    });
+
+    it('keeps an internal mapping for UNDEFINED without surfacing it in the UI', () => {
       expect(severityDisplayName.UNDEFINED).toBe('Undefined');
     });
   });

--- a/src/utils/severityUtils.tsx
+++ b/src/utils/severityUtils.tsx
@@ -61,6 +61,18 @@ export const eventLogSeverityLabelStyles: Record<EventSeverity, React.CSSPropert
   }),
 };
 
+export const normalizeSeverity = (severity?: EventSeverity | null): EventSeverity | undefined => {
+  if (!severity || severity === 'UNDEFINED') {
+    return undefined;
+  }
+
+  return severity;
+};
+
+export const hasDisplayableSeverity = (
+  severity?: EventSeverity | null
+): severity is Exclude<EventSeverity, 'UNDEFINED'> => normalizeSeverity(severity) !== undefined;
+
 export const toSeverityLabelProps = (
   severity?: EventSeverity
 ): Pick<LabelProps, 'color' | 'icon' | 'style' | 'status' | 'variant'> => {


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
“Undefined” severity does not make sense in Notifications context.
When Notifications backend return an empty value for severity, the UI should leave it blank.

[RHCLOUD-47914](https://issues.redhat.com/browse/RHCLOUD-47914)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:
<img width="1938" height="129" alt="Screenshot 2026-06-09 at 9 53 10 AM" src="https://github.com/user-attachments/assets/3e24efcf-4883-42dc-b61d-a1c9d14c8b29" />

---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##


[RHCLOUD-47914]: https://redhat.atlassian.net/browse/RHCLOUD-47914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ