### PR TITLE
fix(svg-contrast): Fix issue with insufficient svg contrast for wizard

### DIFF
--- a/src/pages/Integrations/Create/styling/cardselect.scss
+++ b/src/pages/Integrations/Create/styling/cardselect.scss
@@ -1,6 +1,7 @@
 .src-c-wizard__tile {
   width: 100%;
   text-align: center;
+  background-color: var(--pf-t--global--background--color--600);
 
   .pf-v6-c-tile__header,
   .pf-v6-c-tile__body {


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
Adds an explicit `background-color` to the `.src-c-wizard__tile` component using the PatternFly design token `--pf-t--global--background--color--600`. Without this, the tile's default background does not provide sufficient contrast for SVG icons displayed in the integration creation wizard. This brings the wizard tile in line with accessibility contrast standards.

[RHCLOUD47093](https://issues.redhat.com/browse/RHCLOUD47093)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
<img width="857" height="373" alt="image" src="https://github.com/user-attachments/assets/a7e73a95-f286-4e9e-9ff2-2dc9650e4f25" />
<img width="848" height="369" alt="image" src="https://github.com/user-attachments/assets/05b4fd05-3251-44f2-9a33-b9ef4f02b09f" />


#### After:
<img width="839" height="406" alt="image" src="https://github.com/user-attachments/assets/0adda539-4bc6-46cc-9deb-961f1c968514" />
<img width="853" height="359" alt="image" src="https://github.com/user-attachments/assets/3cb7afca-fd77-4601-bffa-ac185d77fa9b" />


---

### Checklist ☑️
- [X] PR only fixes one issue or story <!-- open new PR for others -->
- [X] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [X] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [X] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
