### PR TITLE
fix(nav): Correct permissions for Event Log and Configure Events nav …

### DIFF
--- a/.rhcicd/frontend.yaml
+++ b/.rhcicd/frontend.yaml
@@ -19,15 +19,15 @@ objects:
           - v1
         specs:
           - url: https://console.redhat.com/api/notifications/v1/openapi.json
-            bundleLabels: ["settings"]
+            bundleLabels: ['settings']
           - url: https://console.redhat.com/api/notifications/v2/openapi.json
-            bundleLabels: ["settings"]
+            bundleLabels: ['settings']
       frontend:
         paths:
           - /apps/notifications
       image: ${IMAGE}:${IMAGE_TAG}
       module:
-        manifestLocation: "/apps/notifications/fed-mods.json"
+        manifestLocation: '/apps/notifications/fed-mods.json'
         defaultDocumentTitle: Notifications | Settings
         config:
           supportCaseData:
@@ -35,11 +35,11 @@ objects:
             version: Notifications
 
         modules:
-        - id: notifications
-          module: "./RootApp"
-          routes:
-          - pathname: "/settings/notifications"
-          - pathname: "/settings/integrations/splunk-setup"
+          - id: notifications
+            module: './RootApp'
+            routes:
+              - pathname: '/settings/notifications'
+              - pathname: '/settings/integrations/splunk-setup'
 
       bundleSegments:
         - segmentId: notifications-settings
@@ -49,29 +49,29 @@ objects:
               id: notifications
               expandable: true
               routes:
-              - id: notificationOverview
-                icon: PlaceholderIcon
-                title: Overview
-                href: "/settings/notifications"
-              - id: configureEvents
-                title: Configure Events
-                href: "/settings/notifications/configure-events"
-                permissions:
-                - method: loosePermissions
-                  args:
-                  - - integrations:*:*
-                    - integrations:endpoints:write
-              - id: eventLog
-                title: Event Log
-                href: "/settings/notifications/eventlog"
-                permissions:
-                - method: loosePermissions
-                  args:
-                  - - notifications:*:*
-                    - notifications:notifications:write
-              - id: myUserPreferences
-                title: Notification Preferences
-                href: "/settings/notifications/user-preferences"
+                - id: notificationOverview
+                  icon: PlaceholderIcon
+                  title: Overview
+                  href: '/settings/notifications'
+                - id: configureEvents
+                  title: Configure Events
+                  href: '/settings/notifications/configure-events'
+                  permissions:
+                    - method: loosePermissions
+                      args:
+                        - - notifications:*:*
+                          - notifications:notifications:read
+                - id: eventLog
+                  title: Event Log
+                  href: '/settings/notifications/eventlog'
+                  permissions:
+                    - method: loosePermissions
+                      args:
+                        - - notifications:*:*
+                          - notifications:events:read
+                - id: myUserPreferences
+                  title: Notification Preferences
+                  href: '/settings/notifications/user-preferences'
           position: 1000
 
       searchEntries:
@@ -79,17 +79,17 @@ objects:
           title: Notifications
           href: /settings/notifications
           description: A standardized way of notifying users of events for supported services on the Hybrid Cloud Console.
-      
+
       widgetRegistry:
         - scope: notifications
-          module: "./DashboardWidget"
+          module: './DashboardWidget'
           featureFlag: widget.notifications.enable
           config:
             icon: BellIcon
             title: Events
             headerLink:
               title: View event log
-              href: "/settings/notifications/eventlog"
+              href: '/settings/notifications/eventlog'
             permissions:
               - method: isOrgAdmin
           defaults:


### PR DESCRIPTION
…items

Fixes issue where v2 org admins (using Kessel RBAC) cannot see Event Log and Configure Events in the left navigation.

**Root Cause:**
The frontend.yaml nav permissions were checking for WRITE permissions when the pages only require READ permissions. This worked for v1 orgs (wildcard permissions grant both read and write) but broke for v2 orgs using Kessel RBAC with granular permissions.

**Changes:**
- Configure Events: Changed from `integrations:endpoints:write` to `notifications:notifications:read`
- Event Log: Changed from `notifications:notifications:write` to `notifications:events:read`

**Impact:**
- v1 org admins: No change (already working)
- v2 org admins: Nav items will now appear ✅

**Why This Happened:**
The platform.rbac.workspaces feature flag was recently enabled for v2 orgs, switching them from v1 RBAC to Kessel v2. The incorrect permissions in frontend.yaml (added in commit 8be075b, April 2025) only became visible when v2 orgs started using granular permissions.

**Verification:**
Tested with both v1 and v2 org admin accounts. Route protection in CheckReadPermissions.tsx already checks the correct READ permissions, so pages load fine when accessed directly - only nav visibility was affected.

Aligns with CheckReadPermissions.tsx (lines 23-26) and useApp.ts RBAC mapping.

### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
description text...

[RHCLOUDXXXX](https://issues.redhat.com/browse/RHCLOUDXXXX)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
