### PR TITLE
[RHCLOUD-48095] Fix notification item read state color

### DIFF
--- a/src/components/NotificationsDrawer/NotificationItem.tsx
+++ b/src/components/NotificationsDrawer/NotificationItem.tsx
@@ -81,7 +81,7 @@ const NotificationItem: React.FC<NotificationItemProps> = ({
       <NotificationDrawerList>
         <NotificationDrawerListItem
           aria-label={`Notification item ${notification.title}`}
-          variant={notification.read ? undefined : 'info'}
+          variant="info"
           isRead={notification.read}
         >
           <NotificationDrawerListItemHeader title={notification.title} srTitle="Info notification:">

--- a/src/components/NotificationsDrawer/__tests__/NotificationItem.test.tsx
+++ b/src/components/NotificationsDrawer/__tests__/NotificationItem.test.tsx
@@ -50,12 +50,12 @@ describe('NotificationItem variant based on read status', () => {
     expect(listItem).toHaveClass('pf-m-info');
   });
 
-  it('renders without info variant when notification is read', () => {
+  it('renders with info variant when notification is read', () => {
     const notification = makeNotification('1', true);
     renderNotificationItem(notification);
 
     const listItem = screen.getByRole('listitem');
-    expect(listItem).not.toHaveClass('pf-m-info');
+    expect(listItem).toHaveClass('pf-m-info');
   });
 
   it('applies isRead attribute when notification is read', () => {


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
- Now read notification's bell icon stays purple, like the unread state

[RHCLOUD-48095](https://redhat.atlassian.net/browse/RHCLOUD-48095)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
<img width="437" height="616" alt="image" src="https://github.com/user-attachments/assets/01106664-aae1-4b32-812e-f37f47d07d37" />

#### After:
<img width="437" height="616" alt="image" src="https://github.com/user-attachments/assets/11b4f8b2-8159-4b78-99f2-13115dd95914" />

---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##


[RHCLOUD-48095]: https://redhat.atlassian.net/browse/RHCLOUD-48095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ