### PR TITLE
fix(RHCLOUD-48919): Fix Kessel workspace 400 error during permission loading

### DIFF
--- a/src/app/rbac/KesselRbacAccessProvider.tsx
+++ b/src/app/rbac/KesselRbacAccessProvider.tsx
@@ -39,24 +39,17 @@ export const KesselRbacAccessProvider: React.FC<{
   }, [workspaceError]);
 
   // Build workspace resource for permission checks
-  // Only create resource if workspace ID is available
+  // Use a placeholder UUID when workspace isn't loaded to prevent 400 validation errors
   const workspace = useMemo(() => {
-    if (!defaultWorkspaceId) {
-      // Return a placeholder - permission hooks will handle undefined gracefully
-      return {
-        id: '',
-        type: 'workspace' as const,
-        reporter: { type: 'rbac' as const },
-      };
-    }
     return {
-      id: defaultWorkspaceId,
+      id: defaultWorkspaceId || '00000000-0000-0000-0000-000000000000',
       type: 'workspace' as const,
       reporter: { type: 'rbac' as const },
     };
   }, [defaultWorkspaceId]);
 
   // Permission checks - using v0.5.0 API which returns { loading, error, data }
+  // Note: When workspace isn't loaded (placeholder UUID), these will return false permissions
   const integrationsEndpointsEdit = useSelfAccessCheck({
     relation: KESSEL_WORKSPACE_RELATIONS.INTEGRATIONS_ENDPOINTS_EDIT,
     resource: workspace,


### PR DESCRIPTION
## Problem

As an org admin in a v2 RBAC org, the Kessel permission checks were throwing 400 validation errors:

```
https://console.stage.redhat.com/api/kessel/v1beta2/checkself
400 Bad Request
{
  "code": 400,
  "reason": "VALIDATOR",
  "message": "validation error: object.resource_id: must be at least 1 characters"
}
```

This occurred because the `KesselRbacAccessProvider` was passing an **empty string** (`id: ''`) as the workspace resource ID before the workspace had loaded, which violated the Kessel API's validation requirement.

## Solution

Changed the placeholder workspace resource ID from empty string to a valid UUID: `'00000000-0000-0000-0000-000000000000'`.

When the real workspace ID loads:
1. The `workspace` useMemo updates (depends on `defaultWorkspaceId`)
2. The `useSelfAccessCheck` hooks detect the `resource.id` change
3. Permission checks automatically re-run with the correct workspace ID

## Testing

**Local testing:**
- ✅ No more 400 errors in network tab
- ✅ Kessel permissions load correctly (`canReadEvents: true`)
- ✅ App RBAC state correctly computed

**Stage testing needed:**
- Verify "Configure Events" appears in left navigation for org admins
- Verify no console errors on page load
- Verify permissions work correctly after workspace loads

## Technical Details

The `useSelfAccessCheck` hook from `@project-kessel/react-kessel-access-check@0.5.0` watches `resource.id` as a dependency, so it automatically re-runs when the workspace ID changes from placeholder to real value.

Fixes RHCLOUD-48919