### PR TITLE
test: Added bundle tab nav test for configure events page

### DIFF
--- a/playwright/notifications-ui.spec.ts
+++ b/playwright/notifications-ui.spec.ts
@@ -249,10 +249,14 @@ test.describe('Configure Events — Bundle Tabs', () => {
 
       // Verify bundle content loaded — scope to the active tab's panel
       // via aria-controls to avoid matching sub-tabs from other mounted panels.
+      // PF6 renders all panels in the DOM with `hidden`; the active one has it removed.
       const panelId = await tab.getAttribute('aria-controls');
       const bundlePanel = page.locator(`#${panelId}`);
+      await expect(bundlePanel).toBeVisible({ timeout: TIMEOUTS.ELEMENT_APPEAR });
+
+      // Wait for the bundle's data to load (spinner disappears, sub-tabs render).
       await expect(bundlePanel.getByRole('tab', { name: 'Configuration' })).toBeVisible({
-        timeout: TIMEOUTS.ELEMENT_APPEAR,
+        timeout: TIMEOUTS.PAGE_LOAD,
       });
 
       console.log(`Bundle tab "${tabName}" (bundle=${currentBundle}) loaded`);

--- a/playwright/notifications-ui.spec.ts
+++ b/playwright/notifications-ui.spec.ts
@@ -229,19 +229,33 @@ test.describe('Configure Events — Bundle Tabs', () => {
     const tabCount = await tabs.count();
     expect(tabCount, 'Configure Events should have bundle tabs').toBeGreaterThanOrEqual(2);
 
+    let previousBundle = '';
     for (let i = 0; i < tabCount; i++) {
       const tab = tabs.nth(i);
       const tabName = await tab.textContent();
       await tab.click();
       await expect(tab).toHaveAttribute('aria-selected', 'true');
+
+      // Verify URL bundle param is set and distinct from the previous tab
       await expect(page).toHaveURL(/bundle=/);
+      const currentBundle = new URL(page.url()).searchParams.get('bundle') ?? '';
+      expect(currentBundle, `Tab "${tabName}" should set a bundle URL param`).toBeTruthy();
+      if (i > 0) {
+        expect(currentBundle, `Tab "${tabName}" should navigate to a different bundle`).not.toBe(
+          previousBundle
+        );
+      }
+      previousBundle = currentBundle;
 
-      // Verify bundle content loaded — the Configuration / Behavior Groups
-      // sub-tabs should appear inside the selected bundle's tab panel.
-      const configSubTab = page.getByRole('tab', { name: 'Configuration' });
-      await expect(configSubTab).toBeVisible({ timeout: TIMEOUTS.ELEMENT_APPEAR });
+      // Verify bundle content loaded — scope to the active tab's panel
+      // via aria-controls to avoid matching sub-tabs from other mounted panels.
+      const panelId = await tab.getAttribute('aria-controls');
+      const bundlePanel = page.locator(`#${panelId}`);
+      await expect(bundlePanel.getByRole('tab', { name: 'Configuration' })).toBeVisible({
+        timeout: TIMEOUTS.ELEMENT_APPEAR,
+      });
 
-      console.log(`Bundle tab "${tabName}" selected and content loaded`);
+      console.log(`Bundle tab "${tabName}" (bundle=${currentBundle}) loaded`);
     }
   });
 });

--- a/playwright/notifications-ui.spec.ts
+++ b/playwright/notifications-ui.spec.ts
@@ -201,6 +201,52 @@ test.describe('Behavior Group Lifecycle', () => {
 });
 
 // =============================================================================
+// Configure Events — Bundle Tab Navigation
+// =============================================================================
+
+test.describe('Configure Events — Bundle Tabs', () => {
+  test.beforeEach(async ({ page }) => {
+    await ensureLoggedIn(page);
+  });
+
+  test('should navigate across all bundle tabs', async ({ page }) => {
+    await page.goto(`${NOTIFICATIONS_PATH}/configure-events`);
+    await page.waitForLoadState('domcontentloaded');
+
+    const heading = page.getByRole('heading', { name: 'Configure Events' });
+    if (!(await heading.isVisible({ timeout: TIMEOUTS.QUICK_CHECK }))) {
+      await page.reload();
+      await page.waitForLoadState('domcontentloaded');
+    }
+    await expect(heading).toBeVisible({ timeout: TIMEOUTS.PAGE_LOAD });
+
+    // The first tablist on the page contains the bundle tabs;
+    // sub-tabs (Configuration / Behavior Groups) are inside each bundle's content.
+    const bundleTablist = page.locator('[role="tablist"]').first();
+    await bundleTablist.waitFor({ state: 'visible', timeout: TIMEOUTS.PAGE_LOAD });
+
+    const tabs = bundleTablist.locator('[role="tab"]');
+    const tabCount = await tabs.count();
+    expect(tabCount, 'Configure Events should have bundle tabs').toBeGreaterThanOrEqual(2);
+
+    for (let i = 0; i < tabCount; i++) {
+      const tab = tabs.nth(i);
+      const tabName = await tab.textContent();
+      await tab.click();
+      await expect(tab).toHaveAttribute('aria-selected', 'true');
+      await expect(page).toHaveURL(/bundle=/);
+
+      // Verify bundle content loaded — the Configuration / Behavior Groups
+      // sub-tabs should appear inside the selected bundle's tab panel.
+      const configSubTab = page.getByRole('tab', { name: 'Configuration' });
+      await expect(configSubTab).toBeVisible({ timeout: TIMEOUTS.ELEMENT_APPEAR });
+
+      console.log(`Bundle tab "${tabName}" selected and content loaded`);
+    }
+  });
+});
+
+// =============================================================================
 // Events Log Tests
 // =============================================================================
 


### PR DESCRIPTION
### Description
<!-- Must include 2-3 sentence summary of proposed changes -->
<!-- Must include links to impacted UI(s) or information regarding the impacted UI -->
<!-- Must include any relevant steps to reproduce (if not clear in tracked issue or story) -->
<!-- Must include RHCLOUDXXXX link (if proposed change involves tracked issue or story) -->

Adds a simple test to verify that navigating the bundles on the configure events page loads a valid sub-page by checking for the sub-tabs. Part of the IQE test migration.

[RHCLOUD-48555](https://issues.redhat.com/browse/RHCLOUD-48555)

---

### Screenshots
<!-- Before and after proposed changes is ideal -->
<!-- Any key UI permutations should be captured -->
<!-- Draw attention to the area of UI that has changed -->
#### Before:


#### After:


---

### Checklist ☑️
- [ ] PR only fixes one issue or story <!-- open new PR for others -->
- [ ] Change reviewed for extraneous code <!-- console statements, comments, files, incorrect file renaming (not using `git mv`), whitespace, etc. -->
- [ ] UI best practices adhered to <!-- TODO: add a link; responsiveness, input sanitization, prioritizing PatternFly and FEC, feature gating, etc. -->
- [ ] Commits squashed and meaningfully named <!-- (2-3 commits per PR maximum, 1 is ideal) -->
- [ ] All PR checks pass locally (build, lint, test, E2E)

##
- [ ] _(Optional) QE: Needs QE attention (OUIA changed, perceived impact to tests, no test coverage)_
- [ ] _(Optional) QE: Has been mentioned_
- [ ] _(Optional) UX: Needs UX attention (end user UX modified, missing designs)_
- [ ] _(Optional) UX: Has been mentioned_
##


[RHCLOUD-48555]: https://redhat.atlassian.net/browse/RHCLOUD-48555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ