### PR TITLE
feat(integrations): Add lock icon to read-only system email integrations

### DIFF
--- a/src/components/Integrations/IntegrationsTable.tsx
+++ b/src/components/Integrations/IntegrationsTable.tsx
@@ -120,7 +120,7 @@ export const DataViewIntegrationsTable: React.FunctionComponent<IntegrationsTabl
           <Split key={`name-${idx}`} hasGutter>
             <SplitItem>{integration.name}</SplitItem>
             <SplitItem>
-              <Tooltip content="This email integration is managed by your organization administrator and cannot be modified.">
+              <Tooltip content={intl.formatMessage(messages.readOnlyEmailTooltip)}>
                 <LockIcon />
               </Tooltip>
             </SplitItem>

--- a/src/components/Integrations/IntegrationsTable.tsx
+++ b/src/components/Integrations/IntegrationsTable.tsx
@@ -1,7 +1,7 @@
 import { Spinner } from '@patternfly/react-core/dist/dynamic/components/Spinner';
 import { Switch } from '@patternfly/react-core/dist/dynamic/components/Switch';
 import { EmptyStateVariant } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
-import { SearchIcon } from '@patternfly/react-icons';
+import { LockIcon, SearchIcon } from '@patternfly/react-icons';
 import { ActionsColumn, IActions, ISortBy, SortByDirection } from '@patternfly/react-table';
 import { SkeletonTableBody, SkeletonTableHead } from '@patternfly/react-component-groups';
 
@@ -10,13 +10,14 @@ import { useIntl } from 'react-intl';
 
 import Config from '../../config/Config';
 import messages from '../../properties/DefinedMessages';
+import { IntegrationEmailSubscription, IntegrationType } from '../../types/Integration';
 import { IntegrationConnectionAttempt, UserIntegration } from '../../types/Integration';
 import { EmptyStateSearch } from '../EmptyStateSearch';
 import { IntegrationStatus, StatusUnknown } from './Table/IntegrationStatus';
 import { DataView } from '@patternfly/react-data-view/dist/dynamic/DataView';
 import { DataViewTable, DataViewTh } from '@patternfly/react-data-view/dist/dynamic/DataViewTable';
 import { getIntegrationIcon } from './IntegrationDetails';
-import { Split, SplitItem } from '@patternfly/react-core';
+import { Split, SplitItem, Tooltip } from '@patternfly/react-core';
 import { OuiaProps } from '@redhat-cloud-services/frontend-components/Ouia/Ouia';
 import { Direction, Sort, UseSortReturn } from '../../utils/insights-common-typescript';
 
@@ -109,9 +110,24 @@ export const DataViewIntegrationsTable: React.FunctionComponent<IntegrationsTabl
         setFocusedIntegration?.(integration);
       }
     };
+    const isReadOnlyEmail = (row: IntegrationRow) =>
+      row.type === IntegrationType.EMAIL_SUBSCRIPTION &&
+      (row as IntegrationRow & IntegrationEmailSubscription).readOnly === true;
+
     return integrations.map((integration, idx) => ({
       row: [
-        integration.name,
+        isReadOnlyEmail(integration) ? (
+          <Split key={`name-${idx}`} hasGutter>
+            <SplitItem>{integration.name}</SplitItem>
+            <SplitItem>
+              <Tooltip content="This email integration is managed by your organization administrator and cannot be modified.">
+                <LockIcon />
+              </Tooltip>
+            </SplitItem>
+          </Split>
+        ) : (
+          integration.name
+        ),
         <Split key={idx}>
           <SplitItem>{getIntegrationIcon(integration.type)}</SplitItem>
           <SplitItem> {Config.integrations.types[integration.type].name} </SplitItem>

--- a/src/components/Integrations/IntegrationsTable.tsx
+++ b/src/components/Integrations/IntegrationsTable.tsx
@@ -153,7 +153,7 @@ export const DataViewIntegrationsTable: React.FunctionComponent<IntegrationsTabl
             aria-label="Enabled"
             isChecked={integration.isEnabled}
             onChange={(_e, isChecked) => onEnable?.(integration, idx, isChecked)}
-            isDisabled={!onEnable}
+            isDisabled={!onEnable || isReadOnlyEmail(integration)}
             ouiaId={`enabled-${integration.id}`}
           />
         ),

--- a/src/components/Integrations/Table.tsx
+++ b/src/components/Integrations/Table.tsx
@@ -98,7 +98,11 @@ const isReadOnlyEmail = (integration: IntegrationRow) =>
   integration.type === IntegrationType.EMAIL_SUBSCRIPTION &&
   (integration as IntegrationRow & IntegrationEmailSubscription).readOnly === true;
 
-const toTableRows = (integrations: Array<IntegrationRow>, onEnable?: OnEnable): IRow[] => {
+const toTableRows = (
+  integrations: Array<IntegrationRow>,
+  onEnable?: OnEnable,
+  readOnlyEmailTooltip?: string
+): IRow[] => {
   return integrations.reduce((rows, integration, idx) => {
     rows.push({
       id: integration.id,
@@ -110,7 +114,7 @@ const toTableRows = (integrations: Array<IntegrationRow>, onEnable?: OnEnable): 
           title: isReadOnlyEmail(integration) ? (
             <>
               {integration.name}{' '}
-              <Tooltip content="This email integration is managed by your organization administrator and cannot be modified.">
+              <Tooltip content={readOnlyEmailTooltip}>
                 <LockIcon className="pf-v5-u-ml-sm" />
               </Tooltip>
             </>
@@ -313,8 +317,12 @@ export const IntegrationsTable: React.FunctionComponent<IntegrationsTableProps> 
   }, [props.sortBy]);
 
   const rows = React.useMemo(() => {
-    return toTableRows(props.integrations, props.onEnable);
-  }, [props.integrations, props.onEnable]);
+    return toTableRows(
+      props.integrations,
+      props.onEnable,
+      intl.formatMessage(messages.readOnlyEmailTooltip)
+    );
+  }, [props.integrations, props.onEnable, intl]);
 
   const actionsResolverCallback: IActionsResolver = React.useCallback(
     (rowData) => {

--- a/src/components/Integrations/Table.tsx
+++ b/src/components/Integrations/Table.tsx
@@ -151,7 +151,7 @@ const toTableRows = (integrations: Array<IntegrationRow>, onEnable?: OnEnable): 
                   aria-label="Enabled"
                   isChecked={integration.isEnabled}
                   onChange={(_e, isChecked) => onEnable && onEnable(integration, idx, isChecked)}
-                  isDisabled={!onEnable}
+                  isDisabled={!onEnable || isReadOnlyEmail(integration)}
                   ouiaId={`enabled-${integration.id}`}
                 />
               )}

--- a/src/components/Integrations/Table.tsx
+++ b/src/components/Integrations/Table.tsx
@@ -2,7 +2,8 @@ import { Spinner } from '@patternfly/react-core/dist/dynamic/components/Spinner'
 import { Switch } from '@patternfly/react-core/dist/dynamic/components/Switch';
 import { Content } from '@patternfly/react-core/dist/dynamic/components/Content';
 import { EmptyStateVariant } from '@patternfly/react-core/dist/dynamic/components/EmptyState';
-import { SearchIcon } from '@patternfly/react-icons';
+import { Tooltip } from '@patternfly/react-core/dist/dynamic/components/Tooltip';
+import { LockIcon, SearchIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import { Table, TableBody, TableHeader } from '@patternfly/react-table/deprecated';
 import {
@@ -28,7 +29,12 @@ import { style } from 'typestyle';
 import Config from '../../config/Config';
 import messages from '../../properties/DefinedMessages';
 import { Messages } from '../../properties/Messages';
-import { IntegrationConnectionAttempt, UserIntegration } from '../../types/Integration';
+import {
+  IntegrationConnectionAttempt,
+  IntegrationEmailSubscription,
+  IntegrationType,
+  UserIntegration,
+} from '../../types/Integration';
 import {
   AggregatedConnectionAttemptStatus,
   aggregateConnectionAttemptStatus,
@@ -88,6 +94,10 @@ const getConnectionAlert = (attempts: Array<IntegrationConnectionAttempt>) => {
   }
 };
 
+const isReadOnlyEmail = (integration: IntegrationRow) =>
+  integration.type === IntegrationType.EMAIL_SUBSCRIPTION &&
+  (integration as IntegrationRow & IntegrationEmailSubscription).readOnly === true;
+
 const toTableRows = (integrations: Array<IntegrationRow>, onEnable?: OnEnable): IRow[] => {
   return integrations.reduce((rows, integration, idx) => {
     rows.push({
@@ -97,7 +107,16 @@ const toTableRows = (integrations: Array<IntegrationRow>, onEnable?: OnEnable): 
       selected: integration.isSelected,
       cells: [
         {
-          title: integration.name,
+          title: isReadOnlyEmail(integration) ? (
+            <>
+              {integration.name}{' '}
+              <Tooltip content="This email integration is managed by your organization administrator and cannot be modified.">
+                <LockIcon className="pf-v5-u-ml-sm" />
+              </Tooltip>
+            </>
+          ) : (
+            integration.name
+          ),
         },
         {
           title: Config.integrations.types[integration.type].name,

--- a/src/components/Notifications/TimeConfig.tsx
+++ b/src/components/Notifications/TimeConfig.tsx
@@ -19,6 +19,7 @@ import {
   StackItem,
   TimePicker,
   Title,
+  Tooltip,
 } from '@patternfly/react-core';
 import { Modal, ModalVariant } from '@patternfly/react-core/deprecated';
 import { Alert } from '@patternfly/react-core';
@@ -32,6 +33,7 @@ import {
   getTimeConfig,
   setTimeConfig,
 } from '../../api/helpers/notifications/time-preference-helper';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 const alertClassName = style({
   marginTop: '12px',
@@ -59,6 +61,14 @@ export const TimeConfigComponent: React.FunctionComponent = () => {
   const menuRef = React.useRef<HTMLDivElement>(null);
 
   const { addSuccessNotification, addDangerNotification } = useNotification();
+  const { auth } = useChrome();
+  const [isOrgAdmin, setIsOrgAdmin] = useState(false);
+
+  useEffect(() => {
+    auth.getUser().then((user) => {
+      setIsOrgAdmin(user?.identity?.user?.is_org_admin ?? false);
+    });
+  }, [auth]);
 
   React.useEffect(() => {
     const timePreferenceLoad = async () => setTimePref(await getTimeConfig());
@@ -77,16 +87,31 @@ export const TimeConfigComponent: React.FunctionComponent = () => {
   }, [timePref]);
 
   const timeconfigTitle = useMemo(() => {
+    const actionLink = (
+      <AlertActionLink
+        onClick={handleModalToggle}
+        ouiaId="TimeConfigModal"
+        isDisabled={!isOrgAdmin}
+      >
+        Edit time settings.
+      </AlertActionLink>
+    );
+
     return (
       <>
         Any daily digest emails you&apos;ve opted into will be sent at{' '}
-        {timeSelect?.utcTime ? timeSelect?.utcTime : '00:00'} UTC.{' '}
-        <AlertActionLink onClick={handleModalToggle} ouiaId="TimeConfigModal">
-          Edit time settings.
-        </AlertActionLink>
+        {timeSelect?.utcTime ?? '00:00'} UTC.
+        <br />
+        {!isOrgAdmin ? (
+          <Tooltip content="Contact your Organization Administrator to edit time settings.">
+            <span>{actionLink}</span>
+          </Tooltip>
+        ) : (
+          actionLink
+        )}
       </>
     );
-  }, [timeSelect?.utcTime, handleModalToggle]);
+  }, [timeSelect?.utcTime, handleModalToggle, isOrgAdmin]);
 
   // Set the time preference value once we load it from the server
   useEffect(() => {

--- a/src/pages/Integrations/List/List.tsx
+++ b/src/pages/Integrations/List/List.tsx
@@ -32,6 +32,7 @@ import { useIntegrationFilter } from './useIntegrationFilter';
 import { useIntegrationRows } from './useIntegrationRows';
 import { useFlag } from '@unleash/proxy-client-react';
 import DopeBox from '../../../components/Integrations/DopeBox';
+import { UnauthorizedState } from './UnauthorizedState';
 import { DataViewIntegrationsTable } from '../../../components/Integrations/IntegrationsTable';
 import { DataViewEventsProvider } from '@patternfly/react-data-view/dist/dynamic/DataViewEventsContext';
 import { Drawer, DrawerContent, DrawerContentBody } from '@patternfly/react-core';
@@ -71,7 +72,7 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
   const [focusedIntegration, setFocusedIntegration] = useState<IntegrationRow>();
   const drawerRef = React.useRef<HTMLDivElement>(null);
   const {
-    rbac: { canWriteIntegrationsEndpoints },
+    rbac: { canWriteIntegrationsEndpoints, canReadIntegrationsEndpoints },
   } = useContext(AppContext);
 
   const { addDangerNotification } = useNotification();
@@ -117,7 +118,11 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
     sort.sortBy,
     category
   );
-  const integrationsQuery = useListIntegrationsQuery(pageData.page);
+  // Only fetch integrations if user has read permissions
+  const integrationsQuery = useListIntegrationsQuery(
+    pageData.page,
+    canReadIntegrationsEndpoints // initFetch parameter
+  );
   const exportIntegrationsQuery = useListIntegrationPQuery();
 
   const integrations = React.useMemo(() => {
@@ -260,6 +265,11 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
     integrations.count < 1 &&
     !integrationsQuery.loading &&
     Object.values(integrationFilter.filters).every((filter) => !filter);
+
+  // If user doesn't have read permissions, show unauthorized state
+  if (!canReadIntegrationsEndpoints) {
+    return <UnauthorizedState />;
+  }
 
   return (
     <>

--- a/src/pages/Integrations/List/List.tsx
+++ b/src/pages/Integrations/List/List.tsx
@@ -117,8 +117,12 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
     sort.sortBy,
     category
   );
-  const integrationsQuery = useListIntegrationsQuery(pageData.page);
-  const exportIntegrationsQuery = useListIntegrationPQuery();
+  const integrationsQuery = useListIntegrationsQuery(
+    pageData.page,
+    undefined,
+    isEmailIntegrationEnabled
+  );
+  const exportIntegrationsQuery = useListIntegrationPQuery(isEmailIntegrationEnabled);
 
   const integrations = React.useMemo(() => {
     const payload = integrationsQuery.payload;

--- a/src/pages/Integrations/List/List.tsx
+++ b/src/pages/Integrations/List/List.tsx
@@ -121,9 +121,10 @@ const IntegrationsList: React.FunctionComponent<IntegrationListProps> = ({
   // Only fetch integrations if user has read permissions
   const integrationsQuery = useListIntegrationsQuery(
     pageData.page,
-    canReadIntegrationsEndpoints // initFetch parameter
+    canReadIntegrationsEndpoints,
+    isEmailIntegrationEnabled
   );
-  const exportIntegrationsQuery = useListIntegrationPQuery();
+  const exportIntegrationsQuery = useListIntegrationPQuery(isEmailIntegrationEnabled);
 
   const integrations = React.useMemo(() => {
     const payload = integrationsQuery.payload;

--- a/src/pages/Integrations/List/UnauthorizedState.stories.tsx
+++ b/src/pages/Integrations/List/UnauthorizedState.stories.tsx
@@ -1,0 +1,65 @@
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { UnauthorizedState } from './UnauthorizedState';
+
+const meta: Meta<typeof UnauthorizedState> = {
+  title: 'Pages/Integrations/UnauthorizedState',
+  component: UnauthorizedState,
+  parameters: {
+    docs: {
+      description: {
+        component: `
+**UnauthorizedState** displays when a user does not have read permissions to view integrations.
+
+## Usage
+Shown on the Communications, Reporting & automation, and Webhooks tabs when users lack \`integrations:endpoints:read\` permissions.
+
+### Features
+- Informative alert explaining permission requirements
+- Link to request access via the Virtual Assistant
+- Clear messaging to contact organization administrator
+- Lock icon and empty state pattern matching other unauthorized views
+
+### When to Use
+- User has no \`integrations:endpoints:read\` permission (RBAC check fails)
+- API returns 401/403 even though RBAC check passed (permission mismatch)
+
+This ensures non-org admin users see a proper empty state instead of an infinite loading spinner.
+        `,
+      },
+    },
+    layout: 'fullscreen',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof UnauthorizedState>;
+
+/**
+ * Default unauthorized state shown when users lack integrations read permissions.
+ * This is the state non-org admin users see on the Communications, Reporting, and Webhooks tabs.
+ */
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The default unauthorized state displayed when a user lacks `integrations:endpoints:read` permissions. Shows an alert with guidance on requesting access and an empty state explaining the permission requirement.',
+      },
+    },
+  },
+};
+
+/**
+ * This story demonstrates what the component looks like in a production environment.
+ * The component uses react-intl for internationalization, so all text is properly translated.
+ */
+export const WithProductionData: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The component in a production-like environment. All text uses internationalized messages via react-intl, ensuring proper translation support across different locales.',
+      },
+    },
+  },
+};

--- a/src/pages/Integrations/List/UnauthorizedState.tsx
+++ b/src/pages/Integrations/List/UnauthorizedState.tsx
@@ -1,0 +1,81 @@
+import {
+  Alert,
+  AlertActionLink,
+  Card,
+  CardBody,
+  Content,
+  ContentVariants,
+  EmptyState,
+  EmptyStateBody,
+  Stack,
+  StackItem,
+} from '@patternfly/react-core';
+import { LockIcon } from '@patternfly/react-icons';
+import React from 'react';
+import { useIntl } from 'react-intl';
+
+export const UnauthorizedState: React.FunctionComponent = () => {
+  const intl = useIntl();
+
+  return (
+    <Stack hasGutter>
+      <StackItem>
+        <Alert
+          customIcon={<LockIcon />}
+          variant="info"
+          isInline
+          isExpandable
+          title={intl.formatMessage({
+            id: 'integrations.unauthorizedState.alertTitle',
+            defaultMessage: 'Need to create an integration?',
+          })}
+          actionLinks={
+            <AlertActionLink
+              component="a"
+              href="https://access.redhat.com/articles/6957948"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              {intl.formatMessage({
+                id: 'integrations.unauthorizedState.alertLink',
+                defaultMessage: 'Learn about requesting access via the Virtual Assistant',
+              })}
+            </AlertActionLink>
+          }
+        >
+          <Content>
+            <Content component={ContentVariants.p}>
+              {intl.formatMessage({
+                id: 'integrations.unauthorizedState.alertParagraph',
+                defaultMessage:
+                  'You do not have the permissions for integration management. Contact your organization admin if you need these permissions updated.',
+              })}
+            </Content>
+          </Content>
+        </Alert>
+      </StackItem>
+      <StackItem>
+        <Card isPlain>
+          <CardBody className="pf-v5-u-text-align-center">
+            <EmptyState
+              headingLevel={ContentVariants.h2}
+              icon={LockIcon}
+              titleText={intl.formatMessage({
+                id: 'integrations.unauthorizedState.heading',
+                defaultMessage: 'No integrations available',
+              })}
+            >
+              <EmptyStateBody>
+                {intl.formatMessage({
+                  id: 'integrations.unauthorizedState.description',
+                  defaultMessage:
+                    'You need read permissions to view integrations. Contact your organization administrator to request access.',
+                })}
+              </EmptyStateBody>
+            </EmptyState>
+          </CardBody>
+        </Card>
+      </StackItem>
+    </Stack>
+  );
+};

--- a/src/pages/Integrations/List/__tests__/Page.test.tsx
+++ b/src/pages/Integrations/List/__tests__/Page.test.tsx
@@ -301,5 +301,30 @@ describe('src/pages/Integrations/List/Page', () => {
       expect(deleteItem).toBeInTheDocument();
       expect(toggleItem).toBeInTheDocument();
     });
+
+    it('Shows unauthorized state when read permissions is false', async () => {
+      render(<IntegrationsListPage />, {
+        wrapper: getConfiguredAppWrapper({
+          appContext: {
+            rbac: {
+              canReadIntegrationsEndpoints: false,
+              canWriteIntegrationsEndpoints: false,
+            },
+          },
+        }),
+      });
+
+      await waitForAsyncEvents();
+
+      // Check for unauthorized state elements
+      expect(screen.getByText(/no integrations available/i)).toBeInTheDocument();
+      expect(screen.getByText(/need to create an integration/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/you need read permissions to view integrations/i)
+      ).toBeInTheDocument();
+
+      // Verify integrations API was NOT called since user lacks permissions
+      expect(fetchMock.calls(/\/api\/integrations\/v1\.0\/endpoints.*/).length).toBe(0);
+    });
   });
 });

--- a/src/pages/Integrations/List/__tests__/UnauthorizedState.test.tsx
+++ b/src/pages/Integrations/List/__tests__/UnauthorizedState.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react';
+import * as React from 'react';
+import { IntlProvider } from 'react-intl';
+
+import { UnauthorizedState } from '../UnauthorizedState';
+
+describe('UnauthorizedState', () => {
+  const renderComponent = () => {
+    return render(
+      <IntlProvider locale="en">
+        <UnauthorizedState />
+      </IntlProvider>
+    );
+  };
+
+  it('renders the alert with permission information', () => {
+    renderComponent();
+
+    // Check for the alert title
+    expect(screen.getByText(/need to create an integration/i)).toBeInTheDocument();
+
+    // Check for the link in the alert
+    expect(
+      screen.getByRole('link', {
+        name: /learn about requesting access via the virtual assistant/i,
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('renders the empty state with lock icon and heading', () => {
+    renderComponent();
+
+    // Check for the empty state heading
+    expect(screen.getByText(/no integrations available/i)).toBeInTheDocument();
+
+    // Check for the description
+    expect(screen.getByText(/you need read permissions to view integrations/i)).toBeInTheDocument();
+  });
+
+  it('renders the link to request access', () => {
+    renderComponent();
+
+    // Check for the Virtual Assistant link
+    const link = screen.getByRole('link', {
+      name: /learn about requesting access via the virtual assistant/i,
+    });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://access.redhat.com/articles/6957948');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders instructions to contact org admin', () => {
+    renderComponent();
+
+    // Check that the empty state description mentions contacting the org administrator
+    expect(
+      screen.getByText(/contact your organization administrator to request access/i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/properties/DefinedMessages.ts
+++ b/src/properties/DefinedMessages.ts
@@ -168,4 +168,10 @@ export default defineMessages({
     description: 'Admin access required tooltip',
     defaultMessage: 'Admin-access required',
   },
+  readOnlyEmailTooltip: {
+    id: 'readOnlyEmailTooltip',
+    description: 'Tooltip for read-only system email integrations',
+    defaultMessage:
+      'This email integration is managed by your organization administrator and cannot be modified.',
+  },
 });

--- a/src/services/useListIntegrations.ts
+++ b/src/services/useListIntegrations.ts
@@ -18,6 +18,20 @@ export const listIntegrationsActionCreator = (pager?: Page) => {
   });
 };
 
+// v2 includes system integrations (e.g. org-admin-configured read-only emails) and exposes read_only
+export const listIntegrationsV2ActionCreator = (pager?: Page) => {
+  const query = (pager ?? Page.defaultPage()).toQuery();
+  const params = Operations.EndpointResource$v1GetEndpoints.actionCreator({
+    limit: +query.limit,
+    offset: +query.offset,
+    type: query.filterType ? (query.filterType as Array<IntegrationType>) : undefined,
+    active: query.filterActive ? query.filterActive === 'true' : undefined,
+    name: query.filterName ? query.filterName.toString() : '',
+    sortBy: pager?.sort ? `${pager.sort.column}:${pager.sort.direction}` : undefined,
+  });
+  return { ...params, endpoint: params.endpoint.replace('/v1.0/', '/v2.0/') };
+};
+
 export const listIntegrationIntegrationDecoder = validationResponseTransformer(
   (payload: Operations.EndpointResource$v1GetEndpoints.Payload) => {
     if (payload?.status === 200) {
@@ -36,14 +50,17 @@ export const listIntegrationIntegrationDecoder = validationResponseTransformer(
   }
 );
 
-export const useListIntegrationsQuery = (pager?: Page, initFetch?: boolean) =>
+export const useListIntegrationsQuery = (pager?: Page, initFetch?: boolean, useV2 = false) =>
   useTransformQueryResponse(
-    useQuery(listIntegrationsActionCreator(pager), initFetch),
+    useQuery(
+      useV2 ? listIntegrationsV2ActionCreator(pager) : listIntegrationsActionCreator(pager),
+      initFetch
+    ),
     listIntegrationIntegrationDecoder
   );
 
-export const useListIntegrationPQuery = () =>
+export const useListIntegrationPQuery = (useV2 = false) =>
   useTransformQueryResponse(
-    useParameterizedQuery(listIntegrationsActionCreator),
+    useParameterizedQuery(useV2 ? listIntegrationsV2ActionCreator : listIntegrationsActionCreator),
     listIntegrationIntegrationDecoder
   );

--- a/src/types/Integration.ts
+++ b/src/types/Integration.ts
@@ -104,6 +104,7 @@ export interface IntegrationEmailSubscription
   onlyAdmin: boolean | null | undefined;
   ignorePreferences: boolean | null | undefined;
   groupId?: UUID;
+  readOnly?: boolean;
 }
 
 export type NameDisplayName = {

--- a/src/types/adapters/IntegrationAdapter.ts
+++ b/src/types/adapters/IntegrationAdapter.ts
@@ -101,12 +101,14 @@ const toIntegrationCamel = (
 
 const toIntegrationEmail = (
   integrationBase: IntegrationBase<IntegrationType.EMAIL_SUBSCRIPTION>,
-  properties: Schemas.SystemSubscriptionProperties
+  properties: Schemas.SystemSubscriptionProperties,
+  readOnly?: boolean
 ): IntegrationEmailSubscription => ({
   ...integrationBase,
   ignorePreferences: properties.ignore_preferences,
   groupId: properties.group_id === null ? undefined : properties.group_id,
   onlyAdmin: properties.only_admins === null ? undefined : properties.only_admins,
+  readOnly,
 });
 
 const toIntegrationDrawer = (
@@ -159,7 +161,8 @@ export const toIntegration = (serverIntegration: ServerIntegrationResponse): Int
     case IntegrationType.EMAIL_SUBSCRIPTION:
       return toIntegrationEmail(
         integrationBase as IntegrationBase<IntegrationType.EMAIL_SUBSCRIPTION>,
-        serverIntegration.properties as Schemas.SystemSubscriptionProperties
+        serverIntegration.properties as Schemas.SystemSubscriptionProperties,
+        (serverIntegration as { read_only?: boolean }).read_only
       );
     case IntegrationType.DRAWER:
       return toIntegrationDrawer(

--- a/src/types/adapters/__tests__/IntegrationAdapter.test.ts
+++ b/src/types/adapters/__tests__/IntegrationAdapter.test.ts
@@ -90,6 +90,52 @@ describe('src/types/adapters/IntegrationAdapter', () => {
       expect(() => toIntegration(serverIntegration)).toThrow();
     });
 
+    it('Maps read_only=true for a system email subscription', () => {
+      const serverIntegration = {
+        id: 'system-email-id',
+        enabled: true,
+        name: 'System email endpoint',
+        description: 'System email endpoint',
+        type: Schemas.EndpointType.Enum.email_subscription,
+        properties: {
+          only_admins: false,
+          ignore_preferences: false,
+          group_id: null,
+        },
+        server_errors: 0,
+        status: 'READY',
+        read_only: true,
+      } as unknown as ServerIntegrationResponse;
+      const integration = toIntegration(serverIntegration);
+      expect(integration).toMatchObject({
+        type: IntegrationType.EMAIL_SUBSCRIPTION,
+        readOnly: true,
+      });
+    });
+
+    it('Maps read_only=false for an org-owned email subscription', () => {
+      const serverIntegration = {
+        id: 'org-email-id',
+        enabled: true,
+        name: 'Org email endpoint',
+        description: 'Org email endpoint',
+        type: Schemas.EndpointType.Enum.email_subscription,
+        properties: {
+          only_admins: false,
+          ignore_preferences: false,
+          group_id: null,
+        },
+        server_errors: 0,
+        status: 'READY',
+        read_only: false,
+      } as unknown as ServerIntegrationResponse;
+      const integration = toIntegration(serverIntegration);
+      expect(integration).toMatchObject({
+        type: IntegrationType.EMAIL_SUBSCRIPTION,
+        readOnly: false,
+      });
+    });
+
     it('Not supporting unknown types', () => {
       const serverIntegration = {
         id: 'meep',


### PR DESCRIPTION
### Description
Replaces the v1 integrations endpoint with v2 for email integrations when the platform.notifications.email.integration flag is enabled. The v2 endpoint includes system-level email integrations (those without and org ID) and exposes a read_only field. Integrations with read_only: true now display a lock icon and tooltip in both table variants

[RHCLOUD-43425](https://issues.redhat.com/browse/RHCLOUD-43425)

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations s
hould be captured -->
<!-- Draw attention to the area of UI that has changed -->
---
<img width="1506" height="865" alt="Screenshot 2026-06-30 at 9 12 59 AM" src="https://github.com/user-attachments/assets/129e1019-c6e5-458a-ac6c-862a07974680" />

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##


[RHCLOUD-43425]: https://redhat.atlassian.net/browse/RHCLOUD-43425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ