### PR TITLE
Add tests for NotificationItem dropdown menu

### DIFF
--- a/src/components/NotificationsDrawer/NotificationItem.stories.tsx
+++ b/src/components/NotificationsDrawer/NotificationItem.stories.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
+import { HttpResponse, http } from 'msw';
 import NotificationItem from './NotificationItem';
 import { NotificationData } from '../../types/Drawer';
 
@@ -27,11 +29,28 @@ const mockNotificationRead: NotificationData = {
   created: '2024-01-14T09:15:00Z',
 };
 
+const readStatusHandler = http.put(
+  '*/api/notifications/*/notifications/drawer/read*',
+  async ({ request }) => {
+    const body = await request.json();
+    readStatusSpy(body);
+    return new HttpResponse(null, { status: 200 });
+  }
+);
+
+const readStatusSpy = fn();
+const onNavigateToSpy = fn();
+const updateNotificationSelectedSpy = fn();
+const updateNotificationReadSpy = fn();
+
 const meta: Meta<typeof NotificationItem> = {
   title: 'Components/NotificationItem',
   component: NotificationItem,
   parameters: {
     layout: 'padded',
+    msw: {
+      handlers: [readStatusHandler],
+    },
   },
   decorators: [
     (Story) => (
@@ -51,79 +70,94 @@ const meta: Meta<typeof NotificationItem> = {
 export default meta;
 type Story = StoryObj<typeof NotificationItem>;
 
-export const UnreadNotificationAdmin: Story = {
+async function openKebabMenu(canvasElement: HTMLElement) {
+  const canvas = within(canvasElement);
+  const page = within(canvasElement.ownerDocument.body);
+  let menu = page.queryByRole('menu');
+  if (!menu) {
+    const toggle = await canvas.findByRole('button', { name: 'Notification actions dropdown' });
+    await userEvent.click(toggle);
+    menu = await page.findByRole('menu');
+  }
+  const menuEl = menu as HTMLElement;
+  await waitFor(() => {
+    expect(within(menuEl).getAllByRole('menuitem')).toHaveLength(4);
+  });
+  return within(menuEl).getAllByRole('menuitem');
+}
+
+export const AdminKebabMenu: Story = {
   args: {
     notification: mockNotificationUnread,
     isOrgAdmin: true,
-    onNavigateTo: (link: string) => console.log('Navigate to:', link),
-    updateNotificationSelected: (id: string, selected: boolean) =>
-      console.log('Update selected:', id, selected),
-    updateNotificationRead: (id: string, read: boolean) => console.log('Update read:', id, read),
+    onNavigateTo: onNavigateToSpy,
+    updateNotificationSelected: updateNotificationSelectedSpy,
+    updateNotificationRead: updateNotificationReadSpy,
   },
   parameters: {
     docs: {
       description: {
-        story:
-          'Unread notification for admin user. Kebab menu shows "Mark as read" and all navigation items are enabled.',
+        story: 'Admin kebab menu with all actions enabled and expected menu order.',
       },
     },
   },
+  render: (args) => {
+    onNavigateToSpy.mockClear();
+    updateNotificationSelectedSpy.mockClear();
+    updateNotificationReadSpy.mockClear();
+    return <NotificationItem {...args} />;
+  },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
+
+    const menuItems = await openKebabMenu(canvasElement);
+    expect(menuItems).toHaveLength(4);
+    expect(menuItems[0]).toHaveTextContent('Mark as read');
+    expect(menuItems[1]).toHaveTextContent('View in event log');
+    expect(menuItems[2]).toHaveTextContent('Manage my event notifications');
+    expect(menuItems[3]).toHaveTextContent('Manage event configuration');
+
+    const divider = await page.findByRole('separator');
+    expect(divider).toBeInTheDocument();
+
+    expect(menuItems[3]).toBeEnabled();
+  },
 };
 
-export const ReadNotificationAdmin: Story = {
-  args: {
-    notification: mockNotificationRead,
-    isOrgAdmin: true,
-    onNavigateTo: (link: string) => console.log('Navigate to:', link),
-    updateNotificationSelected: (id: string, selected: boolean) =>
-      console.log('Update selected:', id, selected),
-    updateNotificationRead: (id: string, read: boolean) => console.log('Update read:', id, read),
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Read notification for admin user. Kebab menu shows "Mark as unread" instead of "Mark as read".',
-      },
-    },
-  },
-};
-
-export const UnreadNotificationNonAdmin: Story = {
+export const NonAdminKebabMenu: Story = {
   args: {
     notification: mockNotificationUnread,
     isOrgAdmin: false,
-    onNavigateTo: (link: string) => console.log('Navigate to:', link),
-    updateNotificationSelected: (id: string, selected: boolean) =>
-      console.log('Update selected:', id, selected),
-    updateNotificationRead: (id: string, read: boolean) => console.log('Update read:', id, read),
+    onNavigateTo: onNavigateToSpy,
+    updateNotificationSelected: updateNotificationSelectedSpy,
+    updateNotificationRead: updateNotificationReadSpy,
   },
   parameters: {
     docs: {
       description: {
-        story:
-          'Unread notification for non-admin user. "Manage event configuration" is disabled with "Admin-access required" tooltip.',
+        story: 'Non-admin kebab menu with disabled manage configuration action and tooltip.',
       },
     },
   },
-};
+  render: (args) => {
+    onNavigateToSpy.mockClear();
+    updateNotificationSelectedSpy.mockClear();
+    updateNotificationReadSpy.mockClear();
+    return <NotificationItem {...args} />;
+  },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.ownerDocument.body);
 
-export const ReadNotificationNonAdmin: Story = {
-  args: {
-    notification: mockNotificationRead,
-    isOrgAdmin: false,
-    onNavigateTo: (link: string) => console.log('Navigate to:', link),
-    updateNotificationSelected: (id: string, selected: boolean) =>
-      console.log('Update selected:', id, selected),
-    updateNotificationRead: (id: string, read: boolean) => console.log('Update read:', id, read),
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Read notification for non-admin user. Kebab menu shows "Mark as unread" and "Manage event configuration" is disabled.',
-      },
-    },
+    const menuItems = await openKebabMenu(canvasElement);
+    expect(menuItems).toHaveLength(4);
+    expect(menuItems[3]).toHaveTextContent('Manage event configuration');
+    expect(menuItems[3]).toBeDisabled();
+
+    const tooltipTrigger = menuItems[3].closest('span') ?? menuItems[3];
+    await userEvent.hover(tooltipTrigger);
+    await waitFor(() => {
+      expect(page.getByRole('tooltip')).toHaveTextContent('Admin-access required');
+    });
   },
 };
 
@@ -141,20 +175,110 @@ export const DynamicURLGeneration: Story = {
       created: '2024-01-16T14:45:00Z',
     },
     isOrgAdmin: true,
-    onNavigateTo: (link: string) => {
-      console.log('Navigate to:', link);
-      alert(`Would navigate to: ${link}`);
-    },
-    updateNotificationSelected: (id: string, selected: boolean) =>
-      console.log('Update selected:', id, selected),
-    updateNotificationRead: (id: string, read: boolean) => console.log('Update read:', id, read),
+    onNavigateTo: onNavigateToSpy,
+    updateNotificationSelected: updateNotificationSelectedSpy,
+    updateNotificationRead: updateNotificationReadSpy,
   },
   parameters: {
     docs: {
       description: {
-        story:
-          'Test dynamic URL generation. Click menu items to see generated URLs with query params:\n- "View in event log": /settings/notifications/eventlog?service=vulnerability&event=Critical vulnerability detected\n- "Manage my event notifications": /settings/notifications/user-preferences?bundle=rhel&app=vulnerability\n- "Manage event configuration": /settings/notifications/configure-events?bundle=rhel&tab=configuration',
+        story: 'Dynamic URL generation for drawer navigation actions.',
       },
     },
+  },
+  render: (args) => {
+    onNavigateToSpy.mockClear();
+    updateNotificationSelectedSpy.mockClear();
+    updateNotificationReadSpy.mockClear();
+    return <NotificationItem {...args} />;
+  },
+  play: async ({ canvasElement }) => {
+    let menuItems = await openKebabMenu(canvasElement);
+
+    await userEvent.click(menuItems[1]);
+    expect(onNavigateToSpy).toHaveBeenCalledWith(
+      '/settings/notifications/eventlog?service=vulnerability&event=Critical+vulnerability+detected'
+    );
+
+    onNavigateToSpy.mockClear();
+    menuItems = await openKebabMenu(canvasElement);
+    await userEvent.click(menuItems[2]);
+    expect(onNavigateToSpy).toHaveBeenCalledWith(
+      '/settings/notifications/user-preferences?bundle=rhel&app=vulnerability'
+    );
+
+    onNavigateToSpy.mockClear();
+    menuItems = await openKebabMenu(canvasElement);
+    await userEvent.click(menuItems[3]);
+    expect(onNavigateToSpy).toHaveBeenCalledWith(
+      '/settings/notifications/configure-events?bundle=rhel&tab=configuration'
+    );
+  },
+};
+
+export const ReadNotificationShowsMarkAsUnread: Story = {
+  args: {
+    notification: mockNotificationRead,
+    isOrgAdmin: true,
+    onNavigateTo: onNavigateToSpy,
+    updateNotificationSelected: updateNotificationSelectedSpy,
+    updateNotificationRead: updateNotificationReadSpy,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Read notification shows the Mark as unread action.',
+      },
+    },
+  },
+  render: (args) => {
+    onNavigateToSpy.mockClear();
+    updateNotificationSelectedSpy.mockClear();
+    updateNotificationReadSpy.mockClear();
+    return <NotificationItem {...args} />;
+  },
+  play: async ({ canvasElement }) => {
+    const menuItems = await openKebabMenu(canvasElement);
+    expect(menuItems[0]).toHaveTextContent('Mark as unread');
+  },
+};
+
+export const MarkAsReadCallsAPI: Story = {
+  args: {
+    notification: mockNotificationUnread,
+    isOrgAdmin: true,
+    onNavigateTo: onNavigateToSpy,
+    updateNotificationSelected: updateNotificationSelectedSpy,
+    updateNotificationRead: updateNotificationReadSpy,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Mark as read calls the read-status API and updates local read state.',
+      },
+    },
+  },
+  render: (args) => {
+    readStatusSpy.mockClear();
+    onNavigateToSpy.mockClear();
+    updateNotificationSelectedSpy.mockClear();
+    updateNotificationReadSpy.mockClear();
+    return <NotificationItem {...args} />;
+  },
+  play: async ({ canvasElement }) => {
+    const menuItems = await openKebabMenu(canvasElement);
+    await userEvent.click(menuItems[0]);
+
+    await waitFor(() => {
+      expect(readStatusSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          notification_ids: ['1'],
+          read_status: true,
+        })
+      );
+    });
+    await waitFor(() => {
+      expect(updateNotificationReadSpy).toHaveBeenCalledWith('1', true);
+    });
   },
 };

--- a/src/components/NotificationsDrawer/NotificationItem.tsx
+++ b/src/components/NotificationsDrawer/NotificationItem.tsx
@@ -70,25 +70,27 @@ const NotificationItem: React.FC<NotificationItemProps> = ({
     <Divider key="divider" />,
     <DropdownItem
       key="view-event-log"
-      onClick={() => {
-        const url = `/settings/notifications/eventlog?${new URLSearchParams({
-          service: notification.source,
-          event: notification.title,
-        }).toString()}`;
-        window.location.href = url;
-      }}
+      onClick={() =>
+        onNavigateTo(
+          `/settings/notifications/eventlog?${new URLSearchParams({
+            service: notification.source,
+            event: notification.title,
+          }).toString()}`
+        )
+      }
     >
       {intl.formatMessage(messages.viewInEventLog)}
     </DropdownItem>,
     <DropdownItem
       key="manage-my-notifications"
-      onClick={() => {
-        const url = `/settings/notifications/user-preferences?${new URLSearchParams({
-          bundle: notification.bundle,
-          ...(notification.application && { app: notification.application }),
-        }).toString()}`;
-        window.location.href = url;
-      }}
+      onClick={() =>
+        onNavigateTo(
+          `/settings/notifications/user-preferences?${new URLSearchParams({
+            bundle: notification.bundle,
+            ...(notification.application && { app: notification.application }),
+          }).toString()}`
+        )
+      }
     >
       {intl.formatMessage(messages.manageMyEventNotifications)}
     </DropdownItem>,

--- a/src/components/NotificationsDrawer/__tests__/DrawerPanel.test.tsx
+++ b/src/components/NotificationsDrawer/__tests__/DrawerPanel.test.tsx
@@ -143,13 +143,7 @@ describe('NotificationItem menu actions', () => {
     expect(params.get('tab')).toBe('configuration');
   });
 
-  it('Manage my event notifications uses window.location.href with bundle and app', async () => {
-    const originalLocation = window.location;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    delete (window as any).location;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    window.location = { ...originalLocation, href: '' } as any;
-
+  it('Manage my event notifications navigates with bundle and app', async () => {
     const notification = { ...makeNotification('1', false), application: 'advisor' };
     renderDrawerPanel([notification]);
 
@@ -165,10 +159,10 @@ describe('NotificationItem menu actions', () => {
     const menuItem = await screen.findByRole('menuitem', { name: 'Manage my event notifications' });
     await userEvent.click(menuItem);
 
-    expect(window.location.href).toContain('/settings/notifications/user-preferences');
-    expect(window.location.href).toContain('bundle=rhel');
-    expect(window.location.href).toContain('app=advisor');
-
-    window.location = originalLocation;
+    const url = mockNavigate.mock.calls[0][0] as string;
+    expect(url).toContain('/settings/notifications/user-preferences');
+    const params = new URLSearchParams(url.split('?')[1]);
+    expect(params.get('bundle')).toBe('rhel');
+    expect(params.get('app')).toBe('advisor');
   });
 });


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->
- Added tests for `NotificationItem`'s dropdown menu
- Updated the `NotificationItem` dropdown to use consistent navigation with `onNavigateTo`
- Updated tests to match that change

[RHCLOUD-48123](https://redhat.atlassian.net/browse/RHCLOUD-48123)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->


---

### Checklist ☑️
- [x] PR only fixes one issue or story <!-- open new PR for others -->
- [x] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [x] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [x] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [x] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##


[RHCLOUD-48123]: https://redhat.atlassian.net/browse/RHCLOUD-48123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ