### PR TITLE
fix: Strip bundled PatternFly styles to prevent sticky header CSS leak

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -9,6 +9,7 @@ module.exports = {
   ],
   debug: true,
   useProxy: true,
+  stripAllPfStyles: true,
   proxyVerbose: true,
   frontendCRDPath: path.resolve(__dirname, './.rhcicd/frontend.yaml'),
   /**


### PR DESCRIPTION
### Description

A PatternFly v6.5.x CSS bug causes column header text to become invisible on tables with sticky headers. The root cause is that apps bundle their own `@patternfly/react-styles` CSS from nested `node_modules` (transitive dependencies), which leaks and overrides the global PatternFly stylesheet served by Chrome.

This PR adds `stripAllPfStyles: true` to `fec.config.js`, which tells the sass-loader to strip all `@patternfly/react-styles` CSS from `node_modules`, preventing the CSS leak. It only affects PF CSS inside `node_modules` — custom app styles in `src/` are not touched.

Affected components with `isStickyHeader={true}`:
- `src/components/Integrations/Table.tsx`
- `src/components/Notifications/NotificationsBehaviorGroupTable.tsx`
- `src/components/Notifications/BehaviorGroup/BehaviorGroupFormActionsTable.tsx`
- `src/components/Notifications/EventLog/EventLogTable.tsx`
- `src/components/Notifications/EventLog/EventLogActionPopoverContent.tsx`

[RHCLOUD-47948](https://redhat.atlassian.net/browse/RHCLOUD-47948)

---

### Screenshots

N/A — this is a one-line config change with no visual component changes.

---

### Checklist ☑️
- [x] PR only fixes one issue or story
- [x] Change reviewed for extraneous code
- [x] UI best practices adhered to
- [x] Commits squashed and meaningfully named
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [x] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_


[RHCLOUD-47948]: https://redhat.atlassian.net/browse/RHCLOUD-47948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ