### PR TITLE
refactor: Consolidate v1/v2 nav permission coexistence in frontend.yaml

### DIFF
--- a/.rhcicd/frontend.yaml
+++ b/.rhcicd/frontend.yaml
@@ -45,68 +45,65 @@ objects:
         - segmentId: notifications-settings
           bundleId: settings
           navItems:
-            # V1 navigation (workspaces flag off)
             - title: Notifications
-              id: notifications-v1
+              id: notifications
               expandable: true
-              permissions:
-                - method: featureFlag
-                  args:
-                    - platform.rbac.workspaces
-                    - false
               routes:
-                - id: notificationOverview-v1
+                - id: notificationOverview
                   icon: PlaceholderIcon
                   title: Overview
                   href: '/settings/notifications'
+                # V1 permission check (workspaces flag off)
                 - id: configureEvents-v1
                   title: Configure Events
                   href: '/settings/notifications/configure-events'
                   permissions:
+                    - method: featureFlag
+                      args:
+                        - platform.rbac.workspaces
+                        - false
                     - method: loosePermissions
                       args:
                         - - notifications:*:*
                           - notifications:notifications:read
-                - id: eventLog-v1
-                  title: Event Log
-                  href: '/settings/notifications/eventlog'
-                  permissions:
-                    - method: loosePermissions
-                      args:
-                        - - notifications:*:*
-                          - notifications:events:read
-                - id: myUserPreferences-v1
-                  title: Notification Preferences
-                  href: '/settings/notifications/user-preferences'
-            # V2 navigation (workspaces flag on)
-            - title: Notifications
-              id: notifications-v2
-              expandable: true
-              permissions:
-                - method: featureFlag
-                  args:
-                    - platform.rbac.workspaces
-                    - true
-              routes:
-                - id: notificationOverview-v2
-                  icon: PlaceholderIcon
-                  title: Overview
-                  href: '/settings/notifications'
+                # V2 permission check (workspaces flag on)
                 - id: configureEvents-v2
                   title: Configure Events
                   href: '/settings/notifications/configure-events'
                   permissions:
+                    - method: featureFlag
+                      args:
+                        - platform.rbac.workspaces
+                        - true
                     - method: loosePermissionsKessel
                       args:
                         - - notifications_notifications_view
+                # V1 permission check (workspaces flag off)
+                - id: eventLog-v1
+                  title: Event Log
+                  href: '/settings/notifications/eventlog'
+                  permissions:
+                    - method: featureFlag
+                      args:
+                        - platform.rbac.workspaces
+                        - false
+                    - method: loosePermissions
+                      args:
+                        - - notifications:*:*
+                          - notifications:events:read
+                # V2 permission check (workspaces flag on)
                 - id: eventLog-v2
                   title: Event Log
                   href: '/settings/notifications/eventlog'
                   permissions:
+                    - method: featureFlag
+                      args:
+                        - platform.rbac.workspaces
+                        - true
                     - method: loosePermissionsKessel
                       args:
                         - - notifications_events_view
-                - id: myUserPreferences-v2
+                - id: myUserPreferences
                   title: Notification Preferences
                   href: '/settings/notifications/user-preferences'
           position: 1000

--- a/.rhcicd/frontend.yaml
+++ b/.rhcicd/frontend.yaml
@@ -71,6 +71,7 @@ objects:
                       args:
                         - - notifications_notifications_view
                           - notifications_notifications_edit
+                          - notifications_events_view
                 # V1 permission check (RBAC)
                 - id: eventLog-v1
                   title: Event Log
@@ -88,6 +89,8 @@ objects:
                     - method: loosePermissionsKessel
                       args:
                         - - notifications_events_view
+                          - notifications_notifications_view
+                          - notifications_notifications_edit
                 - id: myUserPreferences
                   title: Notification Preferences
                   href: '/settings/notifications/user-preferences'

--- a/.rhcicd/frontend.yaml
+++ b/.rhcicd/frontend.yaml
@@ -53,53 +53,38 @@ objects:
                   icon: PlaceholderIcon
                   title: Overview
                   href: '/settings/notifications'
-                # V1 permission check (workspaces flag off)
+                # V1 permission check (RBAC)
                 - id: configureEvents-v1
                   title: Configure Events
                   href: '/settings/notifications/configure-events'
                   permissions:
-                    - method: featureFlag
-                      args:
-                        - platform.rbac.workspaces
-                        - false
                     - method: loosePermissions
                       args:
                         - - notifications:*:*
                           - notifications:notifications:read
-                # V2 permission check (workspaces flag on)
+                # V2 permission check (Kessel)
                 - id: configureEvents-v2
                   title: Configure Events
                   href: '/settings/notifications/configure-events'
                   permissions:
-                    - method: featureFlag
-                      args:
-                        - platform.rbac.workspaces
-                        - true
                     - method: loosePermissionsKessel
                       args:
                         - - notifications_notifications_view
-                # V1 permission check (workspaces flag off)
+                          - notifications_notifications_edit
+                # V1 permission check (RBAC)
                 - id: eventLog-v1
                   title: Event Log
                   href: '/settings/notifications/eventlog'
                   permissions:
-                    - method: featureFlag
-                      args:
-                        - platform.rbac.workspaces
-                        - false
                     - method: loosePermissions
                       args:
                         - - notifications:*:*
                           - notifications:events:read
-                # V2 permission check (workspaces flag on)
+                # V2 permission check (Kessel)
                 - id: eventLog-v2
                   title: Event Log
                   href: '/settings/notifications/eventlog'
                   permissions:
-                    - method: featureFlag
-                      args:
-                        - platform.rbac.workspaces
-                        - true
                     - method: loosePermissionsKessel
                       args:
                         - - notifications_events_view

--- a/.rhcicd/frontend.yaml
+++ b/.rhcicd/frontend.yaml
@@ -53,7 +53,7 @@ objects:
                   icon: PlaceholderIcon
                   title: Overview
                   href: '/settings/notifications'
-                # V1 permission check (RBAC)
+                # FedRAMP/Commercial: v1 RBAC
                 - id: configureEvents-v1
                   title: Configure Events
                   href: '/settings/notifications/configure-events'
@@ -62,7 +62,10 @@ objects:
                       args:
                         - - notifications:*:*
                           - notifications:notifications:read
-                # V2 permission check (Kessel)
+                    - method: isITLess
+                      args:
+                        - - true
+                # Regular cloud: v2 Kessel
                 - id: configureEvents-v2
                   title: Configure Events
                   href: '/settings/notifications/configure-events'
@@ -72,7 +75,10 @@ objects:
                         - - notifications_notifications_view
                           - notifications_notifications_edit
                           - notifications_events_view
-                # V1 permission check (RBAC)
+                    - method: isITLess
+                      args:
+                        - - false
+                # FedRAMP/Commercial: v1 RBAC
                 - id: eventLog-v1
                   title: Event Log
                   href: '/settings/notifications/eventlog'
@@ -81,7 +87,10 @@ objects:
                       args:
                         - - notifications:*:*
                           - notifications:events:read
-                # V2 permission check (Kessel)
+                    - method: isITLess
+                      args:
+                        - - true
+                # Regular cloud: v2 Kessel
                 - id: eventLog-v2
                   title: Event Log
                   href: '/settings/notifications/eventlog'
@@ -91,6 +100,9 @@ objects:
                         - - notifications_events_view
                           - notifications_notifications_view
                           - notifications_notifications_edit
+                    - method: isITLess
+                      args:
+                        - - false
                 - id: myUserPreferences
                   title: Notification Preferences
                   href: '/settings/notifications/user-preferences'

--- a/playwright/integrations-ui.spec.ts
+++ b/playwright/integrations-ui.spec.ts
@@ -23,6 +23,11 @@ test.describe('Integrations Navigation', () => {
   });
 
   test('should navigate across all tabs', async ({ page }) => {
+    // RHCLOUD-48620: chrome tab clicks don't reliably set ?category= URL param.
+    // Marked as expected failure until the chrome fix lands — when it passes,
+    // Playwright will flag it so we can remove test.fail().
+    test.fail();
+
     // Navigate to integrations page
     await page.goto(INTEGRATIONS_PATH);
     await page.waitForLoadState('domcontentloaded');

--- a/playwright/integrations-ui.spec.ts
+++ b/playwright/integrations-ui.spec.ts
@@ -23,11 +23,6 @@ test.describe('Integrations Navigation', () => {
   });
 
   test('should navigate across all tabs', async ({ page }) => {
-    // RHCLOUD-48620: chrome tab clicks don't reliably set ?category= URL param.
-    // Marked as expected failure until the chrome fix lands — when it passes,
-    // Playwright will flag it so we can remove test.fail().
-    test.fail();
-
     // Navigate to integrations page
     await page.goto(INTEGRATIONS_PATH);
     await page.waitForLoadState('domcontentloaded');


### PR DESCRIPTION
## Summary
- Collapses duplicated v1/v2 Notifications nav groups into a single parent (no feature flag gate on the parent)
- Overview and Notification Preferences are now single records visible to all users (no duplication)
- Configure Events and Event Log keep dual v1/v2 records gated by `isITLess` + the appropriate permission method:
  - FedRAMP/Commercial (`isITLess(true)`): `loosePermissions` (v1 RBAC)
  - Regular cloud (`isITLess(false)`): `loosePermissionsKessel` (v2 Kessel)

## Dependencies
- **Requires** [RedHatInsights/insights-chrome#3623](https://github.com/RedHatInsights/insights-chrome/pull/3623) — exposes `isITLess` as a navigation visibility function in Chrome

## Context
Per Karel's finding (see [RHCLOUD-49549](https://redhat.atlassian.net/browse/RHCLOUD-49549) comments): FEO frontend.yaml supports v1/v2 coexistence via independent nav records. The `isITLess` check ensures the correct permission method is used per environment — FedRAMP environments don't have Kessel, so they must use v1 RBAC.

## Test plan
- [ ] Verify v1 org user sees: Overview, Configure Events (v1), Event Log (v1), Notification Preferences
- [ ] Verify v2 org user sees: Overview, Configure Events (v2), Event Log (v2), Notification Preferences
- [ ] Verify no duplicate nav entries appear for either user type
- [ ] Validate YAML against FEO schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[RHCLOUD-49549]: https://redhat.atlassian.net/browse/RHCLOUD-49549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ