### PR TITLE
fix(Drawer): Remove extra drawer spacing

### DIFF
--- a/src/components/NotificationsDrawer/NotificationItem.tsx
+++ b/src/components/NotificationsDrawer/NotificationItem.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { useIntl } from 'react-intl';
 import {
-  NotificationDrawerList,
   NotificationDrawerListItem,
   NotificationDrawerListItemBody,
   NotificationDrawerListItemHeader,
@@ -132,54 +131,50 @@ const NotificationItem: React.FC<NotificationItemProps> = ({
     ),
   ];
   return (
-    <>
-      <NotificationDrawerList>
-        <NotificationDrawerListItem
-          aria-label={`Notification item ${notification.title}`}
-          variant="info"
-          isRead={notification.read}
-        >
-          <NotificationDrawerListItemHeader title={notification.title} srTitle="Info notification:">
-            <Checkbox
-              isChecked={notification.selected}
-              onChange={onCheckboxToggle}
-              id="selected-checkbox"
-              name="selected-checkbox"
-            />
-            <Dropdown
-              toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
-                <MenuToggle
-                  ref={toggleRef}
-                  aria-label="Notification actions dropdown"
-                  onClick={() => setIsDropdownOpen(!isDropdownOpen)}
-                  id="notification-item-toggle"
-                  isExpanded={isDropdownOpen}
-                  variant="plain"
-                >
-                  <EllipsisVIcon />
-                </MenuToggle>
-              )}
-              isOpen={isDropdownOpen}
-              onOpenChange={setIsDropdownOpen}
-              popperProps={{
-                position: PopoverPosition.right,
-              }}
-              id="notification-item-dropdown"
+    <NotificationDrawerListItem
+      aria-label={`Notification item ${notification.title}`}
+      variant="info"
+      isRead={notification.read}
+    >
+      <NotificationDrawerListItemHeader title={notification.title} srTitle="Info notification:">
+        <Checkbox
+          isChecked={notification.selected}
+          onChange={onCheckboxToggle}
+          id="selected-checkbox"
+          name="selected-checkbox"
+        />
+        <Dropdown
+          toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
+            <MenuToggle
+              ref={toggleRef}
+              aria-label="Notification actions dropdown"
+              onClick={() => setIsDropdownOpen(!isDropdownOpen)}
+              id="notification-item-toggle"
+              isExpanded={isDropdownOpen}
+              variant="plain"
             >
-              <DropdownList>{notificationDropdownItems}</DropdownList>
-            </Dropdown>
-          </NotificationDrawerListItemHeader>
-          <NotificationDrawerListItemBody timestamp={<DateFormat date={notification.created} />}>
-            <Label variant="outline" isCompact className="pf-u-mb-md">
-              {notification.source}
-            </Label>
-            <span className="pf-u-display-block">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{notification.description}</ReactMarkdown>
-            </span>
-          </NotificationDrawerListItemBody>
-        </NotificationDrawerListItem>
-      </NotificationDrawerList>
-    </>
+              <EllipsisVIcon />
+            </MenuToggle>
+          )}
+          isOpen={isDropdownOpen}
+          onOpenChange={setIsDropdownOpen}
+          popperProps={{
+            position: PopoverPosition.right,
+          }}
+          id="notification-item-dropdown"
+        >
+          <DropdownList>{notificationDropdownItems}</DropdownList>
+        </Dropdown>
+      </NotificationDrawerListItemHeader>
+      <NotificationDrawerListItemBody timestamp={<DateFormat date={notification.created} />}>
+        <Label variant="outline" isCompact className="pf-u-mb-md">
+          {notification.source}
+        </Label>
+        <span className="pf-u-display-block">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>{notification.description}</ReactMarkdown>
+        </span>
+      </NotificationDrawerListItemBody>
+    </NotificationDrawerListItem>
   );
 };
 


### PR DESCRIPTION
### Description
Removed extra drawer spacing caused by NotificationItems being wrapped by NotificationDrawerList twice.

[RHCLOUD-49072](https://redhat.atlassian.net/browse/RHCLOUD-49072)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:
<img width="475" height="722" alt="Screenshot From 2026-07-08 10-32-27" src="https://github.com/user-attachments/assets/5bdb6fb3-8c57-4f15-b2fb-2fa90f6ca077" />


#### After:

<img width="475" height="722" alt="Screenshot From 2026-07-08 10-05-37" src="https://github.com/user-attachments/assets/2650137f-8c72-4e27-9982-3212af649316" />


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##


[RHCLOUD-49072]: https://redhat.atlassian.net/browse/RHCLOUD-49072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ