### PR TITLE
feat: Add hidePagerDutySeverity prop to conditionally hide alert severity field

### DIFF
--- a/src/pages/Integrations/Create/IntegrationWizard.tsx
+++ b/src/pages/Integrations/Create/IntegrationWizard.tsx
@@ -142,6 +142,12 @@ export const IntegrationWizard: React.FunctionComponent<IntegrationWizardProps> 
             severity,
           }) => {
             const [type, sub_type] = intType?.split(':') || ['webhook'];
+            // When severity field is hidden during edit, preserve the original value
+            // Access severity safely - it exists on IntegrationPagerduty but not in the typed template
+            const templateSeverity =
+              template && 'severity' in template ? template.severity : undefined;
+            const severityValue =
+              hidePagerDutySeverity && isEdit && templateSeverity ? templateSeverity : severity;
             const data = {
               name,
               enabled: true,
@@ -153,7 +159,7 @@ export const IntegrationWizard: React.FunctionComponent<IntegrationWizardProps> 
                 url,
                 disable_ssl_verification: false,
                 secret_token,
-                severity,
+                severity: severityValue,
               },
               ...(isBehaviorGroupsEnabled && {
                 event_types: event_types

--- a/src/pages/Integrations/Create/IntegrationWizard.tsx
+++ b/src/pages/Integrations/Create/IntegrationWizard.tsx
@@ -103,6 +103,7 @@ export const IntegrationWizard: React.FunctionComponent<IntegrationWizardProps> 
   };
   const isBehaviorGroupsEnabled = useFlag('platform.integrations.behavior-groups-move');
   const isPagerDutyEnabled = useFlag('platform.integrations.pager-duty');
+  const hidePagerDutySeverity = useFlag('platform.integrations.pager-duty.hide-severity');
   const isEmailIntegrationEnabled = useFlag('platform.notifications.email.integration');
   const notifications = useNotification();
   const [wizardOpen, setWizardOpen] = React.useState<boolean>(isOpen);
@@ -122,6 +123,7 @@ export const IntegrationWizard: React.FunctionComponent<IntegrationWizardProps> 
             isBehaviorGroupsEnabled,
             isPagerDutyEnabled,
             isEmailIntegrationEnabled,
+            hidePagerDutySeverity,
             intl
           )}
           componentMapper={{ ...componentMapper, ...mapperExtension }}

--- a/src/pages/Integrations/Create/IntegrationWizard.tsx
+++ b/src/pages/Integrations/Create/IntegrationWizard.tsx
@@ -56,7 +56,7 @@ export interface IntegrationWizardProps {
  * Maps integration data from the server format to the form field format
  * This ensures that existing integration data is properly pre-populated in edit mode
  */
-const mapIntegrationToFormFields = (template) => {
+const mapIntegrationToFormFields = (template, hidePagerDutySeverity = false) => {
   if (!template) {
     return {};
   }
@@ -80,6 +80,11 @@ const mapIntegrationToFormFields = (template) => {
   // Handle camel integrations (Slack, Teams, etc.)
   if (template.extras?.channel) {
     formValues.channel = template.extras.channel;
+  }
+
+  // Omit severity from initial values when the field is hidden
+  if (hidePagerDutySeverity && formValues.severity !== undefined) {
+    delete formValues.severity;
   }
 
   return formValues;
@@ -123,8 +128,8 @@ export const IntegrationWizard: React.FunctionComponent<IntegrationWizardProps> 
             isBehaviorGroupsEnabled,
             isPagerDutyEnabled,
             isEmailIntegrationEnabled,
-            hidePagerDutySeverity,
-            intl
+            intl,
+            hidePagerDutySeverity
           )}
           componentMapper={{ ...componentMapper, ...mapperExtension }}
           onSubmit={({
@@ -166,7 +171,7 @@ export const IntegrationWizard: React.FunctionComponent<IntegrationWizardProps> 
               : createEndpoint(data, notifications, afterSubmit);
             closeModal();
           }}
-          initialValues={isEdit ? mapIntegrationToFormFields(template) : {}}
+          initialValues={isEdit ? mapIntegrationToFormFields(template, hidePagerDutySeverity) : {}}
           onCancel={closeModal}
         >
           {(props) => <Pf4FormTemplate {...props} showFormControls={false} />}

--- a/src/pages/Integrations/Create/PagerDutySeverityFlag.stories.tsx
+++ b/src/pages/Integrations/Create/PagerDutySeverityFlag.stories.tsx
@@ -1,0 +1,86 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import { FormRenderer } from '@data-driven-forms/react-form-renderer';
+import componentMapper from '@data-driven-forms/pf4-component-mapper/component-mapper';
+import Pf4FormTemplate from '@data-driven-forms/pf4-component-mapper/form-template';
+import { expect, waitFor, within } from 'storybook/test';
+import { detailSteps } from './detailSteps';
+import { PAGERDUTY_DETAILS } from './helpers';
+import { useIntl } from 'react-intl';
+
+const PagerDutyFormWrapper: React.FC<{ hideSeverity: boolean }> = ({ hideSeverity }) => {
+  const intl = useIntl();
+  const steps = detailSteps(false, false, intl, hideSeverity);
+  const pagerDutyStep = steps.find((s) => s.name === PAGERDUTY_DETAILS);
+
+  if (!pagerDutyStep) {
+    return null;
+  }
+
+  const schema = {
+    fields: [
+      {
+        component: 'sub-form',
+        name: PAGERDUTY_DETAILS,
+        fields: pagerDutyStep.fields,
+      },
+    ],
+  };
+
+  return (
+    <FormRenderer
+      schema={schema}
+      componentMapper={componentMapper}
+      onSubmit={() => {}}
+      onCancel={() => {}}
+      initialValues={{}}
+    >
+      {(props) => <Pf4FormTemplate {...props} showFormControls={false} />}
+    </FormRenderer>
+  );
+};
+
+const meta: Meta<typeof PagerDutyFormWrapper> = {
+  title: 'Integrations/PagerDutySeverityFlag',
+  component: PagerDutyFormWrapper,
+  parameters: {
+    layout: 'padded',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PagerDutyFormWrapper>;
+
+export const SeverityFieldVisible: Story = {
+  parameters: {
+    featureFlags: {
+      'platform.integrations.pager-duty.hide-severity': false,
+    },
+  },
+  render: () => <PagerDutyFormWrapper hideSeverity={false} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      expect(canvas.getByText('Severity')).toBeVisible();
+    });
+    expect(canvas.getByText('Integration name')).toBeVisible();
+    expect(canvas.getByText('Integration key')).toBeVisible();
+  },
+};
+
+export const SeverityFieldHidden: Story = {
+  parameters: {
+    featureFlags: {
+      'platform.integrations.pager-duty.hide-severity': true,
+    },
+  },
+  render: () => <PagerDutyFormWrapper hideSeverity={true} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await waitFor(() => {
+      expect(canvas.getByText('Integration name')).toBeVisible();
+    });
+    expect(canvas.getByText('Integration key')).toBeVisible();
+    expect(canvas.queryByText('Severity')).not.toBeInTheDocument();
+  },
+};

--- a/src/pages/Integrations/Create/detailSteps.ts
+++ b/src/pages/Integrations/Create/detailSteps.ts
@@ -71,8 +71,8 @@ const sslAlert = {
 export const detailSteps = (
   isEdit: boolean,
   isBehaviorGroupsEnabled: boolean,
-  hidePagerDutySeverity: boolean,
-  intl: IntlShape
+  intl: IntlShape,
+  hidePagerDutySeverity: boolean = false
 ) => {
   const title = `${isEdit ? 'Edit' : 'Enter'} details`;
   return [

--- a/src/pages/Integrations/Create/detailSteps.ts
+++ b/src/pages/Integrations/Create/detailSteps.ts
@@ -17,6 +17,7 @@ import {
 import { IntlShape } from 'react-intl';
 import { validated } from './Validated';
 import { asyncValidatorDebouncedWrapper } from './nameValidator';
+import messages from '../messages';
 
 const commonFields = (isSlack: boolean, isEdit: boolean, intl: IntlShape) => [
   {
@@ -167,9 +168,8 @@ export const detailSteps = (
               {
                 component: componentTypes.SELECT,
                 name: 'severity',
-                label: 'Alert severity',
-                helperText:
-                  'Severity of the alert created in PagerDuty when this integration is used.',
+                label: intl.formatMessage(messages.pagerDutySeverityLabel),
+                helperText: intl.formatMessage(messages.pagerDutySeverityHelperText),
                 isRequired: true,
                 validate: [
                   {
@@ -179,19 +179,19 @@ export const detailSteps = (
                 simpleValue: true,
                 options: [
                   {
-                    label: 'Info',
+                    label: intl.formatMessage(messages.pagerDutySeverityInfo),
                     value: 'Info',
                   },
                   {
-                    label: 'Warning',
+                    label: intl.formatMessage(messages.pagerDutySeverityWarning),
                     value: 'Warning',
                   },
                   {
-                    label: 'Error',
+                    label: intl.formatMessage(messages.pagerDutySeverityError),
                     value: 'Error',
                   },
                   {
-                    label: 'Critical',
+                    label: intl.formatMessage(messages.pagerDutySeverityCritical),
                     value: 'Critical',
                   },
                 ],

--- a/src/pages/Integrations/Create/detailSteps.ts
+++ b/src/pages/Integrations/Create/detailSteps.ts
@@ -68,7 +68,12 @@ const sslAlert = {
   variant: 'info',
 };
 
-export const detailSteps = (isEdit: boolean, isBehaviorGroupsEnabled: boolean, intl: IntlShape) => {
+export const detailSteps = (
+  isEdit: boolean,
+  isBehaviorGroupsEnabled: boolean,
+  hidePagerDutySeverity: boolean,
+  intl: IntlShape
+) => {
   const title = `${isEdit ? 'Edit' : 'Enter'} details`;
   return [
     // REPORTING - SPLUNK, ANSIBLE
@@ -156,32 +161,37 @@ export const detailSteps = (isEdit: boolean, isBehaviorGroupsEnabled: boolean, i
             },
           ],
         },
-        {
-          component: componentTypes.SELECT,
-          name: 'severity',
-          label: 'Alert severity',
-          helperText: 'Severity of the alert created in PagerDuty when this integration is used.',
-          isRequired: true,
-          simpleValue: true,
-          options: [
-            {
-              label: 'Info',
-              value: 'Info',
-            },
-            {
-              label: 'Warning',
-              value: 'Warning',
-            },
-            {
-              label: 'Error',
-              value: 'Error',
-            },
-            {
-              label: 'Critical',
-              value: 'Critical',
-            },
-          ],
-        },
+        ...(hidePagerDutySeverity
+          ? []
+          : [
+              {
+                component: componentTypes.SELECT,
+                name: 'severity',
+                label: 'Alert severity',
+                helperText:
+                  'Severity of the alert created in PagerDuty when this integration is used.',
+                isRequired: true,
+                simpleValue: true,
+                options: [
+                  {
+                    label: 'Info',
+                    value: 'Info',
+                  },
+                  {
+                    label: 'Warning',
+                    value: 'Warning',
+                  },
+                  {
+                    label: 'Error',
+                    value: 'Error',
+                  },
+                  {
+                    label: 'Critical',
+                    value: 'Critical',
+                  },
+                ],
+              },
+            ]),
       ],
     },
 

--- a/src/pages/Integrations/Create/detailSteps.ts
+++ b/src/pages/Integrations/Create/detailSteps.ts
@@ -171,6 +171,11 @@ export const detailSteps = (
                 helperText:
                   'Severity of the alert created in PagerDuty when this integration is used.',
                 isRequired: true,
+                validate: [
+                  {
+                    type: validatorTypes.REQUIRED,
+                  },
+                ],
                 simpleValue: true,
                 options: [
                   {

--- a/src/pages/Integrations/Create/schema.ts
+++ b/src/pages/Integrations/Create/schema.ts
@@ -11,8 +11,8 @@ export const schema = (
   isBehaviorGroupsEnabled,
   isPagerDutyEnabled,
   isEmailIntegrationEnabled,
-  hidePagerDutySeverity,
-  intl
+  intl,
+  hidePagerDutySeverity = false
 ) => ({
   fields: [
     {
@@ -31,7 +31,7 @@ export const schema = (
           : []),
 
         // INTEGRATION DETAILS
-        ...detailSteps(isEdit, isBehaviorGroupsEnabled, hidePagerDutySeverity, intl),
+        ...detailSteps(isEdit, isBehaviorGroupsEnabled, intl, hidePagerDutySeverity),
 
         // ASSOCIATE EVENT TYPES
         ...(isBehaviorGroupsEnabled ? [eventTypesStep()] : []),

--- a/src/pages/Integrations/Create/schema.ts
+++ b/src/pages/Integrations/Create/schema.ts
@@ -11,6 +11,7 @@ export const schema = (
   isBehaviorGroupsEnabled,
   isPagerDutyEnabled,
   isEmailIntegrationEnabled,
+  hidePagerDutySeverity,
   intl
 ) => ({
   fields: [
@@ -30,7 +31,7 @@ export const schema = (
           : []),
 
         // INTEGRATION DETAILS
-        ...detailSteps(isEdit, isBehaviorGroupsEnabled, intl),
+        ...detailSteps(isEdit, isBehaviorGroupsEnabled, hidePagerDutySeverity, intl),
 
         // ASSOCIATE EVENT TYPES
         ...(isBehaviorGroupsEnabled ? [eventTypesStep()] : []),

--- a/src/pages/Integrations/messages.ts
+++ b/src/pages/Integrations/messages.ts
@@ -132,6 +132,38 @@ export default defineMessages({
     defaultMessage: 'Filter by group name...',
   },
 
+  // PagerDuty severity
+  pagerDutySeverityLabel: {
+    id: 'integrations.pagerduty.severity.label',
+    description: 'Label for the PagerDuty alert severity select field',
+    defaultMessage: 'Alert severity',
+  },
+  pagerDutySeverityHelperText: {
+    id: 'integrations.pagerduty.severity.helperText',
+    description: 'Helper text for the PagerDuty alert severity select field',
+    defaultMessage: 'Severity of the alert created in PagerDuty when this integration is used.',
+  },
+  pagerDutySeverityInfo: {
+    id: 'integrations.pagerduty.severity.info',
+    description: 'Info option for PagerDuty alert severity',
+    defaultMessage: 'Info',
+  },
+  pagerDutySeverityWarning: {
+    id: 'integrations.pagerduty.severity.warning',
+    description: 'Warning option for PagerDuty alert severity',
+    defaultMessage: 'Warning',
+  },
+  pagerDutySeverityError: {
+    id: 'integrations.pagerduty.severity.error',
+    description: 'Error option for PagerDuty alert severity',
+    defaultMessage: 'Error',
+  },
+  pagerDutySeverityCritical: {
+    id: 'integrations.pagerduty.severity.critical',
+    description: 'Critical option for PagerDuty alert severity',
+    defaultMessage: 'Critical',
+  },
+
   // Permission messages
   usersCountWithoutPrincipalRead: {
     id: 'integrations.userAccessGroups.usersCountWithoutPermission',


### PR DESCRIPTION
## Summary
Read the `platform.integrations.pager-duty.hide-severity` Unleash feature flag directly in the IntegrationWizard component to conditionally hide the "Alert severity" field from the PagerDuty integration form.

This approach is **self-contained** - no changes needed in sources-ui. The wizard reads the flag directly using the existing `@unleash/proxy-client-react` integration.

## Changes
- **IntegrationWizard.tsx**: Read flag using `useFlag('platform.integrations.pager-duty.hide-severity')`
- **schema.ts**: Pass `hidePagerDutySeverity` parameter through to detailSteps
- **detailSteps.ts**: Conditionally include severity field based on flag using spread operator

## Behavior
- **Flag OFF (default)**: Alert severity field is visible and required
- **Flag ON**: Alert severity field is completely hidden from the form schema

## How It Works
```tsx
// IntegrationWizard.tsx
const hidePagerDutySeverity = useFlag('platform.integrations.pager-duty.hide-severity');

// detailSteps.ts - PagerDuty fields
...(hidePagerDutySeverity ? [] : [
  {
    component: componentTypes.SELECT,
    name: 'severity',
    label: 'Alert severity',
    // ... severity field definition
  },
]),
```

When the flag is `true`, the spread operator expands an empty array, effectively removing the field from the form schema. When `false`, the field is included normally.

## Testing
- [ ] Verify with flag OFF: Alert severity field is visible and required
- [ ] Verify with flag ON: Alert severity field is hidden from wizard
- [ ] Verify PagerDuty integration can be created without severity field when hidden
- [ ] Verify existing integrations continue to work
- [ ] Test in all entry points from sources-ui (no sources-ui changes needed):
  - [ ] IntegrationsDropdown
  - [ ] IntegrationsWidget  
  - [ ] Overview page

## Deployment
This is a standalone change. No coordination with sources-ui needed - the flag is read directly by this component.

**Steps:**
1. Merge this PR
2. Create Unleash flag `platform.integrations.pager-duty.hide-severity` (default: OFF)
3. Test in staging
4. Flip flag to ON on coordination day (with backend, docs, user communication)

## JIRA
RHCLOUD-48862