### PR TITLE
feat(RBAC): Add v1 wildcard fallback for v2 orgs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -326,6 +326,30 @@ The following PatternFly React skills are available via the `pf-react` plugin:
 - Auto-sync every 2 minutes
 - Files: `src/app/rbac/KesselRbacAccessProvider.tsx`, `kesselWorkspaceRelations.ts`
 
+#### V2 RBAC with V1 Wildcard Fallback (TEMPORARY)
+
+**Location**: `src/app/useApp.ts` (lines 79-123)
+
+**Current behavior**: For v2 orgs (determined by `platform.rbac.workspaces` feature flag), we fetch BOTH Kessel v2 permissions AND v1 RBAC, then combine them using OR logic:
+
+```typescript
+canWriteIntegrationsEndpoints: kesselPerms.canWriteIntegrationsEndpoints ||
+  v1Rbac.hasPermission('integrations', 'endpoints', 'write');
+```
+
+**Why this exists**: Kessel v2 does not currently support wildcard permission expansion. Org Admins and some legacy roles have wildcard permissions like `integrations:*:*` or `notifications:*:*` in v1 RBAC. Without the v1 fallback, these users would lose access when moved to v2 orgs.
+
+**Known issue**: This creates a permanent dependency on v1 RBAC for v2 orgs, which defeats the migration purpose. Once we're fully on v2, we still call the v1 RBAC endpoint.
+
+**When to remove**: Remove this fallback logic once EITHER:
+
+1. Kessel v2 supports wildcard permission expansion, OR
+2. All wildcard permissions are migrated to explicit Kessel workspace relations
+
+**Coordinated removal required**: This same pattern exists in `insights-chrome` (see PR #3362). Both repos must be updated together to avoid breaking permissions.
+
+**Reference**: https://github.com/RedHatInsights/insights-chrome/pull/3362
+
 ### Feature Flag Routing
 
 - Unleash flag `platform.notifications.overhaul` controls route sets

--- a/src/app/useApp.ts
+++ b/src/app/useApp.ts
@@ -76,21 +76,50 @@ export const useApp = (): Partial<AppContext> => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Effect to fetch v1 RBAC when org is v1 (no need to wait for Kessel)
+  // Effect to fetch v1 RBAC for ALL orgs (v2 orgs need it for wildcard permission fallback)
+  // This is necessary because Kessel v2 does not support wildcard permission expansion,
+  // so we must check v1 wildcards (integrations:*:*, notifications:*:*) as fallback.
+  // See: https://github.com/RedHatInsights/insights-chrome/pull/3362
   useEffect(() => {
-    if (userLoaded && !isV2Org) {
+    if (userLoaded) {
       fetchRBAC(`${Config.notifications.subAppId},${Config.integrations.subAppId}`).then(setV1Rbac);
     }
-  }, [userLoaded, isV2Org]);
+  }, [userLoaded]);
 
   // Compute final RBAC object based on org version
   const rbac = React.useMemo(() => {
     if (isV2Org) {
-      // v2 org: map Kessel permissions to v1 structure
-      if (isKesselLoading) {
-        return undefined; // Still loading v2 permissions
+      // v2 org: combine Kessel v2 permissions with v1 wildcard fallback
+      // Kessel v2 does not support wildcard expansion, so we must check v1 wildcards
+      // (integrations:*:*, notifications:*:*) as fallback for Org Admins and legacy roles.
+      // See: https://github.com/RedHatInsights/insights-chrome/pull/3362
+      if (isKesselLoading || !v1Rbac) {
+        return undefined; // Still loading
       }
-      return mapKesselToV1Permissions(kesselPermissions);
+
+      const kesselPerms = mapKesselToV1Permissions(kesselPermissions);
+
+      return {
+        // Grant permission if EITHER Kessel v2 OR v1 wildcard check passes
+        canWriteIntegrationsEndpoints:
+          kesselPerms.canWriteIntegrationsEndpoints ||
+          v1Rbac.hasPermission('integrations', 'endpoints', 'write'),
+
+        canReadIntegrationsEndpoints:
+          kesselPerms.canReadIntegrationsEndpoints ||
+          v1Rbac.hasPermission('integrations', 'endpoints', 'read'),
+
+        canWriteNotifications:
+          kesselPerms.canWriteNotifications ||
+          v1Rbac.hasPermission('notifications', 'notifications', 'write'),
+
+        canReadNotifications:
+          kesselPerms.canReadNotifications ||
+          v1Rbac.hasPermission('notifications', 'notifications', 'read'),
+
+        canReadEvents:
+          kesselPerms.canReadEvents || v1Rbac.hasPermission('notifications', 'events', 'read'),
+      };
     } else {
       // v1 org: use traditional v1 RBAC
       if (!v1Rbac) {

--- a/src/app/useApp.ts
+++ b/src/app/useApp.ts
@@ -21,7 +21,11 @@ export const useApp = (): Partial<AppContext> => {
 
   // Get Kessel v2 permissions
   const kesselRbacContext = useKesselRbacAccess();
-  const { permissions: kesselPermissions, isLoading: isKesselLoading } = kesselRbacContext;
+  const {
+    permissions: kesselPermissions,
+    isLoading: isKesselLoading,
+    errors: kesselErrors,
+  } = kesselRbacContext;
 
   // Determine org version using feature flag (v2 if flag enabled, v1 otherwise)
   const isV2Org = useFlag('platform.rbac.workspaces');
@@ -82,9 +86,16 @@ export const useApp = (): Partial<AppContext> => {
   // See: https://github.com/RedHatInsights/insights-chrome/pull/3362
   useEffect(() => {
     if (userLoaded) {
-      fetchRBAC(`${Config.notifications.subAppId},${Config.integrations.subAppId}`).then(setV1Rbac);
+      fetchRBAC(`${Config.notifications.subAppId},${Config.integrations.subAppId}`).then((rbac) => {
+        console.log('[RBAC DEBUG] v1 RBAC loaded:', {
+          // @ts-expect-error - accessing private field for debugging
+          permissions: rbac?.permissions,
+          isOrgAdmin,
+        });
+        setV1Rbac(rbac);
+      });
     }
-  }, [userLoaded]);
+  }, [userLoaded, isOrgAdmin]);
 
   // Compute final RBAC object based on org version
   const rbac = React.useMemo(() => {
@@ -93,11 +104,44 @@ export const useApp = (): Partial<AppContext> => {
       // Kessel v2 does not support wildcard expansion, so we must check v1 wildcards
       // (integrations:*:*, notifications:*:*) as fallback for Org Admins and legacy roles.
       // See: https://github.com/RedHatInsights/insights-chrome/pull/3362
+
+      // If Kessel errors (e.g., no workspace ID), fall back to v1 only
+      const kesselFailed = kesselErrors && kesselErrors.length > 0;
+
+      if (kesselFailed) {
+        console.log('[RBAC DEBUG] Kessel failed, using v1 fallback only:', kesselErrors);
+        if (!v1Rbac) {
+          return undefined; // Still loading v1
+        }
+        // Use v1 permissions only when Kessel fails
+        return {
+          canWriteNotifications: v1Rbac.hasPermission('notifications', 'notifications', 'write'),
+          canReadNotifications: v1Rbac.hasPermission('notifications', 'notifications', 'read'),
+          canWriteIntegrationsEndpoints: v1Rbac.hasPermission('integrations', 'endpoints', 'write'),
+          canReadIntegrationsEndpoints: v1Rbac.hasPermission('integrations', 'endpoints', 'read'),
+          canReadEvents: v1Rbac.hasPermission('notifications', 'events', 'read'),
+        };
+      }
+
       if (isKesselLoading || !v1Rbac) {
+        console.log('[RBAC DEBUG] Still loading:', { isKesselLoading, hasV1Rbac: !!v1Rbac });
         return undefined; // Still loading
       }
 
       const kesselPerms = mapKesselToV1Permissions(kesselPermissions);
+
+      // Debug logging
+      console.log('[RBAC DEBUG] v2 org permissions:', {
+        isOrgAdmin,
+        kesselPerms,
+        v1Rbac: {
+          integrationsEndpointsWrite: v1Rbac.hasPermission('integrations', 'endpoints', 'write'),
+          integrationsEndpointsRead: v1Rbac.hasPermission('integrations', 'endpoints', 'read'),
+          notificationsWrite: v1Rbac.hasPermission('notifications', 'notifications', 'write'),
+          notificationsRead: v1Rbac.hasPermission('notifications', 'notifications', 'read'),
+          eventsRead: v1Rbac.hasPermission('notifications', 'events', 'read'),
+        },
+      });
 
       return {
         // Grant permission if EITHER Kessel v2 OR v1 wildcard check passes
@@ -133,7 +177,7 @@ export const useApp = (): Partial<AppContext> => {
         canReadEvents: v1Rbac.hasPermission('notifications', 'events', 'read'),
       };
     }
-  }, [isV2Org, isKesselLoading, kesselPermissions, v1Rbac]);
+  }, [isV2Org, isKesselLoading, kesselPermissions, v1Rbac, kesselErrors, isOrgAdmin]);
 
   return {
     rbac,

--- a/src/app/useApp.ts
+++ b/src/app/useApp.ts
@@ -90,7 +90,7 @@ export const useApp = (): Partial<AppContext> => {
         setV1Rbac(rbac);
       });
     }
-  }, [userLoaded, isOrgAdmin]);
+  }, [userLoaded]);
 
   // Compute final RBAC object based on org version
   const rbac = React.useMemo(() => {

--- a/src/app/useApp.ts
+++ b/src/app/useApp.ts
@@ -157,7 +157,7 @@ export const useApp = (): Partial<AppContext> => {
         canReadEvents: v1Rbac.hasPermission('notifications', 'events', 'read'),
       };
     }
-  }, [isV2Org, isKesselLoading, kesselPermissions, v1Rbac, kesselErrors, isOrgAdmin]);
+  }, [isV2Org, isKesselLoading, kesselPermissions, v1Rbac, kesselErrors]);
 
   return {
     rbac,

--- a/src/app/useApp.ts
+++ b/src/app/useApp.ts
@@ -87,11 +87,6 @@ export const useApp = (): Partial<AppContext> => {
   useEffect(() => {
     if (userLoaded) {
       fetchRBAC(`${Config.notifications.subAppId},${Config.integrations.subAppId}`).then((rbac) => {
-        console.log('[RBAC DEBUG] v1 RBAC loaded:', {
-          // @ts-expect-error - accessing private field for debugging
-          permissions: rbac?.permissions,
-          isOrgAdmin,
-        });
         setV1Rbac(rbac);
       });
     }
@@ -109,7 +104,6 @@ export const useApp = (): Partial<AppContext> => {
       const kesselFailed = kesselErrors && kesselErrors.length > 0;
 
       if (kesselFailed) {
-        console.log('[RBAC DEBUG] Kessel failed, using v1 fallback only:', kesselErrors);
         if (!v1Rbac) {
           return undefined; // Still loading v1
         }
@@ -124,24 +118,10 @@ export const useApp = (): Partial<AppContext> => {
       }
 
       if (isKesselLoading || !v1Rbac) {
-        console.log('[RBAC DEBUG] Still loading:', { isKesselLoading, hasV1Rbac: !!v1Rbac });
         return undefined; // Still loading
       }
 
       const kesselPerms = mapKesselToV1Permissions(kesselPermissions);
-
-      // Debug logging
-      console.log('[RBAC DEBUG] v2 org permissions:', {
-        isOrgAdmin,
-        kesselPerms,
-        v1Rbac: {
-          integrationsEndpointsWrite: v1Rbac.hasPermission('integrations', 'endpoints', 'write'),
-          integrationsEndpointsRead: v1Rbac.hasPermission('integrations', 'endpoints', 'read'),
-          notificationsWrite: v1Rbac.hasPermission('notifications', 'notifications', 'write'),
-          notificationsRead: v1Rbac.hasPermission('notifications', 'notifications', 'read'),
-          eventsRead: v1Rbac.hasPermission('notifications', 'events', 'read'),
-        },
-      });
 
       return {
         // Grant permission if EITHER Kessel v2 OR v1 wildcard check passes


### PR DESCRIPTION
For v2 orgs, combine Kessel v2 permissions with v1 RBAC wildcard checks using OR logic. This ensures Org Admins and legacy roles with wildcard permissions (integrations:*:*, notifications:*:*) maintain access on v2 orgs.

Why: Kessel v2 does not currently support wildcard permission expansion. Without this fallback, users with wildcard permissions would lose access when their org is migrated to v2.

Temporary workaround: Should be removed once EITHER:
1. Kessel v2 supports wildcard permission expansion, OR
2. All wildcard permissions are migrated to explicit Kessel workspace relations

Related: insights-chrome PR #3362
Issue: RHCLOUD-48396

### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
description text...

[RHCLOUDXXXX](https://issues.redhat.com/browse/RHCLOUDXXXX)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##
